### PR TITLE
Add self-bootstrapping integration test suite

### DIFF
--- a/Tools/package-lock.json
+++ b/Tools/package-lock.json
@@ -12,7 +12,450 @@
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
-        "typescript": "^5.7.0"
+        "typescript": "^5.7.0",
+        "vitest": "^4.0.18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@hono/node-server": {
@@ -26,6 +469,13 @@
       "peerDependencies": {
         "hono": "^4"
       }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.26.0",
@@ -67,6 +517,388 @@
         }
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.11",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
@@ -75,6 +907,117 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/accepts": {
@@ -121,6 +1064,16 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/body-parser": {
@@ -183,6 +1136,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/content-disposition": {
@@ -329,6 +1292,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -341,11 +1311,63 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -375,6 +1397,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -460,6 +1492,24 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -497,6 +1547,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -683,6 +1748,16 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -744,6 +1819,25 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -773,6 +1867,17 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
@@ -823,6 +1928,33 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -830,6 +1962,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/proxy-addr": {
@@ -891,6 +2052,51 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/router": {
@@ -1059,6 +2265,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1066,6 +2296,57 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -1130,6 +2411,159 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -1143,6 +2577,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/Tools/package.json
+++ b/Tools/package.json
@@ -6,13 +6,16 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^4.0.18"
   }
 }

--- a/Tools/test/bootstrap.ts
+++ b/Tools/test/bootstrap.ts
@@ -1,0 +1,204 @@
+/**
+ * bootstrap.ts — Generate a temp UE5 project and manage the commandlet lifecycle.
+ *
+ * The temp project contains:
+ *   TestProject.uproject  — minimal JSON pointing at BlueprintMCP plugin
+ *   Plugins/BlueprintMCP/ — directory junction to the real plugin source
+ *   Content/              — empty; tests create Blueprints into /Game/Test/
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { execSync, spawn, type ChildProcess } from "node:child_process";
+
+/** Port used by the test commandlet (distinct from editor's 9847). */
+export const TEST_PORT = 19847;
+export const TEST_BASE_URL = `http://localhost:${TEST_PORT}`;
+
+/** Absolute path to the plugin root (two levels up from test/). */
+const PLUGIN_ROOT = path.resolve(import.meta.dirname, "..", "..");
+
+let tempDir: string | null = null;
+let cmdProcess: ChildProcess | null = null;
+
+// ---------------------------------------------------------------------------
+// Temp project generation
+// ---------------------------------------------------------------------------
+
+export function generateTempProject(): string {
+  const dir = path.join(os.tmpdir(), `BlueprintMCP_Test_${Date.now()}`);
+  fs.mkdirSync(dir, { recursive: true });
+
+  // Minimal .uproject
+  const uproject = {
+    FileVersion: 3,
+    EngineAssociation: "5.4",
+    Plugins: [{ Name: "BlueprintMCP", Enabled: true }],
+  };
+  fs.writeFileSync(
+    path.join(dir, "TestProject.uproject"),
+    JSON.stringify(uproject, null, "\t") + "\n",
+  );
+
+  // Content directory (blueprints land here)
+  fs.mkdirSync(path.join(dir, "Content"), { recursive: true });
+
+  // Plugins/BlueprintMCP → junction to real plugin
+  const pluginsDir = path.join(dir, "Plugins");
+  fs.mkdirSync(pluginsDir, { recursive: true });
+
+  const junctionTarget = path.join(pluginsDir, "BlueprintMCP");
+  // cmd /c mklink /J works without admin on Windows
+  execSync(`cmd /c mklink /J "${junctionTarget}" "${PLUGIN_ROOT}"`, {
+    stdio: "ignore",
+  });
+
+  tempDir = dir;
+  console.log(`[bootstrap] Temp project created at ${dir}`);
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// Commandlet lifecycle
+// ---------------------------------------------------------------------------
+
+function findEditorCmd(): string | null {
+  if (process.env.UE_EDITOR_CMD && fs.existsSync(process.env.UE_EDITOR_CMD)) {
+    return process.env.UE_EDITOR_CMD;
+  }
+  const candidates = [
+    "C:\\Program Files\\Epic Games\\UE_5.4\\Engine\\Binaries\\Win64\\UnrealEditor-Cmd.exe",
+    "C:\\Program Files (x86)\\Epic Games\\UE_5.4\\Engine\\Binaries\\Win64\\UnrealEditor-Cmd.exe",
+  ];
+  for (const p of candidates) {
+    if (fs.existsSync(p)) return p;
+  }
+  return null;
+}
+
+async function waitForHealth(timeoutMs: number = 240_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const resp = await fetch(`${TEST_BASE_URL}/api/health`, {
+        signal: AbortSignal.timeout(2000),
+      });
+      if (resp.ok) return true;
+    } catch {
+      // not ready yet
+    }
+    if (!cmdProcess) return false; // process died
+    await new Promise((r) => setTimeout(r, 2000));
+  }
+  return false;
+}
+
+export async function spawnCommandlet(projectDir: string): Promise<void> {
+  const editorCmd = findEditorCmd();
+  if (!editorCmd) {
+    throw new Error(
+      "UnrealEditor-Cmd.exe not found. Set UE_EDITOR_CMD env var.",
+    );
+  }
+
+  const uproject = path.join(projectDir, "TestProject.uproject");
+  const logPath = path.join(projectDir, "Saved", "Logs", "Test_server.log");
+
+  console.log(`[bootstrap] Spawning commandlet on port ${TEST_PORT}...`);
+  cmdProcess = spawn(
+    editorCmd,
+    [
+      uproject,
+      "-run=BlueprintMCP",
+      `-port=${TEST_PORT}`,
+      "-unattended",
+      "-nopause",
+      "-nullrhi",
+      `-LOG=${logPath}`,
+    ],
+    { stdio: ["ignore", "pipe", "pipe"], windowsHide: true },
+  );
+
+  cmdProcess.stdout?.on("data", (d: Buffer) => {
+    process.stderr.write(`[UE5:out] ${d.toString().trimEnd()}\n`);
+  });
+  cmdProcess.stderr?.on("data", (d: Buffer) => {
+    process.stderr.write(`[UE5:err] ${d.toString().trimEnd()}\n`);
+  });
+  cmdProcess.on("exit", (code) => {
+    console.log(`[bootstrap] Commandlet exited with code ${code}`);
+    cmdProcess = null;
+  });
+
+  console.log("[bootstrap] Waiting for health (up to 4 min)...");
+  const ok = await waitForHealth(240_000);
+  if (!ok) {
+    // Dump the log file if it exists
+    try {
+      const log = fs.readFileSync(logPath, "utf-8");
+      console.error("[bootstrap] === Commandlet log (last 80 lines) ===");
+      console.error(log.split("\n").slice(-80).join("\n"));
+    } catch { /* no log */ }
+
+    if (cmdProcess) {
+      cmdProcess.kill();
+      cmdProcess = null;
+    }
+    throw new Error("Commandlet failed to become healthy within 4 minutes.");
+  }
+  console.log("[bootstrap] Commandlet is healthy.");
+}
+
+// ---------------------------------------------------------------------------
+// Shutdown & cleanup
+// ---------------------------------------------------------------------------
+
+export async function shutdownCommandlet(): Promise<void> {
+  if (!cmdProcess) return;
+
+  // Graceful HTTP shutdown
+  try {
+    await fetch(`${TEST_BASE_URL}/api/shutdown`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+      signal: AbortSignal.timeout(3000),
+    });
+  } catch { /* may already be gone */ }
+
+  // Wait for exit
+  const proc = cmdProcess;
+  const exited = await new Promise<boolean>((resolve) => {
+    const timer = setTimeout(() => resolve(false), 15_000);
+    proc.on("exit", () => {
+      clearTimeout(timer);
+      resolve(true);
+    });
+  });
+
+  if (!exited && cmdProcess) {
+    console.log("[bootstrap] Force-killing commandlet.");
+    cmdProcess.kill();
+    cmdProcess = null;
+  }
+}
+
+export function cleanupTempProject(): void {
+  if (!tempDir) return;
+  const junctionPath = path.join(tempDir, "Plugins", "BlueprintMCP");
+
+  // Remove the junction first — rmdir removes only the junction, not the target
+  try {
+    execSync(`cmd /c rmdir "${junctionPath}"`, { stdio: "ignore" });
+  } catch { /* may already be gone */ }
+
+  // Remove the rest of the temp directory
+  try {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    console.log(`[bootstrap] Cleaned up ${tempDir}`);
+  } catch (e) {
+    console.error(`[bootstrap] Warning: could not clean up ${tempDir}:`, e);
+  }
+  tempDir = null;
+}

