### PR TITLE
Add comment/reroute nodes and node comment tools (#20, #21)

### DIFF
--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -428,6 +428,10 @@ bool FBlueprintMCPServer::Start(int32 InPort, bool bEditorMode)
 		QueuedHandler(TEXT("setPinDefault")));
 	Router->BindRoute(FHttpPath(TEXT("/api/move-node")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("moveNode")));
+	Router->BindRoute(FHttpPath(TEXT("/api/get-node-comment")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("getNodeComment")));
+	Router->BindRoute(FHttpPath(TEXT("/api/set-node-comment")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("setNodeComment")));
 	Router->BindRoute(FHttpPath(TEXT("/api/change-struct-node-type")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("changeStructNodeType")));
 	Router->BindRoute(FHttpPath(TEXT("/api/remove-function-parameter")), EHttpServerRequestVerbs::VERB_POST,
@@ -611,6 +615,7 @@ void FBlueprintMCPServer::RegisterHandlers()
 		TEXT("deleteNode"),
 		TEXT("duplicateNodes"),
 		TEXT("addNode"),
+		TEXT("setNodeComment"),
 		TEXT("renameAsset"),
 		TEXT("reparentBlueprint"),
 		TEXT("setBlueprintDefault"),
@@ -649,6 +654,8 @@ void FBlueprintMCPServer::RegisterHandlers()
 	HandlerMap.Add(TEXT("refreshAllNodes"),         [this](const TMap<FString, FString>&, const FString& B) { return HandleRefreshAllNodes(B); });
 	HandlerMap.Add(TEXT("setPinDefault"),           [this](const TMap<FString, FString>&, const FString& B) { return HandleSetPinDefault(B); });
 	HandlerMap.Add(TEXT("moveNode"),               [this](const TMap<FString, FString>&, const FString& B) { return HandleMoveNode(B); });
+	HandlerMap.Add(TEXT("getNodeComment"),          [this](const TMap<FString, FString>&, const FString& B) { return HandleGetNodeComment(B); });
+	HandlerMap.Add(TEXT("setNodeComment"),          [this](const TMap<FString, FString>&, const FString& B) { return HandleSetNodeComment(B); });
 	HandlerMap.Add(TEXT("changeStructNodeType"),    [this](const TMap<FString, FString>&, const FString& B) { return HandleChangeStructNodeType(B); });
 	HandlerMap.Add(TEXT("deleteNode"),              [this](const TMap<FString, FString>&, const FString& B) { return HandleDeleteNode(B); });
 	HandlerMap.Add(TEXT("duplicateNodes"),          [this](const TMap<FString, FString>&, const FString& B) { return HandleDuplicateNodes(B); });

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -134,6 +134,8 @@ private:
 	FString HandleRefreshAllNodes(const FString& Body);
 	FString HandleSetPinDefault(const FString& Body);
 	FString HandleMoveNode(const FString& Body);
+	FString HandleGetNodeComment(const FString& Body);
+	FString HandleSetNodeComment(const FString& Body);
 
 	// ----- Struct node manipulation (write) -----
 	FString HandleChangeStructNodeType(const FString& Body);

--- a/Tools/test/tools/add-node.test.ts
+++ b/Tools/test/tools/add-node.test.ts
@@ -199,4 +199,45 @@ describe("add_node", () => {
     expect(data.nodeId).toBeDefined();
     expect(data.saved).toBe(true);
   });
+
+  it("adds a Comment node", async () => {
+    const data = await uePost("/api/add-node", {
+      blueprint: bpName,
+      graph: "EventGraph",
+      nodeType: "Comment",
+      comment: "Test Section",
+      width: 500,
+      height: 300,
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.nodeId).toBeDefined();
+    expect(data.saved).toBe(true);
+  });
+
+  it("adds a Comment node with defaults", async () => {
+    const data = await uePost("/api/add-node", {
+      blueprint: bpName,
+      graph: "EventGraph",
+      nodeType: "Comment",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.nodeId).toBeDefined();
+    expect(data.saved).toBe(true);
+  });
+
+  it("adds a Reroute node", async () => {
+    const data = await uePost("/api/add-node", {
+      blueprint: bpName,
+      graph: "EventGraph",
+      nodeType: "Reroute",
+      posX: 300,
+      posY: 200,
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.nodeId).toBeDefined();
+    expect(data.saved).toBe(true);
+  });
 });

--- a/Tools/test/tools/node-comments.test.ts
+++ b/Tools/test/tools/node-comments.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { uePost, createTestBlueprint, deleteTestBlueprint, uniqueName } from "../helpers.js";
+
+describe("node_comments", () => {
+  const bpName = uniqueName("BP_NodeCommentTest");
+  const packagePath = "/Game/Test";
+  let testNodeId: string;
+
+  beforeAll(async () => {
+    const res = await createTestBlueprint({ name: bpName });
+    expect(res.error).toBeUndefined();
+
+    // Add a node to test comments on
+    const node = await uePost("/api/add-node", {
+      blueprint: bpName,
+      graph: "EventGraph",
+      nodeType: "CallFunction",
+      functionName: "PrintString",
+    });
+    expect(node.error).toBeUndefined();
+    testNodeId = node.nodeId;
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  it("gets an empty comment on a new node", async () => {
+    const data = await uePost("/api/get-node-comment", {
+      blueprint: bpName,
+      nodeId: testNodeId,
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.comment).toBe("");
+  });
+
+  it("sets a comment on a node", async () => {
+    const data = await uePost("/api/set-node-comment", {
+      blueprint: bpName,
+      nodeId: testNodeId,
+      comment: "This prints a debug message",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.oldComment).toBe("");
+    expect(data.newComment).toBe("This prints a debug message");
+    expect(data.saved).toBe(true);
+  });
+
+  it("reads back the comment that was set", async () => {
+    const data = await uePost("/api/get-node-comment", {
+      blueprint: bpName,
+      nodeId: testNodeId,
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.comment).toBe("This prints a debug message");
+    expect(data.commentBubbleVisible).toBe(true);
+  });
+
+  it("clears a comment by setting empty string", async () => {
+    const data = await uePost("/api/set-node-comment", {
+      blueprint: bpName,
+      nodeId: testNodeId,
+      comment: "",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.oldComment).toBe("This prints a debug message");
+    expect(data.newComment).toBe("");
+    expect(data.saved).toBe(true);
+  });
+
+  it("rejects missing blueprint field", async () => {
+    const data = await uePost("/api/set-node-comment", {
+      nodeId: testNodeId,
+      comment: "test",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("rejects missing nodeId field", async () => {
+    const data = await uePost("/api/set-node-comment", {
+      blueprint: bpName,
+      comment: "test",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("rejects missing comment field", async () => {
+    const data = await uePost("/api/set-node-comment", {
+      blueprint: bpName,
+      nodeId: testNodeId,
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("returns error for non-existent node", async () => {
+    const data = await uePost("/api/set-node-comment", {
+      blueprint: bpName,
+      nodeId: "00000000-0000-0000-0000-000000000000",
+      comment: "test",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("returns error for non-existent blueprint", async () => {
+    const data = await uePost("/api/get-node-comment", {
+      blueprint: "BP_Nonexistent_XYZ_999",
+      nodeId: testNodeId,
+    });
+    expect(data.error).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- **Issue #20**: Added `Comment` and `Reroute` node types to `add_node`. Comment nodes support `comment`, `width`, and `height` parameters. Reroute nodes (knot/wire routing) support `posX`/`posY`.
- **Issue #21**: Added `get_node_comment` and `set_node_comment` tools for reading/writing per-node comment bubble text. Setting a non-empty comment automatically makes the bubble visible and pinned.

## Changes
- **C++ (`BlueprintMCPHandlers_Mutation.cpp`)**: Added Comment (`UEdGraphNode_Comment`) and Reroute (`UK2Node_Knot`) handlers in `HandleAddNode`; added `HandleGetNodeComment` and `HandleSetNodeComment` endpoints
- **C++ (`BlueprintMCPServer.cpp/h`)**: Registered routes, mutation endpoints, and handler map entries for the new endpoints
- **TypeScript (`mutation.ts`)**: Updated `add_node` schema with Comment/Reroute types and new params; added `get_node_comment` and `set_node_comment` tool definitions
- **Tests**: Added 3 new tests for Comment/Reroute in `add-node.test.ts`; created `node-comments.test.ts` with 9 test cases

## Test plan
- [ ] `npm run build` passes (verified)
- [ ] C++ compiles cleanly with UBT (verified)
- [ ] `add_node` with `nodeType="Comment"` creates comment box with custom text/dimensions
- [ ] `add_node` with `nodeType="Reroute"` creates a reroute/knot node
- [ ] `get_node_comment` reads empty and non-empty comments
- [ ] `set_node_comment` sets comment text and makes bubble visible
- [ ] Error cases handled (missing fields, non-existent nodes/blueprints)

Closes #20, closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)