### PR TITLE
Add level blueprint filtering, tagging, and fix search_by_type formatter

### DIFF
--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -124,11 +124,11 @@ UBlueprint* FBlueprintMCPServer::LoadBlueprintByName(const FString& NameOrPath, 
 				return LevelBP;
 			}
 		}
-		OutError = FString::Printf(TEXT("Map '%s' loaded but level blueprint could not be retrieved"), *NameOrPath);
+		OutError = FString::Printf(TEXT("Map '%s' loaded but its level blueprint could not be retrieved. The map may not contain a level blueprint."), *NameOrPath);
 		return nullptr;
 	}
 
-	OutError = FString::Printf(TEXT("Blueprint or map '%s' not found"), *NameOrPath);
+	OutError = FString::Printf(TEXT("Blueprint or map '%s' not found. Use list_blueprints to see available assets. Level blueprints are referenced by their map name (e.g. 'MAP_Ward')."), *NameOrPath);
 	return nullptr;
 }
 

--- a/Tools/test/tools/list-blueprints.test.ts
+++ b/Tools/test/tools/list-blueprints.test.ts
@@ -41,4 +41,34 @@ describe("list_blueprints", () => {
     expect(bp.name).toBeDefined();
     expect(bp.path).toBeDefined();
   });
+
+  it("type=regular excludes level blueprints", async () => {
+    const data = await ueGet("/api/list", { type: "regular" });
+    expect(data.error).toBeUndefined();
+    const levelBPs = data.blueprints.filter((bp: any) => bp.isLevelBlueprint);
+    expect(levelBPs).toHaveLength(0);
+  });
+
+  it("type=level returns only level blueprints", async () => {
+    const data = await ueGet("/api/list", { type: "level" });
+    expect(data.error).toBeUndefined();
+    // Every entry should be a level blueprint
+    for (const bp of data.blueprints) {
+      expect(bp.isLevelBlueprint).toBe(true);
+    }
+  });
+
+  it("type=all returns both regular and level blueprints", async () => {
+    const all = await ueGet("/api/list", { type: "all" });
+    const regular = await ueGet("/api/list", { type: "regular" });
+    const level = await ueGet("/api/list", { type: "level" });
+    expect(all.error).toBeUndefined();
+    expect(all.count).toBe(regular.count + level.count);
+  });
+
+  it("regular blueprint entries do not have isLevelBlueprint", async () => {
+    const data = await ueGet("/api/list", { filter: bpName });
+    expect(data.count).toBe(1);
+    expect(data.blueprints[0].isLevelBlueprint).toBeUndefined();
+  });
 });

--- a/Tools/test/tools/search.test.ts
+++ b/Tools/test/tools/search.test.ts
@@ -44,14 +44,31 @@ describe("search_blueprints", () => {
     const data = await ueGet("/api/search", {});
     expect(data.error).toBeDefined();
   });
+
+  it("regular BP search results do not have isLevelBlueprint", async () => {
+    const data = await ueGet("/api/search", {
+      query: "PrintString",
+      path: "/Game/Test",
+    });
+    expect(data.error).toBeUndefined();
+    for (const r of data.results) {
+      expect(r.isLevelBlueprint).toBeUndefined();
+    }
+  });
 });
 
 describe("search_by_type", () => {
-  it("returns type usage results structure", async () => {
-    // Search for a type that likely exists in engine BPs
+  it("returns flat results array with usage field", async () => {
     const data = await ueGet("/api/search-by-type", { typeName: "Vector" });
     expect(data.error).toBeUndefined();
-    // May or may not find results, but the structure should be valid
+    expect(Array.isArray(data.results)).toBe(true);
+    expect(typeof data.resultCount).toBe("number");
+    // If results exist, each should have a usage field
+    for (const r of data.results) {
+      expect(r.usage).toBeDefined();
+      expect(r.blueprint).toBeDefined();
+      expect(r.blueprintPath).toBeDefined();
+    }
   });
 
   it("returns empty for non-existent type", async () => {
@@ -59,5 +76,17 @@ describe("search_by_type", () => {
       typeName: "FNonExistentType_XYZ_999",
     });
     expect(data.error).toBeUndefined();
+    expect(data.resultCount).toBe(0);
+  });
+
+  it("regular BP results do not have isLevelBlueprint", async () => {
+    const data = await ueGet("/api/search-by-type", {
+      typeName: "Vector",
+      filter: "/Game/Test",
+    });
+    expect(data.error).toBeUndefined();
+    for (const r of data.results) {
+      expect(r.isLevelBlueprint).toBeUndefined();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Adds `type` parameter to `list_blueprints` (`all`/`regular`/`level`) so users can filter by blueprint type
- Tags level BP results with `isLevelBlueprint: true` in `search_blueprints` and `search_by_type` responses, shown as `[Level]` in formatted output
- Extends `search_by_type` to search level blueprints from map assets (previously only searched regular BPs)
- **Fixes pre-existing bug**: `search_by_type` TS formatter expected categorized fields (`data.variables`, `data.parameters`) but C++ returns a flat `data.results` array — always showed "No usages found"
- Improves `LoadBlueprintByName()` error messages with actionable hints

Closes #18

## Test plan
- [ ] `list_blueprints` with `type=regular` returns no level BPs
- [ ] `list_blueprints` with `type=level` returns only level BPs with `isLevelBlueprint: true`
- [ ] `list_blueprints` with `type=all` count equals regular + level counts
- [ ] `search_blueprints` tags level BP results with `isLevelBlueprint`
- [ ] `search_by_type` now finds usages inside level blueprints
- [ ] `search_by_type` formatter correctly categorizes results by usage type (was broken)
- [ ] Regular BP results never have `isLevelBlueprint` field
- [ ] Run `npm test` — new tests for type filter and isLevelBlueprint tagging pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)