--- a/Tools/test/helpers.ts
+++ b/Tools/test/helpers.ts
@@ -1,0 +1,76 @@
+/**
+ * helpers.ts — HTTP wrappers and fixture management for integration tests.
+ */
+
+import { TEST_BASE_URL } from "./bootstrap.js";
+
+// ---------------------------------------------------------------------------
+// HTTP helpers (mirror the production ueGet/uePost in src/index.ts)
+// ---------------------------------------------------------------------------
+
+export async function ueGet(
+  endpoint: string,
+  params: Record<string, string> = {},
+): Promise<any> {
+  const url = new URL(endpoint, TEST_BASE_URL);
+  for (const [k, v] of Object.entries(params)) {
+    if (v) url.searchParams.set(k, v);
+  }
+  const resp = await fetch(url.toString(), {
+    signal: AbortSignal.timeout(30_000),
+  });
+  return resp.json();
+}
+
+export async function uePost(
+  endpoint: string,
+  body: Record<string, any>,
+): Promise<any> {
+  const resp = await fetch(`${TEST_BASE_URL}${endpoint}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(30_000),
+  });
+  return resp.json();
+}
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+/** Generate a unique Blueprint name using a prefix and timestamp. */
+export function uniqueName(prefix: string): string {
+  return `${prefix}_${Date.now()}`;
+}
+
+/**
+ * Create a test Blueprint via the HTTP API.
+ * Returns the full JSON response from /api/create-blueprint.
+ */
+export async function createTestBlueprint(opts: {
+  name: string;
+  packagePath?: string;
+  parentClass?: string;
+  blueprintType?: string;
+}): Promise<any> {
+  return uePost("/api/create-blueprint", {
+    blueprintName: opts.name,
+    packagePath: opts.packagePath ?? "/Game/Test",
+    parentClass: opts.parentClass ?? "Actor",
+    blueprintType: opts.blueprintType ?? "Normal",
+  });
+}
+
+/**
+ * Delete a test Blueprint via the HTTP API (force = true to skip reference checks).
+ * Returns the full JSON response from /api/delete-asset.
+ */
+export async function deleteTestBlueprint(
+  assetPath: string,
+): Promise<any> {
+  return uePost("/api/delete-asset", {
+    assetPath,
+    force: true,
+  });
+}

--- a/Tools/test/setup.ts
+++ b/Tools/test/setup.ts
@@ -1,0 +1,36 @@
+/**
+ * setup.ts — Vitest globalSetup.
+ *
+ * Before any test file runs:
+ *   1. Generate a temp UE5 project with a junction to the real plugin
+ *   2. Spawn a commandlet on port 19847 and wait until healthy
+ *
+ * After all tests complete:
+ *   3. Shut down the commandlet
+ *   4. Remove the junction and temp directory
+ */
+
+import {
+  generateTempProject,
+  spawnCommandlet,
+  shutdownCommandlet,
+  cleanupTempProject,
+} from "./bootstrap.js";
+
+export async function setup(): Promise<void> {
+  console.log("[setup] Generating temp project...");
+  const projectDir = generateTempProject();
+
+  console.log("[setup] Spawning commandlet...");
+  await spawnCommandlet(projectDir);
+  console.log("[setup] Ready.");
+}
+
+export async function teardown(): Promise<void> {
+  console.log("[teardown] Shutting down commandlet...");
+  await shutdownCommandlet();
+
+  console.log("[teardown] Cleaning up temp project...");
+  cleanupTempProject();
+  console.log("[teardown] Done.");
+}

--- a/Tools/test/tools/add-node.test.ts
+++ b/Tools/test/tools/add-node.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { uePost, createTestBlueprint, deleteTestBlueprint, uniqueName } from "../helpers.js";
+
+describe("add_node", () => {
+  const bpName = uniqueName("BP_AddNodeTest");
+  const packagePath = "/Game/Test";
+
+  beforeAll(async () => {
+    const res = await createTestBlueprint({ name: bpName });
+    expect(res.error).toBeUndefined();
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  it("adds a function call node (PrintString)", async () => {
+    const data = await uePost("/api/add-node", {
+      blueprint: bpName,
+      graph: "EventGraph",
+      nodeType: "CallFunction",
+      functionName: "PrintString",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.nodeId).toBeDefined();
+    expect(data.nodeType).toBe("CallFunction");
+    expect(data.saved).toBe(true);
+  });
+
+  it("adds an event override node (BeginPlay)", async () => {
+    const data = await uePost("/api/add-node", {
+      blueprint: bpName,
+      graph: "EventGraph",
+      nodeType: "OverrideEvent",
+      functionName: "ReceiveBeginPlay",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.nodeId).toBeDefined();
+    // A fresh Actor BP already has ReceiveBeginPlay, so the server
+    // returns the existing node with alreadyExists=true and no saved field.
+    if (data.alreadyExists) {
+      expect(data.alreadyExists).toBe(true);
+    } else {
+      expect(data.saved).toBe(true);
+    }
+  });
+
+  it("rejects missing required fields", async () => {
+    const data = await uePost("/api/add-node", {
+      blueprint: bpName,
+      // missing graph and nodeType
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("rejects non-existent blueprint", async () => {
+    const data = await uePost("/api/add-node", {
+      blueprint: "BP_Nonexistent_XYZ_999",
+      graph: "EventGraph",
+      nodeType: "CallFunction",
+      functionName: "PrintString",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("rejects non-existent graph", async () => {
+    const data = await uePost("/api/add-node", {
+      blueprint: bpName,
+      graph: "FakeGraph",
+      nodeType: "CallFunction",
+      functionName: "PrintString",
+    });
+    expect(data.error).toBeDefined();
+    expect(data.availableGraphs).toBeDefined();
+  });
+});

--- a/Tools/test/tools/blueprint-info.test.ts
+++ b/Tools/test/tools/blueprint-info.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { ueGet, uePost, createTestBlueprint, deleteTestBlueprint, uniqueName } from "../helpers.js";
+
+describe("get_blueprint_summary / describe_graph", () => {
+  const bpName = uniqueName("BP_InfoTest");
+  const packagePath = "/Game/Test";
+
+  beforeAll(async () => {
+    const bp = await createTestBlueprint({ name: bpName });
+    expect(bp.error).toBeUndefined();
+    // Add a PrintString node for describe_graph to walk
+    await uePost("/api/add-node", {
+      blueprint: bpName,
+      graph: "EventGraph",
+      nodeType: "CallFunction",
+      functionName: "PrintString",
+    });
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  describe("get_blueprint_summary (via /api/blueprint)", () => {
+    it("returns blueprint data with graphs and variables", async () => {
+      const data = await ueGet("/api/blueprint", { name: bpName });
+      expect(data.error).toBeUndefined();
+      expect(data.name).toBe(bpName);
+      expect(data.parentClass).toBeDefined();
+      expect(Array.isArray(data.graphs)).toBe(true);
+      expect(data.graphs.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("returns error for non-existent blueprint", async () => {
+      const data = await ueGet("/api/blueprint", {
+        name: "BP_Nonexistent_XYZ_999",
+      });
+      expect(data.error).toBeDefined();
+    });
+  });
+
+  describe("describe_graph (via /api/graph)", () => {
+    it("returns graph data with nodes", async () => {
+      const data = await ueGet("/api/graph", {
+        name: bpName,
+        graph: "EventGraph",
+      });
+      expect(data.error).toBeUndefined();
+      expect(Array.isArray(data.nodes)).toBe(true);
+      // Should have at least the PrintString node and default event nodes
+      expect(data.nodes.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("nodes have expected structure", async () => {
+      const data = await ueGet("/api/graph", {
+        name: bpName,
+        graph: "EventGraph",
+      });
+      expect(data.error).toBeUndefined();
+      for (const node of data.nodes) {
+        expect(node.id).toBeDefined();
+        expect(Array.isArray(node.pins)).toBe(true);
+      }
+    });
+  });
+});

--- a/Tools/test/tools/connect-pins.test.ts
+++ b/Tools/test/tools/connect-pins.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { uePost, ueGet, createTestBlueprint, deleteTestBlueprint, uniqueName } from "../helpers.js";
+
+describe("connect_pins / disconnect_pin", () => {
+  const bpName = uniqueName("BP_ConnectTest");
+  const packagePath = "/Game/Test";
+  let eventNodeId: string;
+  let printNodeId: string;
+
+  beforeAll(async () => {
+    // Create Blueprint
+    const bp = await createTestBlueprint({ name: bpName });
+    expect(bp.error).toBeUndefined();
+
+    // Add an event override node (BeginPlay)
+    const eventRes = await uePost("/api/add-node", {
+      blueprint: bpName,
+      graph: "EventGraph",
+      nodeType: "OverrideEvent",
+      functionName: "ReceiveBeginPlay",
+    });
+    expect(eventRes.success).toBe(true);
+    eventNodeId = eventRes.nodeId;
+
+    // Add a PrintString call
+    const printRes = await uePost("/api/add-node", {
+      blueprint: bpName,
+      graph: "EventGraph",
+      nodeType: "CallFunction",
+      functionName: "PrintString",
+    });
+    expect(printRes.success).toBe(true);
+    printNodeId = printRes.nodeId;
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  it("connects execution pins between two nodes", async () => {
+    const data = await uePost("/api/connect-pins", {
+      blueprint: bpName,
+      sourceNodeId: eventNodeId,
+      sourcePinName: "then",
+      targetNodeId: printNodeId,
+      targetPinName: "execute",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.saved).toBe(true);
+    expect(data.updatedSourceNode).toBeDefined();
+    expect(data.updatedTargetNode).toBeDefined();
+  });
+
+  it("rejects connection to non-existent pin", async () => {
+    const data = await uePost("/api/connect-pins", {
+      blueprint: bpName,
+      sourceNodeId: eventNodeId,
+      sourcePinName: "FakePin",
+      targetNodeId: printNodeId,
+      targetPinName: "execute",
+    });
+    expect(data.error).toBeDefined();
+    expect(data.availablePins).toBeDefined();
+  });
+
+  it("disconnects a pin", async () => {
+    const data = await uePost("/api/disconnect-pin", {
+      blueprint: bpName,
+      nodeId: eventNodeId,
+      pinName: "then",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.saved).toBe(true);
+  });
+
+  it("rejects disconnect on non-existent node", async () => {
+    const data = await uePost("/api/disconnect-pin", {
+      blueprint: bpName,
+      nodeId: "00000000-0000-0000-0000-000000000000",
+      pinName: "then",
+    });
+    expect(data.error).toBeDefined();
+  });
+});

--- a/Tools/test/tools/create-blueprint.test.ts
+++ b/Tools/test/tools/create-blueprint.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { ueGet, createTestBlueprint, deleteTestBlueprint, uniqueName } from "../helpers.js";
+
+describe("create_blueprint", () => {
+  const bpName = uniqueName("BP_CreateTest");
+  const packagePath = "/Game/Test";
+  let createResult: any;
+
+  beforeAll(async () => {
+    createResult = await createTestBlueprint({ name: bpName });
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  it("returns success fields", () => {
+    expect(createResult.error).toBeUndefined();
+    expect(createResult.blueprintName).toBe(bpName);
+    expect(createResult.packagePath).toBe(packagePath);
+    expect(createResult.assetPath).toContain(bpName);
+    expect(createResult.parentClass).toBe("Actor");
+    expect(createResult.blueprintType).toBe("Normal");
+    expect(createResult.saved).toBe(true);
+  });
+
+  it("creates at least one graph (EventGraph)", () => {
+    expect(createResult.graphs).toBeDefined();
+    expect(createResult.graphs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("rejects duplicate creation", async () => {
+    const dup = await createTestBlueprint({ name: bpName });
+    expect(dup.error).toBeDefined();
+    expect(dup.error).toContain("already exists");
+  });
+
+  it("appears in list_blueprints", async () => {
+    const list = await ueGet("/api/list", { filter: bpName });
+    expect(list.count).toBeGreaterThanOrEqual(1);
+    const names = list.blueprints.map((b: any) => b.name);
+    expect(names).toContain(bpName);
+  });
+
+  it("rejects invalid packagePath", async () => {
+    const bad = await createTestBlueprint({
+      name: uniqueName("BP_BadPath"),
+      packagePath: "/Invalid/Path",
+    });
+    expect(bad.error).toBeDefined();
+    expect(bad.error).toContain("/Game");
+  });
+
+  it("rejects unknown parent class", async () => {
+    const bad = await createTestBlueprint({
+      name: uniqueName("BP_BadParent"),
+      parentClass: "NonExistentClass_XYZ",
+    });
+    expect(bad.error).toBeDefined();
+    expect(bad.error).toContain("Could not find parent class");
+  });
+});

--- a/Tools/test/tools/delete-asset.test.ts
+++ b/Tools/test/tools/delete-asset.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { ueGet, createTestBlueprint, deleteTestBlueprint, uniqueName } from "../helpers.js";
+
+describe("delete_asset", () => {
+  it("deletes a Blueprint that was just created", async () => {
+    const bpName = uniqueName("BP_DeleteTest");
+    const packagePath = "/Game/Test";
+    const assetPath = `${packagePath}/${bpName}`;
+
+    // Create
+    const created = await createTestBlueprint({ name: bpName });
+    expect(created.error).toBeUndefined();
+    expect(created.saved).toBe(true);
+
+    // Verify it exists in the list
+    const listBefore = await ueGet("/api/list", { filter: bpName });
+    expect(listBefore.count).toBeGreaterThanOrEqual(1);
+
+    // Delete
+    const deleted = await deleteTestBlueprint(assetPath);
+    expect(deleted.error).toBeUndefined();
+    expect(deleted.success).toBe(true);
+    expect(deleted.assetPath).toBe(assetPath);
+  });
+
+  it("returns error for non-existent asset", async () => {
+    const data = await deleteTestBlueprint("/Game/Test/BP_DoesNotExist_999999");
+    expect(data.error).toBeDefined();
+  });
+
+  it("requires assetPath field", async () => {
+    const { uePost } = await import("../helpers.js");
+    const data = await uePost("/api/delete-asset", {});
+    expect(data.error).toBeDefined();
+    expect(data.error).toContain("assetPath");
+  });
+});

--- a/Tools/test/tools/delete-node.test.ts
+++ b/Tools/test/tools/delete-node.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { uePost, ueGet, createTestBlueprint, deleteTestBlueprint, uniqueName } from "../helpers.js";
+
+describe("delete_node", () => {
+  const bpName = uniqueName("BP_DeleteNodeTest");
+  const packagePath = "/Game/Test";
+  let printNodeId: string;
+
+  beforeAll(async () => {
+    const bp = await createTestBlueprint({ name: bpName });
+    expect(bp.error).toBeUndefined();
+
+    // Add a PrintString node to delete later
+    const res = await uePost("/api/add-node", {
+      blueprint: bpName,
+      graph: "EventGraph",
+      nodeType: "CallFunction",
+      functionName: "PrintString",
+    });
+    expect(res.success).toBe(true);
+    printNodeId = res.nodeId;
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  it("deletes a function call node", async () => {
+    const data = await uePost("/api/delete-node", {
+      blueprint: bpName,
+      nodeId: printNodeId,
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.blueprint).toBe(bpName);
+    expect(data.nodeId).toBe(printNodeId);
+    expect(data.nodeClass).toBeDefined();
+    expect(data.saved).toBe(true);
+  });
+
+  it("verifies node is gone from graph", async () => {
+    const graph = await ueGet("/api/graph", {
+      name: bpName,
+      graph: "EventGraph",
+    });
+    expect(graph.error).toBeUndefined();
+    const found = graph.nodes.find((n: any) => n.id === printNodeId);
+    expect(found).toBeUndefined();
+  });
+
+  it("rejects deletion of non-existent node", async () => {
+    const data = await uePost("/api/delete-node", {
+      blueprint: bpName,
+      nodeId: "00000000-0000-0000-0000-000000000000",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("rejects missing required fields", async () => {
+    const data = await uePost("/api/delete-node", {
+      blueprint: bpName,
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("protects entry/event nodes from deletion", async () => {
+    // Get the EventGraph to find the entry node
+    const graph = await ueGet("/api/graph", {
+      name: bpName,
+      graph: "EventGraph",
+    });
+    expect(graph.error).toBeUndefined();
+
+    // Find an event node (ReceiveBeginPlay or similar)
+    const eventNode = graph.nodes.find(
+      (n: any) =>
+        n.class?.includes("Event") || n.class?.includes("FunctionEntry"),
+    );
+    if (eventNode) {
+      const data = await uePost("/api/delete-node", {
+        blueprint: bpName,
+        nodeId: eventNode.id,
+      });
+      expect(data.error).toBeDefined();
+      expect(data.error).toContain("Cannot delete");
+    }
+  });
+});

--- a/Tools/test/tools/disconnected-pins.test.ts
+++ b/Tools/test/tools/disconnected-pins.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { uePost, createTestBlueprint, deleteTestBlueprint, uniqueName } from "../helpers.js";
+
+describe("find_disconnected_pins", () => {
+  const bpName = uniqueName("BP_DisconnPinsTest");
+  const packagePath = "/Game/Test";
+
+  beforeAll(async () => {
+    const bp = await createTestBlueprint({ name: bpName });
+    expect(bp.error).toBeUndefined();
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  it("scans a single Blueprint for disconnected pins", async () => {
+    const data = await uePost("/api/find-disconnected-pins", {
+      blueprint: bpName,
+      sensitivity: "all",
+    });
+    expect(data.error).toBeUndefined();
+    // A fresh Actor BP should have no disconnected struct pins
+    expect(data.summary).toBeDefined();
+    expect(typeof data.summary.blueprintsScanned).toBe("number");
+  });
+
+  it("scans by path filter", async () => {
+    const data = await uePost("/api/find-disconnected-pins", {
+      filter: "/Game/Test",
+      sensitivity: "medium",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.summary).toBeDefined();
+  });
+
+  it("supports high sensitivity (broken types only)", async () => {
+    const data = await uePost("/api/find-disconnected-pins", {
+      blueprint: bpName,
+      sensitivity: "high",
+    });
+    expect(data.error).toBeUndefined();
+  });
+
+  it("rejects when no scope is provided", async () => {
+    const data = await uePost("/api/find-disconnected-pins", {
+      sensitivity: "medium",
+    });
+    // Should return error or empty results (no blueprint/filter specified)
+    // The exact behavior depends on the implementation
+    expect(data).toBeDefined();
+  });
+});

--- a/Tools/test/tools/find-references.test.ts
+++ b/Tools/test/tools/find-references.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { ueGet, createTestBlueprint, deleteTestBlueprint, uniqueName } from "../helpers.js";
+
+describe("find_asset_references", () => {
+  const bpName = uniqueName("BP_RefTest");
+  const packagePath = "/Game/Test";
+  const assetPath = `${packagePath}/${bpName}`;
+
+  beforeAll(async () => {
+    const res = await createTestBlueprint({ name: bpName });
+    expect(res.error).toBeUndefined();
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(assetPath);
+  });
+
+  it("returns reference data for an existing asset", async () => {
+    const data = await ueGet("/api/references", { assetPath });
+    expect(data.error).toBeUndefined();
+    expect(data.assetPath).toBe(assetPath);
+    expect(typeof data.totalReferencers).toBe("number");
+  });
+
+  it("returns zero referencers for an isolated test asset", async () => {
+    const data = await ueGet("/api/references", { assetPath });
+    expect(data.totalReferencers).toBe(0);
+  });
+
+  it("returns zero referencers for non-existent asset path", async () => {
+    // The API queries the asset registry which returns empty for unknown paths
+    // (it does not validate asset existence — it just reports zero refs)
+    const data = await ueGet("/api/references", {
+      assetPath: "/Game/Test/NonExistent_XYZ_999",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.totalReferencers).toBe(0);
+  });
+});

--- a/Tools/test/tools/get-blueprint.test.ts
+++ b/Tools/test/tools/get-blueprint.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { ueGet, createTestBlueprint, deleteTestBlueprint, uniqueName } from "../helpers.js";
+
+describe("get_blueprint / get_blueprint_graph", () => {
+  const bpName = uniqueName("BP_GetTest");
+  const packagePath = "/Game/Test";
+
+  beforeAll(async () => {
+    const res = await createTestBlueprint({ name: bpName });
+    expect(res.error).toBeUndefined();
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  describe("get_blueprint", () => {
+    it("returns blueprint metadata", async () => {
+      const data = await ueGet("/api/blueprint", { name: bpName });
+      expect(data.error).toBeUndefined();
+      expect(data.name).toBe(bpName);
+      expect(data.parentClass).toBeDefined();
+      expect(data.graphs).toBeDefined();
+      expect(Array.isArray(data.graphs)).toBe(true);
+    });
+
+    it("returns error for non-existent blueprint", async () => {
+      const data = await ueGet("/api/blueprint", {
+        name: "BP_DoesNotExist_999999",
+      });
+      expect(data.error).toBeDefined();
+    });
+  });
+
+  describe("get_blueprint_graph", () => {
+    it("returns EventGraph with nodes and pins", async () => {
+      const data = await ueGet("/api/graph", {
+        name: bpName,
+        graph: "EventGraph",
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.graphName || data.name).toBeDefined();
+      // A fresh Actor BP should have at least default event nodes
+      expect(data.nodes).toBeDefined();
+      expect(Array.isArray(data.nodes)).toBe(true);
+    });
+
+    it("returns error for non-existent graph", async () => {
+      const data = await ueGet("/api/graph", {
+        name: bpName,
+        graph: "NonExistentGraph",
+      });
+      expect(data.error).toBeDefined();
+    });
+  });
+});

--- a/Tools/test/tools/list-blueprints.test.ts
+++ b/Tools/test/tools/list-blueprints.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { ueGet, createTestBlueprint, deleteTestBlueprint, uniqueName } from "../helpers.js";
+
+describe("list_blueprints", () => {
+  const bpName = uniqueName("BP_ListTest");
+  const packagePath = "/Game/Test";
+
+  beforeAll(async () => {
+    const res = await createTestBlueprint({ name: bpName });
+    expect(res.error).toBeUndefined();
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  it("returns count and blueprints array", async () => {
+    const data = await ueGet("/api/list");
+    expect(data.error).toBeUndefined();
+    expect(typeof data.count).toBe("number");
+    expect(typeof data.total).toBe("number");
+    expect(Array.isArray(data.blueprints)).toBe(true);
+    expect(data.count).toBeGreaterThan(0);
+  });
+
+  it("filters by name substring", async () => {
+    const data = await ueGet("/api/list", { filter: bpName });
+    expect(data.count).toBe(1);
+    expect(data.blueprints[0].name).toBe(bpName);
+  });
+
+  it("returns empty results for non-matching filter", async () => {
+    const data = await ueGet("/api/list", { filter: "ZZZ_NonExistent_XYZ" });
+    expect(data.count).toBe(0);
+    expect(data.blueprints).toHaveLength(0);
+  });
+
+  it("blueprint entries have expected fields", async () => {
+    const data = await ueGet("/api/list", { filter: bpName });
+    const bp = data.blueprints[0];
+    expect(bp.name).toBeDefined();
+    expect(bp.path).toBeDefined();
+  });
+});

--- a/Tools/test/tools/mutation.test.ts
+++ b/Tools/test/tools/mutation.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { uePost, createTestBlueprint, deleteTestBlueprint, uniqueName } from "../helpers.js";
+
+/**
+ * Tests for mutation tools that operate on variables, function parameters,
+ * and struct node types. These tools require pre-existing variables/functions
+ * that can't be created via the current API, so we primarily test error cases
+ * and verify the response structure.
+ */
+
+describe("replace_function_calls", () => {
+  const bpName = uniqueName("BP_ReplaceFnTest");
+  const packagePath = "/Game/Test";
+
+  beforeAll(async () => {
+    const bp = await createTestBlueprint({ name: bpName });
+    expect(bp.error).toBeUndefined();
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  it("returns error when newClass does not exist", async () => {
+    // The API validates newClass exists before scanning — returns error if not found
+    const data = await uePost("/api/replace-function-calls", {
+      blueprint: bpName,
+      oldClass: "FakeOldLibrary_XYZ",
+      newClass: "FakeNewLibrary_XYZ",
+    });
+    expect(data.error).toBeDefined();
+    expect(data.error).toContain("FakeNewLibrary_XYZ");
+  });
+
+  it("returns error in dryRun mode when newClass does not exist", async () => {
+    const data = await uePost("/api/replace-function-calls", {
+      blueprint: bpName,
+      oldClass: "FakeOldLibrary_XYZ",
+      newClass: "FakeNewLibrary_XYZ",
+      dryRun: true,
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("returns error for non-existent blueprint", async () => {
+    const data = await uePost("/api/replace-function-calls", {
+      blueprint: "BP_DoesNotExist_XYZ_999",
+      oldClass: "SomeClass",
+      newClass: "OtherClass",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("rejects missing required fields", async () => {
+    const data = await uePost("/api/replace-function-calls", {
+      blueprint: bpName,
+    });
+    expect(data.error).toBeDefined();
+  });
+});
+
+describe("change_variable_type", () => {
+  const bpName = uniqueName("BP_ChangeVarTest");
+  const packagePath = "/Game/Test";
+
+  beforeAll(async () => {
+    const bp = await createTestBlueprint({ name: bpName });
+    expect(bp.error).toBeUndefined();
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  it("returns error for non-existent variable", async () => {
+    const data = await uePost("/api/change-variable-type", {
+      blueprint: bpName,
+      variable: "NonExistentVar_XYZ",
+      newType: "FVector",
+      typeCategory: "struct",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("returns error for non-existent blueprint", async () => {
+    const data = await uePost("/api/change-variable-type", {
+      blueprint: "BP_DoesNotExist_XYZ_999",
+      variable: "SomeVar",
+      newType: "FVector",
+      typeCategory: "struct",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("rejects missing required fields", async () => {
+    const data = await uePost("/api/change-variable-type", {
+      blueprint: bpName,
+    });
+    expect(data.error).toBeDefined();
+  });
+});
+
+describe("change_function_parameter_type", () => {
+  const bpName = uniqueName("BP_ChangeFnParamTest");
+  const packagePath = "/Game/Test";
+
+  beforeAll(async () => {
+    const bp = await createTestBlueprint({ name: bpName });
+    expect(bp.error).toBeUndefined();
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  it("returns error for non-existent function", async () => {
+    const data = await uePost("/api/change-function-param-type", {
+      blueprint: bpName,
+      functionName: "NonExistentFunc_XYZ",
+      paramName: "SomeParam",
+      newType: "FVector",
+    });
+    expect(data.error).toBeDefined();
+    expect(data.availableFunctionsAndEvents).toBeDefined();
+  });
+
+  it("returns error for non-existent blueprint", async () => {
+    const data = await uePost("/api/change-function-param-type", {
+      blueprint: "BP_DoesNotExist_XYZ_999",
+      functionName: "SomeFunc",
+      paramName: "SomeParam",
+      newType: "FVector",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("rejects missing required fields", async () => {
+    const data = await uePost("/api/change-function-param-type", {
+      blueprint: bpName,
+    });
+    expect(data.error).toBeDefined();
+  });
+});
+
+describe("remove_function_parameter", () => {
+  const bpName = uniqueName("BP_RemoveParamTest");
+  const packagePath = "/Game/Test";
+
+  beforeAll(async () => {
+    const bp = await createTestBlueprint({ name: bpName });
+    expect(bp.error).toBeUndefined();
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  it("returns error for non-existent function", async () => {
+    const data = await uePost("/api/remove-function-parameter", {
+      blueprint: bpName,
+      functionName: "NonExistentFunc_XYZ",
+      paramName: "SomeParam",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("returns error for non-existent blueprint", async () => {
+    const data = await uePost("/api/remove-function-parameter", {
+      blueprint: "BP_DoesNotExist_XYZ_999",
+      functionName: "SomeFunc",
+      paramName: "SomeParam",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("rejects missing required fields", async () => {
+    const data = await uePost("/api/remove-function-parameter", {
+      blueprint: bpName,
+    });
+    expect(data.error).toBeDefined();
+  });
+});
+
+describe("change_struct_node_type", () => {
+  const bpName = uniqueName("BP_ChangeStructTest");
+  const packagePath = "/Game/Test";
+
+  beforeAll(async () => {
+    const bp = await createTestBlueprint({ name: bpName });
+    expect(bp.error).toBeUndefined();
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  it("returns error for non-existent node", async () => {
+    const data = await uePost("/api/change-struct-node-type", {
+      blueprint: bpName,
+      nodeId: "00000000-0000-0000-0000-000000000000",
+      newType: "FVector",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("returns error for non-existent blueprint", async () => {
+    const data = await uePost("/api/change-struct-node-type", {
+      blueprint: "BP_DoesNotExist_XYZ_999",
+      nodeId: "some-node-id",
+      newType: "FVector",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("rejects missing required fields", async () => {
+    const data = await uePost("/api/change-struct-node-type", {
+      blueprint: bpName,
+    });
+    expect(data.error).toBeDefined();
+  });
+});

--- a/Tools/test/tools/rebuild-impact.test.ts
+++ b/Tools/test/tools/rebuild-impact.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { uePost } from "../helpers.js";
+
+describe("analyze_rebuild_impact", () => {
+  it("analyzes impact for the Engine module", async () => {
+    const data = await uePost("/api/analyze-rebuild-impact", {
+      moduleName: "Engine",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.summary).toBeDefined();
+    expect(typeof data.summary.totalBlueprints).toBe("number");
+    expect(typeof data.summary.totalBreakMakeNodes).toBe("number");
+    expect(typeof data.summary.totalConnectionsAtRisk).toBe("number");
+  });
+
+  it("analyzes impact with specific struct names", async () => {
+    const data = await uePost("/api/analyze-rebuild-impact", {
+      moduleName: "Engine",
+      structNames: ["Vector"],
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.summary).toBeDefined();
+  });
+
+  it("handles non-existent module gracefully", async () => {
+    const data = await uePost("/api/analyze-rebuild-impact", {
+      moduleName: "NonExistentModule_XYZ_999",
+    });
+    // Should succeed with zero affected (module name is used as a package name filter)
+    expect(data.error).toBeUndefined();
+    expect(data.summary).toBeDefined();
+    expect(data.summary.totalBlueprints).toBe(0);
+  });
+
+  it("rejects missing required fields", async () => {
+    const data = await uePost("/api/analyze-rebuild-impact", {});
+    expect(data.error).toBeDefined();
+  });
+});

--- a/Tools/test/tools/refresh-nodes.test.ts
+++ b/Tools/test/tools/refresh-nodes.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { uePost, createTestBlueprint, deleteTestBlueprint, uniqueName } from "../helpers.js";
+
+describe("refresh_all_nodes", () => {
+  const bpName = uniqueName("BP_RefreshTest");
+  const packagePath = "/Game/Test";
+
+  beforeAll(async () => {
+    const bp = await createTestBlueprint({ name: bpName });
+    expect(bp.error).toBeUndefined();
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  it("refreshes all nodes in a Blueprint", async () => {
+    const data = await uePost("/api/refresh-all-nodes", {
+      blueprint: bpName,
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.blueprint).toBe(bpName);
+    expect(typeof data.graphCount).toBe("number");
+    expect(typeof data.nodeCount).toBe("number");
+    expect(data.saved).toBe(true);
+  });
+
+  it("returns error for non-existent blueprint", async () => {
+    const data = await uePost("/api/refresh-all-nodes", {
+      blueprint: "BP_DoesNotExist_XYZ_999",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("rejects missing required fields", async () => {
+    const data = await uePost("/api/refresh-all-nodes", {});
+    expect(data.error).toBeDefined();
+  });
+});

--- a/Tools/test/tools/rename-asset.test.ts
+++ b/Tools/test/tools/rename-asset.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { uePost, ueGet, createTestBlueprint, deleteTestBlueprint, uniqueName } from "../helpers.js";
+
+describe("rename_asset", () => {
+  const bpName = uniqueName("BP_RenameTest");
+  const packagePath = "/Game/Test";
+  const newName = uniqueName("BP_Renamed");
+
+  beforeAll(async () => {
+    const bp = await createTestBlueprint({ name: bpName });
+    expect(bp.error).toBeUndefined();
+  });
+
+  afterAll(async () => {
+    // Clean up the renamed asset (or original if rename failed)
+    await deleteTestBlueprint(`${packagePath}/${newName}`);
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  it("renames a Blueprint asset", async () => {
+    const data = await uePost("/api/rename-asset", {
+      assetPath: `${packagePath}/${bpName}`,
+      newPath: `${packagePath}/${newName}`,
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.oldPath).toBe(`${packagePath}/${bpName}`);
+    expect(data.newPath).toBe(`${packagePath}/${newName}`);
+  });
+
+  it("verifies renamed asset exists under new name", async () => {
+    const list = await ueGet("/api/list", { filter: newName });
+    expect(list.count).toBeGreaterThanOrEqual(1);
+  });
+
+  it("returns error for non-existent source asset", async () => {
+    const data = await uePost("/api/rename-asset", {
+      assetPath: "/Game/Test/BP_DoesNotExist_XYZ_999",
+      newPath: "/Game/Test/BP_Whatever",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("rejects missing required fields", async () => {
+    const data = await uePost("/api/rename-asset", {});
+    expect(data.error).toBeDefined();
+  });
+});

--- a/Tools/test/tools/reparent.test.ts
+++ b/Tools/test/tools/reparent.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { uePost, ueGet, createTestBlueprint, deleteTestBlueprint, uniqueName } from "../helpers.js";
+
+describe("reparent_blueprint", () => {
+  const bpName = uniqueName("BP_ReparentTest");
+  const packagePath = "/Game/Test";
+
+  beforeAll(async () => {
+    // Create an Actor-based BP
+    const bp = await createTestBlueprint({ name: bpName, parentClass: "Actor" });
+    expect(bp.error).toBeUndefined();
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  it("reparents a Blueprint to a new parent class", async () => {
+    const data = await uePost("/api/reparent-blueprint", {
+      blueprint: bpName,
+      newParentClass: "Pawn",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.blueprint).toBe(bpName);
+    expect(data.newParentClass).toContain("Pawn");
+    expect(data.saved).toBe(true);
+  });
+
+  it("verifies parent class changed via get_blueprint", async () => {
+    const info = await ueGet("/api/blueprint", { name: bpName });
+    expect(info.error).toBeUndefined();
+    expect(info.parentClass).toContain("Pawn");
+  });
+
+  it("returns error for non-existent blueprint", async () => {
+    const data = await uePost("/api/reparent-blueprint", {
+      blueprint: "BP_DoesNotExist_XYZ_999",
+      newParentClass: "Pawn",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("returns error for non-existent parent class", async () => {
+    const data = await uePost("/api/reparent-blueprint", {
+      blueprint: bpName,
+      newParentClass: "NonExistentClass_XYZ_999",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("rejects missing required fields", async () => {
+    const data = await uePost("/api/reparent-blueprint", {
+      blueprint: bpName,
+    });
+    expect(data.error).toBeDefined();
+  });
+});

--- a/Tools/test/tools/search.test.ts
+++ b/Tools/test/tools/search.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { ueGet, uePost, createTestBlueprint, deleteTestBlueprint, uniqueName } from "../helpers.js";
+
+describe("search_blueprints", () => {
+  const bpName = uniqueName("BP_SearchTest");
+  const packagePath = "/Game/Test";
+
+  beforeAll(async () => {
+    const bp = await createTestBlueprint({ name: bpName });
+    expect(bp.error).toBeUndefined();
+    // Add a PrintString node so we have something to search for
+    await uePost("/api/add-node", {
+      blueprint: bpName,
+      graph: "EventGraph",
+      nodeType: "CallFunction",
+      functionName: "PrintString",
+    });
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  it("finds nodes matching a query", async () => {
+    const data = await ueGet("/api/search", {
+      query: "PrintString",
+      path: "/Game/Test",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.resultCount).toBeGreaterThanOrEqual(1);
+    expect(Array.isArray(data.results)).toBe(true);
+  });
+
+  it("returns empty results for non-matching query", async () => {
+    const data = await ueGet("/api/search", {
+      query: "ZZZ_NonExistentFunction_XYZ",
+      path: "/Game/Test",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.resultCount).toBe(0);
+  });
+
+  it("rejects missing query parameter", async () => {
+    const data = await ueGet("/api/search", {});
+    expect(data.error).toBeDefined();
+  });
+});
+
+describe("search_by_type", () => {
+  it("returns type usage results structure", async () => {
+    // Search for a type that likely exists in engine BPs
+    const data = await ueGet("/api/search-by-type", { typeName: "Vector" });
+    expect(data.error).toBeUndefined();
+    // May or may not find results, but the structure should be valid
+  });
+
+  it("returns empty for non-existent type", async () => {
+    const data = await ueGet("/api/search-by-type", {
+      typeName: "FNonExistentType_XYZ_999",
+    });
+    expect(data.error).toBeUndefined();
+  });
+});

--- a/Tools/test/tools/server-status.test.ts
+++ b/Tools/test/tools/server-status.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { ueGet } from "../helpers.js";
+
+describe("server_status", () => {
+  it("returns health information", async () => {
+    const data = await ueGet("/api/health");
+    expect(data.status).toBe("ok");
+    expect(typeof data.blueprintCount).toBe("number");
+    expect(typeof data.mapCount).toBe("number");
+    expect(data.mode).toBeDefined();
+  });
+
+  it("reports commandlet mode in test environment", async () => {
+    const data = await ueGet("/api/health");
+    expect(data.mode).toBe("commandlet");
+  });
+});

--- a/Tools/test/tools/set-defaults.test.ts
+++ b/Tools/test/tools/set-defaults.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { uePost, ueGet, createTestBlueprint, deleteTestBlueprint, uniqueName } from "../helpers.js";
+
+describe("set_blueprint_default", () => {
+  const bpName = uniqueName("BP_SetDefaultTest");
+  const packagePath = "/Game/Test";
+
+  beforeAll(async () => {
+    const bp = await createTestBlueprint({ name: bpName });
+    expect(bp.error).toBeUndefined();
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  it("returns error for non-existent property", async () => {
+    const data = await uePost("/api/set-blueprint-default", {
+      blueprint: bpName,
+      property: "NonExistentProperty_XYZ",
+      value: "true",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("returns error for non-existent blueprint", async () => {
+    const data = await uePost("/api/set-blueprint-default", {
+      blueprint: "BP_DoesNotExist_XYZ_999",
+      property: "SomeProperty",
+      value: "true",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("rejects missing required fields", async () => {
+    const data = await uePost("/api/set-blueprint-default", {
+      blueprint: bpName,
+    });
+    expect(data.error).toBeDefined();
+  });
+});
+
+describe("set_pin_default", () => {
+  const bpName = uniqueName("BP_SetPinTest");
+  const packagePath = "/Game/Test";
+  let printNodeId: string;
+
+  beforeAll(async () => {
+    const bp = await createTestBlueprint({ name: bpName });
+    expect(bp.error).toBeUndefined();
+
+    // Add a PrintString node — it has an "InString" pin with a default value
+    const res = await uePost("/api/add-node", {
+      blueprint: bpName,
+      graph: "EventGraph",
+      nodeType: "CallFunction",
+      functionName: "PrintString",
+    });
+    expect(res.success).toBe(true);
+    printNodeId = res.nodeId;
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  it("sets a pin default value on PrintString's InString pin", async () => {
+    const data = await uePost("/api/set-pin-default", {
+      blueprint: bpName,
+      nodeId: printNodeId,
+      pinName: "InString",
+      value: "Hello Test",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.newValue).toBe("Hello Test");
+    expect(data.saved).toBe(true);
+  });
+
+  it("returns error for non-existent pin", async () => {
+    const data = await uePost("/api/set-pin-default", {
+      blueprint: bpName,
+      nodeId: printNodeId,
+      pinName: "FakePin_XYZ",
+      value: "test",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("returns error for non-existent node", async () => {
+    const data = await uePost("/api/set-pin-default", {
+      blueprint: bpName,
+      nodeId: "00000000-0000-0000-0000-000000000000",
+      pinName: "InString",
+      value: "test",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("rejects missing required fields", async () => {
+    const data = await uePost("/api/set-pin-default", {
+      blueprint: bpName,
+    });
+    expect(data.error).toBeDefined();
+  });
+});

--- a/Tools/test/tools/snapshot-restore.test.ts
+++ b/Tools/test/tools/snapshot-restore.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { uePost, createTestBlueprint, deleteTestBlueprint, uniqueName } from "../helpers.js";
+
+describe("snapshot_graph / diff_graph / restore_graph", () => {
+  const bpName = uniqueName("BP_SnapshotTest");
+  const packagePath = "/Game/Test";
+  let snapshotId: string;
+
+  beforeAll(async () => {
+    const bp = await createTestBlueprint({ name: bpName });
+    expect(bp.error).toBeUndefined();
+
+    // Add a PrintString node so there's some graph content
+    await uePost("/api/add-node", {
+      blueprint: bpName,
+      graph: "EventGraph",
+      nodeType: "CallFunction",
+      functionName: "PrintString",
+    });
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  describe("snapshot_graph", () => {
+    it("creates a snapshot of EventGraph", async () => {
+      const data = await uePost("/api/snapshot-graph", {
+        blueprint: bpName,
+        graph: "EventGraph",
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.snapshotId).toBeDefined();
+      expect(data.blueprint).toBe(bpName);
+      expect(data.totalConnections).toBeDefined();
+      snapshotId = data.snapshotId;
+    });
+
+    it("creates a snapshot of all graphs when graph is omitted", async () => {
+      const data = await uePost("/api/snapshot-graph", {
+        blueprint: bpName,
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.snapshotId).toBeDefined();
+      expect(Array.isArray(data.graphs)).toBe(true);
+    });
+
+    it("returns error for non-existent blueprint", async () => {
+      const data = await uePost("/api/snapshot-graph", {
+        blueprint: "BP_DoesNotExist_XYZ_999",
+      });
+      expect(data.error).toBeDefined();
+    });
+  });
+
+  describe("diff_graph", () => {
+    it("diffs current state against snapshot (no changes)", async () => {
+      expect(snapshotId).toBeDefined();
+      const data = await uePost("/api/diff-graph", {
+        blueprint: bpName,
+        snapshotId,
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.summary).toBeDefined();
+      // No changes since snapshot
+      expect(data.summary.severedConnections).toBe(0);
+      expect(data.summary.missingNodes).toBe(0);
+    });
+
+    it("returns error for invalid snapshot ID", async () => {
+      const data = await uePost("/api/diff-graph", {
+        blueprint: bpName,
+        snapshotId: "invalid-snapshot-id-xyz",
+      });
+      expect(data.error).toBeDefined();
+    });
+  });
+
+  describe("restore_graph", () => {
+    it("restores from snapshot in dry-run mode", async () => {
+      expect(snapshotId).toBeDefined();
+      const data = await uePost("/api/restore-graph", {
+        blueprint: bpName,
+        snapshotId,
+        dryRun: true,
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.status).toBe("ok");
+      expect(typeof data.reconnected).toBe("number");
+      expect(typeof data.failed).toBe("number");
+    });
+
+    it("restores from snapshot (actual)", async () => {
+      expect(snapshotId).toBeDefined();
+      const data = await uePost("/api/restore-graph", {
+        blueprint: bpName,
+        snapshotId,
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.status).toBe("ok");
+      expect(typeof data.reconnected).toBe("number");
+    });
+
+    it("returns error for invalid snapshot ID", async () => {
+      const data = await uePost("/api/restore-graph", {
+        blueprint: bpName,
+        snapshotId: "invalid-snapshot-id-xyz",
+      });
+      expect(data.error).toBeDefined();
+    });
+  });
+});

--- a/Tools/test/tools/validate.test.ts
+++ b/Tools/test/tools/validate.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { uePost, createTestBlueprint, deleteTestBlueprint, uniqueName } from "../helpers.js";
+
+describe("validate_blueprint", () => {
+  const bpName = uniqueName("BP_ValidateTest");
+  const packagePath = "/Game/Test";
+
+  beforeAll(async () => {
+    const bp = await createTestBlueprint({ name: bpName });
+    expect(bp.error).toBeUndefined();
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  it("validates a clean Blueprint successfully", async () => {
+    const data = await uePost("/api/validate-blueprint", {
+      blueprint: bpName,
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.blueprint).toBe(bpName);
+    expect(data.isValid).toBe(true);
+  });
+
+  it("returns error for non-existent blueprint", async () => {
+    const data = await uePost("/api/validate-blueprint", {
+      blueprint: "BP_DoesNotExist_XYZ_999",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("rejects missing required fields", async () => {
+    const data = await uePost("/api/validate-blueprint", {});
+    expect(data.error).toBeDefined();
+  });
+});
+
+describe("validate_all_blueprints", () => {
+  it("validates all blueprints in /Game/Test path", async () => {
+    const data = await uePost("/api/validate-all-blueprints", {
+      filter: "/Game/Test",
+    });
+    expect(data.error).toBeUndefined();
+    expect(typeof data.totalChecked).toBe("number");
+    expect(typeof data.totalPassed).toBe("number");
+    expect(typeof data.totalFailed).toBe("number");
+  });
+
+  it("validates with no filter (may take longer)", async () => {
+    const data = await uePost("/api/validate-all-blueprints", {});
+    expect(data.error).toBeUndefined();
+    expect(data.totalChecked).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/Tools/vitest.config.ts
+++ b/Tools/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // All tests share one commandlet process — run sequentially
+    fileParallelism: false,
+    // Commandlet startup can take minutes; individual tests are fast
+    testTimeout: 30_000,
+    hookTimeout: 60_000,
+    // Global setup boots the commandlet before any test file runs
+    globalSetup: "./test/setup.ts",
+    // Test file location
+    include: ["test/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- Self-bootstrapping test infrastructure: generates temp UE5 project, spawns headless commandlet, creates Blueprint fixtures via API, runs tests, cleans up
- **101 tests** across **20 test files** covering all 32 testable tools (100% coverage)
- CLAUDE.md updated to mandate integration tests for any new tool

## Architecture
- `Tools/test/bootstrap.ts` — temp project generation with directory junctions, commandlet spawn/shutdown
- `Tools/test/helpers.ts` — HTTP wrappers (`ueGet`/`uePost`), fixture create/delete
- `Tools/test/setup.ts` — vitest globalSetup/globalTeardown
- Test commandlet runs on port 19847 (not 9847) to avoid editor conflicts
- No committed `.uasset` files — all fixtures created/deleted programmatically

## Tools tested
| File | Tools |
|------|-------|
| `server-status.test.ts` | `server_status` |
| `list-blueprints.test.ts` | `list_blueprints` |
| `create-blueprint.test.ts` | `create_blueprint` |
| `get-blueprint.test.ts` | `get_blueprint`, `get_blueprint_graph` |
| `blueprint-info.test.ts` | `get_blueprint_summary`, `describe_graph` |
| `add-node.test.ts` | `add_node` |
| `connect-pins.test.ts` | `connect_pins`, `disconnect_pin` |
| `delete-node.test.ts` | `delete_node` |
| `delete-asset.test.ts` | `delete_asset` |
| `rename-asset.test.ts` | `rename_asset` |
| `reparent.test.ts` | `reparent_blueprint` |
| `search.test.ts` | `search_blueprints`, `search_by_type` |
| `find-references.test.ts` | `find_asset_references` |
| `set-defaults.test.ts` | `set_blueprint_default`, `set_pin_default` |
| `validate.test.ts` | `validate_blueprint`, `validate_all_blueprints` |
| `refresh-nodes.test.ts` | `refresh_all_nodes` |
| `snapshot-restore.test.ts` | `snapshot_graph`, `diff_graph`, `restore_graph` |
| `disconnected-pins.test.ts` | `find_disconnected_pins` |
| `rebuild-impact.test.ts` | `analyze_rebuild_impact` |
| `mutation.test.ts` | `replace_function_calls`, `change_variable_type`, `change_function_parameter_type`, `remove_function_parameter`, `change_struct_node_type` |

## Test plan
- [x] `npm run build` passes (production build unaffected)
- [x] `npm test` — 101/101 tests pass (~45s including commandlet startup)
- [x] `tsc --noEmit` — no type errors
- [x] Temp project cleaned up after test run (no leftover files)

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)