### PR TITLE
Add pagination and progress reporting to validate_all_blueprints

### DIFF
--- a/Tools/test/tools/validate.test.ts
+++ b/Tools/test/tools/validate.test.ts
@@ -45,11 +45,96 @@ describe("validate_all_blueprints", () => {
     expect(typeof data.totalChecked).toBe("number");
     expect(typeof data.totalPassed).toBe("number");
     expect(typeof data.totalFailed).toBe("number");
+    expect(typeof data.totalMatching).toBe("number");
   });
 
   it("validates with no filter (may take longer)", async () => {
     const data = await uePost("/api/validate-all-blueprints", {});
     expect(data.error).toBeUndefined();
     expect(data.totalChecked).toBeGreaterThanOrEqual(0);
+    expect(typeof data.totalMatching).toBe("number");
+  });
+});
+
+describe("validate_all_blueprints pagination", () => {
+  const bpNames = [
+    uniqueName("BP_ValidatePag_A"),
+    uniqueName("BP_ValidatePag_B"),
+    uniqueName("BP_ValidatePag_C"),
+  ];
+  const packagePath = "/Game/Test";
+
+  beforeAll(async () => {
+    for (const name of bpNames) {
+      const bp = await createTestBlueprint({ name });
+      expect(bp.error).toBeUndefined();
+    }
+  });
+
+  afterAll(async () => {
+    for (const name of bpNames) {
+      await deleteTestBlueprint(`${packagePath}/${name}`);
+    }
+  });
+
+  it("countOnly returns totalMatching without validation fields", async () => {
+    const data = await uePost("/api/validate-all-blueprints", {
+      filter: "BP_ValidatePag_",
+      countOnly: true,
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.totalMatching).toBeGreaterThanOrEqual(3);
+    // countOnly should NOT include validation result fields
+    expect(data.totalChecked).toBeUndefined();
+    expect(data.totalPassed).toBeUndefined();
+    expect(data.totalFailed).toBeUndefined();
+    expect(data.failed).toBeUndefined();
+  });
+
+  it("countOnly with non-matching filter returns 0", async () => {
+    const data = await uePost("/api/validate-all-blueprints", {
+      filter: "BP_NoSuchBlueprint_ZZZ_999",
+      countOnly: true,
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.totalMatching).toBe(0);
+  });
+
+  it("offset + limit respects limit on totalChecked", async () => {
+    const data = await uePost("/api/validate-all-blueprints", {
+      filter: "BP_ValidatePag_",
+      offset: 0,
+      limit: 2,
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.totalMatching).toBeGreaterThanOrEqual(3);
+    expect(data.totalChecked).toBeLessThanOrEqual(2);
+  });
+
+  it("offset beyond total returns totalChecked: 0", async () => {
+    const data = await uePost("/api/validate-all-blueprints", {
+      filter: "BP_ValidatePag_",
+      offset: 9999,
+      limit: 10,
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.totalMatching).toBeGreaterThanOrEqual(3);
+    expect(data.totalChecked).toBe(0);
+  });
+
+  it("offset=0, limit=0 matches unparameterized call (backward compat)", async () => {
+    const withParams = await uePost("/api/validate-all-blueprints", {
+      filter: "BP_ValidatePag_",
+      offset: 0,
+      limit: 0,
+    });
+    const withoutParams = await uePost("/api/validate-all-blueprints", {
+      filter: "BP_ValidatePag_",
+    });
+    expect(withParams.error).toBeUndefined();
+    expect(withoutParams.error).toBeUndefined();
+    expect(withParams.totalChecked).toBe(withoutParams.totalChecked);
+    expect(withParams.totalPassed).toBe(withoutParams.totalPassed);
+    expect(withParams.totalFailed).toBe(withoutParams.totalFailed);
   });
 });


### PR DESCRIPTION
## Summary
- Add `countOnly`, `offset`, `limit` params to the C++ `HandleValidateAllBlueprints` endpoint for pagination without breaking existing callers
- Rewrite the TypeScript `validate_all_blueprints` tool to iterate in batches of 50 (configurable via `batchSize`), sending MCP `notifications/progress` between each batch
- Add 5 new integration tests covering `countOnly`, offset/limit bounds, and backward compatibility

Closes #25

## Test plan
- [ ] `npm run build` passes (TypeScript)
- [ ] C++ compiles via UnrealBuildTool
- [ ] Existing `validate_all_blueprints` tests still pass (backward compat: `offset=0, limit=0` = validate all)
- [ ] New pagination tests pass: `countOnly`, `offset+limit`, offset beyond total, backward compat
- [ ] Manual: call `validate_all_blueprints` with a filter via MCP — should see progress updates in Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)