### PR TITLE
Add pin introspection and class/function discovery tools (#23, #24)

### DIFF
--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_Discovery.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_Discovery.cpp
@@ -1,0 +1,549 @@
+#include "BlueprintMCPServer.h"
+#include "Engine/Blueprint.h"
+#include "EdGraph/EdGraph.h"
+#include "EdGraph/EdGraphNode.h"
+#include "EdGraph/EdGraphPin.h"
+#include "EdGraphSchema_K2.h"
+#include "K2Node.h"
+#include "Kismet2/BlueprintEditorUtils.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+#include "UObject/UObjectIterator.h"
+
+// ============================================================
+// HandleGetPinInfo — detailed information about a specific pin
+// ============================================================
+
+FString FBlueprintMCPServer::HandleGetPinInfo(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString BlueprintName = Json->GetStringField(TEXT("blueprint"));
+	FString NodeId = Json->GetStringField(TEXT("nodeId"));
+	FString PinName = Json->GetStringField(TEXT("pinName"));
+
+	if (BlueprintName.IsEmpty() || NodeId.IsEmpty() || PinName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: blueprint, nodeId, pinName"));
+	}
+
+	FString LoadError;
+	UBlueprint* BP = LoadBlueprintByName(BlueprintName, LoadError);
+	if (!BP)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	UEdGraph* Graph = nullptr;
+	UEdGraphNode* Node = FindNodeByGuid(BP, NodeId, &Graph);
+	if (!Node)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Node '%s' not found"), *NodeId));
+	}
+
+	UEdGraphPin* Pin = Node->FindPin(FName(*PinName));
+	if (!Pin)
+	{
+		// List available pins
+		TArray<TSharedPtr<FJsonValue>> AvailPins;
+		for (UEdGraphPin* P : Node->Pins)
+		{
+			if (P)
+			{
+				TSharedRef<FJsonObject> PinObj = MakeShared<FJsonObject>();
+				PinObj->SetStringField(TEXT("name"), P->PinName.ToString());
+				PinObj->SetStringField(TEXT("direction"), P->Direction == EGPD_Input ? TEXT("Input") : TEXT("Output"));
+				PinObj->SetStringField(TEXT("type"), P->PinType.PinCategory.ToString());
+				AvailPins.Add(MakeShared<FJsonValueObject>(PinObj));
+			}
+		}
+		TSharedRef<FJsonObject> E = MakeShared<FJsonObject>();
+		E->SetStringField(TEXT("error"), FString::Printf(TEXT("Pin '%s' not found on node '%s'"), *PinName, *NodeId));
+		E->SetArrayField(TEXT("availablePins"), AvailPins);
+		return JsonToString(E);
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("blueprint"), BlueprintName);
+	Result->SetStringField(TEXT("nodeId"), NodeId);
+	Result->SetStringField(TEXT("pinName"), Pin->PinName.ToString());
+	Result->SetStringField(TEXT("direction"), Pin->Direction == EGPD_Input ? TEXT("Input") : TEXT("Output"));
+	Result->SetStringField(TEXT("type"), Pin->PinType.PinCategory.ToString());
+
+	if (!Pin->PinType.PinSubCategory.IsNone())
+	{
+		Result->SetStringField(TEXT("subCategory"), Pin->PinType.PinSubCategory.ToString());
+	}
+	if (Pin->PinType.PinSubCategoryObject.IsValid())
+	{
+		Result->SetStringField(TEXT("subtype"), Pin->PinType.PinSubCategoryObject->GetName());
+	}
+
+	Result->SetBoolField(TEXT("isArray"), Pin->PinType.IsArray());
+	Result->SetBoolField(TEXT("isSet"), Pin->PinType.IsSet());
+	Result->SetBoolField(TEXT("isMap"), Pin->PinType.IsMap());
+	Result->SetBoolField(TEXT("isReference"), Pin->PinType.bIsReference);
+	Result->SetBoolField(TEXT("isConst"), Pin->PinType.bIsConst);
+
+	if (!Pin->DefaultValue.IsEmpty())
+	{
+		Result->SetStringField(TEXT("defaultValue"), Pin->DefaultValue);
+	}
+	if (!Pin->DefaultTextValue.IsEmpty())
+	{
+		Result->SetStringField(TEXT("defaultTextValue"), Pin->DefaultTextValue.ToString());
+	}
+	if (Pin->DefaultObject)
+	{
+		Result->SetStringField(TEXT("defaultObject"), Pin->DefaultObject->GetPathName());
+	}
+
+	// Connected pins
+	if (Pin->LinkedTo.Num() > 0)
+	{
+		TArray<TSharedPtr<FJsonValue>> Conns;
+		for (UEdGraphPin* Linked : Pin->LinkedTo)
+		{
+			if (!Linked || !Linked->GetOwningNode()) continue;
+			TSharedRef<FJsonObject> CJ = MakeShared<FJsonObject>();
+			CJ->SetStringField(TEXT("nodeId"), Linked->GetOwningNode()->NodeGuid.ToString());
+			CJ->SetStringField(TEXT("pinName"), Linked->PinName.ToString());
+			CJ->SetStringField(TEXT("nodeTitle"), Linked->GetOwningNode()->GetNodeTitle(ENodeTitleType::FullTitle).ToString());
+			Conns.Add(MakeShared<FJsonValueObject>(CJ));
+		}
+		Result->SetArrayField(TEXT("connectedTo"), Conns);
+	}
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleCheckPinCompatibility — pre-flight check for connect_pins
+// ============================================================
+
+FString FBlueprintMCPServer::HandleCheckPinCompatibility(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString BlueprintName = Json->GetStringField(TEXT("blueprint"));
+	FString SourceNodeId = Json->GetStringField(TEXT("sourceNodeId"));
+	FString SourcePinName = Json->GetStringField(TEXT("sourcePinName"));
+	FString TargetNodeId = Json->GetStringField(TEXT("targetNodeId"));
+	FString TargetPinName = Json->GetStringField(TEXT("targetPinName"));
+
+	if (BlueprintName.IsEmpty() || SourceNodeId.IsEmpty() || SourcePinName.IsEmpty() ||
+		TargetNodeId.IsEmpty() || TargetPinName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: blueprint, sourceNodeId, sourcePinName, targetNodeId, targetPinName"));
+	}
+
+	FString LoadError;
+	UBlueprint* BP = LoadBlueprintByName(BlueprintName, LoadError);
+	if (!BP)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	UEdGraph* SourceGraph = nullptr;
+	UEdGraphNode* SourceNode = FindNodeByGuid(BP, SourceNodeId, &SourceGraph);
+	if (!SourceNode)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Source node '%s' not found"), *SourceNodeId));
+	}
+
+	UEdGraphNode* TargetNode = FindNodeByGuid(BP, TargetNodeId);
+	if (!TargetNode)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Target node '%s' not found"), *TargetNodeId));
+	}
+
+	UEdGraphPin* SourcePin = SourceNode->FindPin(FName(*SourcePinName));
+	if (!SourcePin)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Source pin '%s' not found on node '%s'"), *SourcePinName, *SourceNodeId));
+	}
+
+	UEdGraphPin* TargetPin = TargetNode->FindPin(FName(*TargetPinName));
+	if (!TargetPin)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Target pin '%s' not found on node '%s'"), *TargetPinName, *TargetNodeId));
+	}
+
+	const UEdGraphSchema* Schema = SourceGraph ? SourceGraph->GetSchema() : nullptr;
+	if (!Schema)
+	{
+		return MakeErrorJson(TEXT("Graph schema not found"));
+	}
+
+	// Check compatibility using the schema
+	const FPinConnectionResponse Response = Schema->CanCreateConnection(SourcePin, TargetPin);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("blueprint"), BlueprintName);
+
+	bool bCompatible = (Response.Response != ECanCreateConnectionResponse::CONNECT_RESPONSE_DISALLOW);
+	Result->SetBoolField(TEXT("compatible"), bCompatible);
+
+	// Decode the response type
+	FString ResponseType;
+	switch (Response.Response)
+	{
+	case ECanCreateConnectionResponse::CONNECT_RESPONSE_MAKE:
+		ResponseType = TEXT("direct");
+		break;
+	case ECanCreateConnectionResponse::CONNECT_RESPONSE_BREAK_OTHERS_A:
+		ResponseType = TEXT("breakSourceConnections");
+		break;
+	case ECanCreateConnectionResponse::CONNECT_RESPONSE_BREAK_OTHERS_B:
+		ResponseType = TEXT("breakTargetConnections");
+		break;
+	case ECanCreateConnectionResponse::CONNECT_RESPONSE_BREAK_OTHERS_AB:
+		ResponseType = TEXT("breakBothConnections");
+		break;
+	case ECanCreateConnectionResponse::CONNECT_RESPONSE_MAKE_WITH_CONVERSION_NODE:
+		ResponseType = TEXT("requiresConversion");
+		break;
+	case ECanCreateConnectionResponse::CONNECT_RESPONSE_MAKE_WITH_PROMOTION:
+		ResponseType = TEXT("requiresPromotion");
+		break;
+	case ECanCreateConnectionResponse::CONNECT_RESPONSE_DISALLOW:
+	default:
+		ResponseType = TEXT("disallowed");
+		break;
+	}
+	Result->SetStringField(TEXT("connectionType"), ResponseType);
+
+	if (!Response.Message.IsEmpty())
+	{
+		Result->SetStringField(TEXT("message"), Response.Message.ToString());
+	}
+
+	// Include pin type info for context
+	Result->SetStringField(TEXT("sourcePinType"), SourcePin->PinType.PinCategory.ToString());
+	if (SourcePin->PinType.PinSubCategoryObject.IsValid())
+		Result->SetStringField(TEXT("sourcePinSubtype"), SourcePin->PinType.PinSubCategoryObject->GetName());
+	Result->SetStringField(TEXT("targetPinType"), TargetPin->PinType.PinCategory.ToString());
+	if (TargetPin->PinType.PinSubCategoryObject.IsValid())
+		Result->SetStringField(TEXT("targetPinSubtype"), TargetPin->PinType.PinSubCategoryObject->GetName());
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleListClasses — discover available UClasses
+// ============================================================
+
+FString FBlueprintMCPServer::HandleListClasses(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString Filter = Json->GetStringField(TEXT("filter"));
+	FString ParentClassName = Json->GetStringField(TEXT("parentClass"));
+	int32 Limit = 100;
+	if (Json->HasField(TEXT("limit")))
+	{
+		Limit = FMath::Clamp(Json->GetIntegerField(TEXT("limit")), 1, 500);
+	}
+
+	UClass* ParentClass = nullptr;
+	if (!ParentClassName.IsEmpty())
+	{
+		for (TObjectIterator<UClass> It; It; ++It)
+		{
+			if (It->GetName() == ParentClassName || It->GetName() == ParentClassName + TEXT("_C"))
+			{
+				ParentClass = *It;
+				break;
+			}
+		}
+		if (!ParentClass)
+		{
+			return MakeErrorJson(FString::Printf(TEXT("Parent class '%s' not found"), *ParentClassName));
+		}
+	}
+
+	TArray<TSharedPtr<FJsonValue>> ClassList;
+	int32 TotalMatched = 0;
+
+	for (TObjectIterator<UClass> It; It; ++It)
+	{
+		UClass* Class = *It;
+		if (!Class) continue;
+
+		// Skip internal/deprecated classes
+		if (Class->HasAnyClassFlags(CLASS_Deprecated | CLASS_NewerVersionExists)) continue;
+
+		// Apply parent filter
+		if (ParentClass && !Class->IsChildOf(ParentClass)) continue;
+
+		FString ClassName = Class->GetName();
+
+		// Apply name filter
+		if (!Filter.IsEmpty() && !ClassName.Contains(Filter, ESearchCase::IgnoreCase))
+		{
+			continue;
+		}
+
+		TotalMatched++;
+		if (ClassList.Num() >= Limit) continue; // Count but don't add beyond limit
+
+		TSharedRef<FJsonObject> ClassObj = MakeShared<FJsonObject>();
+		ClassObj->SetStringField(TEXT("name"), ClassName);
+		ClassObj->SetStringField(TEXT("fullPath"), Class->GetPathName());
+
+		// Determine if it's a Blueprint-generated class
+		bool bIsBlueprint = Class->ClassGeneratedBy != nullptr;
+		ClassObj->SetBoolField(TEXT("isBlueprint"), bIsBlueprint);
+
+		// Parent class
+		if (Class->GetSuperClass())
+		{
+			ClassObj->SetStringField(TEXT("parentClass"), Class->GetSuperClass()->GetName());
+		}
+
+		// Module/package info
+		UPackage* Package = Class->GetOuterUPackage();
+		if (Package)
+		{
+			ClassObj->SetStringField(TEXT("package"), Package->GetName());
+		}
+
+		// Flags
+		TArray<TSharedPtr<FJsonValue>> Flags;
+		if (Class->HasAnyClassFlags(CLASS_Abstract)) Flags.Add(MakeShared<FJsonValueString>(TEXT("Abstract")));
+		if (Class->HasAnyClassFlags(CLASS_Interface)) Flags.Add(MakeShared<FJsonValueString>(TEXT("Interface")));
+		if (Class->HasAnyClassFlags(CLASS_MinimalAPI)) Flags.Add(MakeShared<FJsonValueString>(TEXT("MinimalAPI")));
+		if (Flags.Num() > 0)
+		{
+			ClassObj->SetArrayField(TEXT("flags"), Flags);
+		}
+
+		ClassList.Add(MakeShared<FJsonValueObject>(ClassObj));
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetNumberField(TEXT("count"), ClassList.Num());
+	Result->SetNumberField(TEXT("totalMatched"), TotalMatched);
+	if (TotalMatched > Limit)
+	{
+		Result->SetBoolField(TEXT("truncated"), true);
+		Result->SetNumberField(TEXT("limit"), Limit);
+	}
+	Result->SetArrayField(TEXT("classes"), ClassList);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleListFunctions — list Blueprint-callable functions on a class
+// ============================================================
+
+FString FBlueprintMCPServer::HandleListFunctions(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString ClassName = Json->GetStringField(TEXT("className"));
+	FString Filter = Json->GetStringField(TEXT("filter"));
+
+	if (ClassName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: className"));
+	}
+
+	// Find the class
+	UClass* FoundClass = nullptr;
+	for (TObjectIterator<UClass> It; It; ++It)
+	{
+		if (It->GetName() == ClassName || It->GetName() == ClassName + TEXT("_C"))
+		{
+			FoundClass = *It;
+			break;
+		}
+	}
+	if (!FoundClass)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Class '%s' not found"), *ClassName));
+	}
+
+	TArray<TSharedPtr<FJsonValue>> FuncList;
+
+	for (TFieldIterator<UFunction> FuncIt(FoundClass); FuncIt; ++FuncIt)
+	{
+		UFunction* Func = *FuncIt;
+		if (!Func) continue;
+
+		// Only include Blueprint-callable functions
+		if (!Func->HasAnyFunctionFlags(FUNC_BlueprintCallable | FUNC_BlueprintPure | FUNC_BlueprintEvent)) continue;
+
+		FString FuncName = Func->GetName();
+
+		// Apply filter
+		if (!Filter.IsEmpty() && !FuncName.Contains(Filter, ESearchCase::IgnoreCase))
+		{
+			continue;
+		}
+
+		TSharedRef<FJsonObject> FuncObj = MakeShared<FJsonObject>();
+		FuncObj->SetStringField(TEXT("name"), FuncName);
+
+		// Determine the owning class
+		UClass* OwnerClass = Func->GetOwnerClass();
+		if (OwnerClass)
+		{
+			FuncObj->SetStringField(TEXT("definedIn"), OwnerClass->GetName());
+		}
+
+		// Function flags
+		FuncObj->SetBoolField(TEXT("isPure"), Func->HasAnyFunctionFlags(FUNC_BlueprintPure));
+		FuncObj->SetBoolField(TEXT("isStatic"), Func->HasAnyFunctionFlags(FUNC_Static));
+		FuncObj->SetBoolField(TEXT("isEvent"), Func->HasAnyFunctionFlags(FUNC_BlueprintEvent));
+		FuncObj->SetBoolField(TEXT("isConst"), Func->HasAnyFunctionFlags(FUNC_Const));
+
+		// Parameters
+		TArray<TSharedPtr<FJsonValue>> Params;
+		FString ReturnType;
+		for (TFieldIterator<FProperty> PropIt(Func); PropIt; ++PropIt)
+		{
+			FProperty* Prop = *PropIt;
+			if (!Prop) continue;
+
+			FString PropType = Prop->GetCPPType();
+
+			if (Prop->HasAnyPropertyFlags(CPF_ReturnParm))
+			{
+				ReturnType = PropType;
+				continue;
+			}
+
+			if (Prop->HasAnyPropertyFlags(CPF_Parm))
+			{
+				TSharedRef<FJsonObject> ParamObj = MakeShared<FJsonObject>();
+				ParamObj->SetStringField(TEXT("name"), Prop->GetName());
+				ParamObj->SetStringField(TEXT("type"), PropType);
+				ParamObj->SetBoolField(TEXT("isOutput"), Prop->HasAnyPropertyFlags(CPF_OutParm) && !Prop->HasAnyPropertyFlags(CPF_ReferenceParm));
+				ParamObj->SetBoolField(TEXT("isReference"), Prop->HasAnyPropertyFlags(CPF_ReferenceParm));
+				Params.Add(MakeShared<FJsonValueObject>(ParamObj));
+			}
+		}
+		FuncObj->SetArrayField(TEXT("parameters"), Params);
+		if (!ReturnType.IsEmpty())
+		{
+			FuncObj->SetStringField(TEXT("returnType"), ReturnType);
+		}
+
+		FuncList.Add(MakeShared<FJsonValueObject>(FuncObj));
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("className"), FoundClass->GetName());
+	Result->SetNumberField(TEXT("count"), FuncList.Num());
+	Result->SetArrayField(TEXT("functions"), FuncList);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleListProperties — list properties on a class
+// ============================================================
+
+FString FBlueprintMCPServer::HandleListProperties(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString ClassName = Json->GetStringField(TEXT("className"));
+	FString Filter = Json->GetStringField(TEXT("filter"));
+
+	if (ClassName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: className"));
+	}
+
+	// Find the class
+	UClass* FoundClass = nullptr;
+	for (TObjectIterator<UClass> It; It; ++It)
+	{
+		if (It->GetName() == ClassName || It->GetName() == ClassName + TEXT("_C"))
+		{
+			FoundClass = *It;
+			break;
+		}
+	}
+	if (!FoundClass)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Class '%s' not found"), *ClassName));
+	}
+
+	TArray<TSharedPtr<FJsonValue>> PropList;
+
+	for (TFieldIterator<FProperty> PropIt(FoundClass); PropIt; ++PropIt)
+	{
+		FProperty* Prop = *PropIt;
+		if (!Prop) continue;
+
+		FString PropName = Prop->GetName();
+
+		// Apply filter
+		if (!Filter.IsEmpty() && !PropName.Contains(Filter, ESearchCase::IgnoreCase))
+		{
+			continue;
+		}
+
+		TSharedRef<FJsonObject> PropObj = MakeShared<FJsonObject>();
+		PropObj->SetStringField(TEXT("name"), PropName);
+		PropObj->SetStringField(TEXT("type"), Prop->GetCPPType());
+
+		// Determine the owning class
+		UClass* OwnerClass = Prop->GetOwnerClass();
+		if (OwnerClass)
+		{
+			PropObj->SetStringField(TEXT("definedIn"), OwnerClass->GetName());
+		}
+
+		// Property flags
+		TArray<TSharedPtr<FJsonValue>> Flags;
+		if (Prop->HasAnyPropertyFlags(CPF_BlueprintVisible)) Flags.Add(MakeShared<FJsonValueString>(TEXT("BlueprintVisible")));
+		if (Prop->HasAnyPropertyFlags(CPF_BlueprintReadOnly)) Flags.Add(MakeShared<FJsonValueString>(TEXT("BlueprintReadOnly")));
+		if (Prop->HasAnyPropertyFlags(CPF_Edit)) Flags.Add(MakeShared<FJsonValueString>(TEXT("EditAnywhere")));
+		if (Prop->HasAnyPropertyFlags(CPF_EditConst)) Flags.Add(MakeShared<FJsonValueString>(TEXT("VisibleOnly")));
+		if (Prop->HasAnyPropertyFlags(CPF_Config)) Flags.Add(MakeShared<FJsonValueString>(TEXT("Config")));
+		if (Prop->HasAnyPropertyFlags(CPF_SaveGame)) Flags.Add(MakeShared<FJsonValueString>(TEXT("SaveGame")));
+		if (Prop->HasAnyPropertyFlags(CPF_Transient)) Flags.Add(MakeShared<FJsonValueString>(TEXT("Transient")));
+		if (Prop->HasAnyPropertyFlags(CPF_RepNotify)) Flags.Add(MakeShared<FJsonValueString>(TEXT("RepNotify")));
+		if (Flags.Num() > 0)
+		{
+			PropObj->SetArrayField(TEXT("flags"), Flags);
+		}
+
+		PropList.Add(MakeShared<FJsonValueObject>(PropObj));
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("className"), FoundClass->GetName());
+	Result->SetNumberField(TEXT("count"), PropList.Num());
+	Result->SetArrayField(TEXT("properties"), PropList);
+	return JsonToString(Result);
+}

--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -432,6 +432,16 @@ bool FBlueprintMCPServer::Start(int32 InPort, bool bEditorMode)
 		QueuedHandler(TEXT("getNodeComment")));
 	Router->BindRoute(FHttpPath(TEXT("/api/set-node-comment")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("setNodeComment")));
+	Router->BindRoute(FHttpPath(TEXT("/api/get-pin-info")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("getPinInfo")));
+	Router->BindRoute(FHttpPath(TEXT("/api/check-pin-compatibility")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("checkPinCompatibility")));
+	Router->BindRoute(FHttpPath(TEXT("/api/list-classes")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("listClasses")));
+	Router->BindRoute(FHttpPath(TEXT("/api/list-functions")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("listFunctions")));
+	Router->BindRoute(FHttpPath(TEXT("/api/list-properties")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("listProperties")));
 	Router->BindRoute(FHttpPath(TEXT("/api/change-struct-node-type")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("changeStructNodeType")));
 	Router->BindRoute(FHttpPath(TEXT("/api/remove-function-parameter")), EHttpServerRequestVerbs::VERB_POST,
@@ -656,6 +666,11 @@ void FBlueprintMCPServer::RegisterHandlers()
 	HandlerMap.Add(TEXT("moveNode"),               [this](const TMap<FString, FString>&, const FString& B) { return HandleMoveNode(B); });
 	HandlerMap.Add(TEXT("getNodeComment"),          [this](const TMap<FString, FString>&, const FString& B) { return HandleGetNodeComment(B); });
 	HandlerMap.Add(TEXT("setNodeComment"),          [this](const TMap<FString, FString>&, const FString& B) { return HandleSetNodeComment(B); });
+	HandlerMap.Add(TEXT("getPinInfo"),              [this](const TMap<FString, FString>&, const FString& B) { return HandleGetPinInfo(B); });
+	HandlerMap.Add(TEXT("checkPinCompatibility"),   [this](const TMap<FString, FString>&, const FString& B) { return HandleCheckPinCompatibility(B); });
+	HandlerMap.Add(TEXT("listClasses"),             [this](const TMap<FString, FString>&, const FString& B) { return HandleListClasses(B); });
+	HandlerMap.Add(TEXT("listFunctions"),           [this](const TMap<FString, FString>&, const FString& B) { return HandleListFunctions(B); });
+	HandlerMap.Add(TEXT("listProperties"),          [this](const TMap<FString, FString>&, const FString& B) { return HandleListProperties(B); });
 	HandlerMap.Add(TEXT("changeStructNodeType"),    [this](const TMap<FString, FString>&, const FString& B) { return HandleChangeStructNodeType(B); });
 	HandlerMap.Add(TEXT("deleteNode"),              [this](const TMap<FString, FString>&, const FString& B) { return HandleDeleteNode(B); });
 	HandlerMap.Add(TEXT("duplicateNodes"),          [this](const TMap<FString, FString>&, const FString& B) { return HandleDuplicateNodes(B); });

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -137,6 +137,15 @@ private:
 	FString HandleGetNodeComment(const FString& Body);
 	FString HandleSetNodeComment(const FString& Body);
 
+	// ----- Pin introspection (read-only) -----
+	FString HandleGetPinInfo(const FString& Body);
+	FString HandleCheckPinCompatibility(const FString& Body);
+
+	// ----- Class/function discovery (read-only) -----
+	FString HandleListClasses(const FString& Body);
+	FString HandleListFunctions(const FString& Body);
+	FString HandleListProperties(const FString& Body);
+
 	// ----- Struct node manipulation (write) -----
 	FString HandleChangeStructNodeType(const FString& Body);
 

--- a/Tools/src/index.ts
+++ b/Tools/src/index.ts
@@ -14,6 +14,7 @@ import { registerComponentTools } from "./tools/components.js";
 import { registerSnapshotTools } from "./tools/snapshot.js";
 import { registerValidationTools } from "./tools/validation.js";
 import { registerUtilityTools } from "./tools/utility.js";
+import { registerDiscoveryTools } from "./tools/discovery.js";
 
 // Resource registrations
 import { registerBlueprintListResource } from "./resources/blueprint-list.js";
@@ -36,6 +37,7 @@ registerComponentTools(server);
 registerSnapshotTools(server);
 registerValidationTools(server);
 registerUtilityTools(server);
+registerDiscoveryTools(server);
 
 // Register resources
 registerBlueprintListResource(server);

--- a/Tools/src/tools/discovery.ts
+++ b/Tools/src/tools/discovery.ts
@@ -1,0 +1,217 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ensureUE, uePost } from "../ue-bridge.js";
+
+export function registerDiscoveryTools(server: McpServer): void {
+  server.tool(
+    "get_pin_info",
+    "Get detailed information about a specific pin on a Blueprint node, including type details, container type (array/set/map), default value, and current connections.",
+    {
+      blueprint: z.string().describe("Blueprint name or package path"),
+      nodeId: z.string().describe("Node GUID"),
+      pinName: z.string().describe("Pin name"),
+    },
+    async ({ blueprint, nodeId, pinName }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/get-pin-info", { blueprint, nodeId, pinName });
+      if (data.error) {
+        let msg = `Error: ${data.error}`;
+        if (data.availablePins?.length) {
+          msg += `\n\nAvailable pins:`;
+          for (const p of data.availablePins) {
+            msg += `\n  ${p.direction === "Output" ? "\u2192" : "\u2190"} ${p.name}: ${p.type}`;
+          }
+        }
+        return { content: [{ type: "text" as const, text: msg }] };
+      }
+
+      const lines: string[] = [];
+      lines.push(`Pin: ${data.pinName}`);
+      lines.push(`Direction: ${data.direction}`);
+      lines.push(`Type: ${data.type}${data.subtype ? ` (${data.subtype})` : ""}${data.subCategory ? ` [${data.subCategory}]` : ""}`);
+
+      const containers: string[] = [];
+      if (data.isArray) containers.push("Array");
+      if (data.isSet) containers.push("Set");
+      if (data.isMap) containers.push("Map");
+      if (containers.length) lines.push(`Container: ${containers.join(", ")}`);
+
+      if (data.isReference) lines.push(`Reference: true`);
+      if (data.isConst) lines.push(`Const: true`);
+
+      if (data.defaultValue !== undefined) lines.push(`Default value: ${data.defaultValue}`);
+      if (data.defaultTextValue !== undefined) lines.push(`Default text: ${data.defaultTextValue}`);
+      if (data.defaultObject !== undefined) lines.push(`Default object: ${data.defaultObject}`);
+
+      if (data.connectedTo?.length) {
+        lines.push(`\nConnections (${data.connectedTo.length}):`);
+        for (const c of data.connectedTo) {
+          lines.push(`  ${c.nodeTitle} (${c.nodeId}).${c.pinName}`);
+        }
+      } else {
+        lines.push(`\nConnections: none`);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "check_pin_compatibility",
+    "Check whether two pins can be connected before attempting connect_pins. Returns compatibility status, connection type (direct, requires conversion, etc.), and any UE5 schema messages.",
+    {
+      blueprint: z.string().describe("Blueprint name or package path"),
+      sourceNodeId: z.string().describe("Source node GUID"),
+      sourcePinName: z.string().describe("Source pin name"),
+      targetNodeId: z.string().describe("Target node GUID"),
+      targetPinName: z.string().describe("Target pin name"),
+    },
+    async ({ blueprint, sourceNodeId, sourcePinName, targetNodeId, targetPinName }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/check-pin-compatibility", {
+        blueprint, sourceNodeId, sourcePinName, targetNodeId, targetPinName,
+      });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      const icon = data.compatible ? "\u2705" : "\u274c";
+      lines.push(`${icon} Compatible: ${data.compatible}`);
+      lines.push(`Connection type: ${data.connectionType}`);
+      if (data.message) lines.push(`Message: ${data.message}`);
+      lines.push(``);
+      lines.push(`Source pin type: ${data.sourcePinType}${data.sourcePinSubtype ? ` (${data.sourcePinSubtype})` : ""}`);
+      lines.push(`Target pin type: ${data.targetPinType}${data.targetPinSubtype ? ` (${data.targetPinSubtype})` : ""}`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "list_classes",
+    "List available UE5 classes. Filter by name substring and/or parent class. Useful for discovering class names to use with add_node(CallFunction), add_node(DynamicCast), add_node(SpawnActorFromClass), etc.",
+    {
+      filter: z.string().optional().describe("Substring to match against class name (case-insensitive)"),
+      parentClass: z.string().optional().describe("Only show classes that inherit from this class (e.g. 'Actor', 'ActorComponent')"),
+      limit: z.number().optional().default(100).describe("Maximum number of results (default: 100, max: 500)"),
+    },
+    async ({ filter, parentClass, limit }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = {};
+      if (filter) body.filter = filter;
+      if (parentClass) body.parentClass = parentClass;
+      if (limit !== undefined) body.limit = limit;
+
+      const data = await uePost("/api/list-classes", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      if (data.truncated) {
+        lines.push(`Showing ${data.count} of ${data.totalMatched} matching classes (limit: ${data.limit}).\n`);
+      } else {
+        lines.push(`Found ${data.count} classes.\n`);
+      }
+
+      for (const cls of data.classes) {
+        const tags: string[] = [];
+        if (cls.isBlueprint) tags.push("BP");
+        if (cls.flags?.length) tags.push(...cls.flags);
+        const tagStr = tags.length ? ` [${tags.join(", ")}]` : "";
+        lines.push(`${cls.name}${tagStr} : ${cls.parentClass || "none"}`);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "list_functions",
+    "List Blueprint-callable functions on a UE5 class, including parameter signatures and return types. Use this to discover function names for add_node(CallFunction, functionName=...).",
+    {
+      className: z.string().describe("Class name (e.g. 'KismetSystemLibrary', 'KismetMathLibrary', 'Actor')"),
+      filter: z.string().optional().describe("Substring to match against function name (case-insensitive)"),
+    },
+    async ({ className, filter }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { className };
+      if (filter) body.filter = filter;
+
+      const data = await uePost("/api/list-functions", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`${data.className}: ${data.count} callable functions.\n`);
+
+      for (const fn of data.functions) {
+        const tags: string[] = [];
+        if (fn.isPure) tags.push("pure");
+        if (fn.isStatic) tags.push("static");
+        if (fn.isEvent) tags.push("event");
+        if (fn.isConst) tags.push("const");
+        const tagStr = tags.length ? ` [${tags.join(", ")}]` : "";
+
+        const params = fn.parameters
+          .filter((p: any) => !p.isOutput)
+          .map((p: any) => `${p.name}: ${p.type}`)
+          .join(", ");
+        const outParams = fn.parameters
+          .filter((p: any) => p.isOutput)
+          .map((p: any) => `${p.name}: ${p.type}`)
+          .join(", ");
+
+        let sig = `${fn.name}(${params})`;
+        if (fn.returnType) sig += ` -> ${fn.returnType}`;
+        if (outParams) sig += ` [out: ${outParams}]`;
+        sig += tagStr;
+
+        if (fn.definedIn && fn.definedIn !== data.className) {
+          sig += ` (from ${fn.definedIn})`;
+        }
+
+        lines.push(sig);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "list_properties",
+    "List properties on a UE5 class, including types and property flags (BlueprintVisible, EditAnywhere, etc.).",
+    {
+      className: z.string().describe("Class name (e.g. 'Actor', 'CharacterMovementComponent')"),
+      filter: z.string().optional().describe("Substring to match against property name (case-insensitive)"),
+    },
+    async ({ className, filter }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { className };
+      if (filter) body.filter = filter;
+
+      const data = await uePost("/api/list-properties", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`${data.className}: ${data.count} properties.\n`);
+
+      for (const prop of data.properties) {
+        const flagStr = prop.flags?.length ? ` [${prop.flags.join(", ")}]` : "";
+        let line = `${prop.name}: ${prop.type}${flagStr}`;
+        if (prop.definedIn && prop.definedIn !== data.className) {
+          line += ` (from ${prop.definedIn})`;
+        }
+        lines.push(line);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+}

--- a/Tools/test/tools/class-discovery.test.ts
+++ b/Tools/test/tools/class-discovery.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { uePost } from "../helpers.js";
+
+describe("class_discovery", () => {
+  // --- list_classes ---
+
+  it("lists classes with no filter", async () => {
+    const data = await uePost("/api/list-classes", { limit: 10 });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.count).toBeGreaterThan(0);
+    expect(data.classes).toBeDefined();
+    expect(data.classes.length).toBeGreaterThan(0);
+    // Verify structure
+    const cls = data.classes[0];
+    expect(cls.name).toBeDefined();
+    expect(cls.isBlueprint).toBeDefined();
+  });
+
+  it("filters classes by name", async () => {
+    const data = await uePost("/api/list-classes", { filter: "Actor", limit: 20 });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.count).toBeGreaterThan(0);
+    // Every returned class should contain "Actor" in the name
+    for (const cls of data.classes) {
+      expect(cls.name.toLowerCase()).toContain("actor");
+    }
+  });
+
+  it("filters classes by parent class", async () => {
+    const data = await uePost("/api/list-classes", { parentClass: "Actor", limit: 20 });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.count).toBeGreaterThan(0);
+  });
+
+  it("returns error for non-existent parent class", async () => {
+    const data = await uePost("/api/list-classes", { parentClass: "FakeClass_XYZ_999" });
+    expect(data.error).toBeDefined();
+  });
+
+  it("respects limit parameter", async () => {
+    const data = await uePost("/api/list-classes", { limit: 5 });
+    expect(data.error).toBeUndefined();
+    expect(data.classes.length).toBeLessThanOrEqual(5);
+  });
+
+  // --- list_functions ---
+
+  it("lists functions on KismetSystemLibrary", async () => {
+    const data = await uePost("/api/list-functions", { className: "KismetSystemLibrary" });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.count).toBeGreaterThan(0);
+    // Should contain PrintString
+    const names = data.functions.map((f: any) => f.name);
+    expect(names).toContain("PrintString");
+  });
+
+  it("filters functions by name", async () => {
+    const data = await uePost("/api/list-functions", {
+      className: "KismetSystemLibrary",
+      filter: "Print",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.count).toBeGreaterThan(0);
+    for (const fn of data.functions) {
+      expect(fn.name.toLowerCase()).toContain("print");
+    }
+  });
+
+  it("includes parameter info in function listing", async () => {
+    const data = await uePost("/api/list-functions", {
+      className: "KismetSystemLibrary",
+      filter: "PrintString",
+    });
+    expect(data.error).toBeUndefined();
+    const printFn = data.functions.find((f: any) => f.name === "PrintString");
+    expect(printFn).toBeDefined();
+    expect(printFn.parameters).toBeDefined();
+    expect(printFn.parameters.length).toBeGreaterThan(0);
+    // Verify parameter structure
+    const param = printFn.parameters[0];
+    expect(param.name).toBeDefined();
+    expect(param.type).toBeDefined();
+  });
+
+  it("returns error for non-existent class", async () => {
+    const data = await uePost("/api/list-functions", { className: "FakeClass_XYZ_999" });
+    expect(data.error).toBeDefined();
+  });
+
+  it("returns error for missing className", async () => {
+    const data = await uePost("/api/list-functions", {});
+    expect(data.error).toBeDefined();
+  });
+
+  // --- list_properties ---
+
+  it("lists properties on Actor", async () => {
+    const data = await uePost("/api/list-properties", { className: "Actor" });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.count).toBeGreaterThan(0);
+    // Verify structure
+    const prop = data.properties[0];
+    expect(prop.name).toBeDefined();
+    expect(prop.type).toBeDefined();
+  });
+
+  it("filters properties by name", async () => {
+    const data = await uePost("/api/list-properties", {
+      className: "Actor",
+      filter: "Root",
+    });
+    expect(data.error).toBeUndefined();
+    for (const prop of data.properties) {
+      expect(prop.name.toLowerCase()).toContain("root");
+    }
+  });
+
+  it("returns error for non-existent class", async () => {
+    const data = await uePost("/api/list-properties", { className: "FakeClass_XYZ_999" });
+    expect(data.error).toBeDefined();
+  });
+
+  it("returns error for missing className", async () => {
+    const data = await uePost("/api/list-properties", {});
+    expect(data.error).toBeDefined();
+  });
+});

--- a/Tools/test/tools/pin-introspection.test.ts
+++ b/Tools/test/tools/pin-introspection.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { uePost, createTestBlueprint, deleteTestBlueprint, uniqueName } from "../helpers.js";
+
+describe("pin_introspection", () => {
+  const bpName = uniqueName("BP_PinInfoTest");
+  const packagePath = "/Game/Test";
+  let printStringNodeId: string;
+  let branchNodeId: string;
+
+  beforeAll(async () => {
+    const res = await createTestBlueprint({ name: bpName });
+    expect(res.error).toBeUndefined();
+
+    // Add a PrintString node
+    const ps = await uePost("/api/add-node", {
+      blueprint: bpName,
+      graph: "EventGraph",
+      nodeType: "CallFunction",
+      functionName: "PrintString",
+    });
+    expect(ps.error).toBeUndefined();
+    printStringNodeId = ps.nodeId;
+
+    // Add a Branch node
+    const br = await uePost("/api/add-node", {
+      blueprint: bpName,
+      graph: "EventGraph",
+      nodeType: "Branch",
+    });
+    expect(br.error).toBeUndefined();
+    branchNodeId = br.nodeId;
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${bpName}`);
+  });
+
+  // --- get_pin_info ---
+
+  it("gets pin info for an exec pin", async () => {
+    const data = await uePost("/api/get-pin-info", {
+      blueprint: bpName,
+      nodeId: printStringNodeId,
+      pinName: "execute",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.direction).toBe("Input");
+    expect(data.type).toBe("exec");
+    expect(data.isArray).toBe(false);
+  });
+
+  it("gets pin info for a data pin", async () => {
+    const data = await uePost("/api/get-pin-info", {
+      blueprint: bpName,
+      nodeId: branchNodeId,
+      pinName: "Condition",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.direction).toBe("Input");
+    expect(data.type).toBe("bool");
+  });
+
+  it("returns available pins when pin not found", async () => {
+    const data = await uePost("/api/get-pin-info", {
+      blueprint: bpName,
+      nodeId: printStringNodeId,
+      pinName: "FakePin",
+    });
+    expect(data.error).toBeDefined();
+    expect(data.availablePins).toBeDefined();
+    expect(data.availablePins.length).toBeGreaterThan(0);
+  });
+
+  it("rejects missing required fields", async () => {
+    const data = await uePost("/api/get-pin-info", {
+      blueprint: bpName,
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("rejects non-existent node", async () => {
+    const data = await uePost("/api/get-pin-info", {
+      blueprint: bpName,
+      nodeId: "00000000-0000-0000-0000-000000000000",
+      pinName: "execute",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  // --- check_pin_compatibility ---
+
+  it("checks compatible exec pins", async () => {
+    const data = await uePost("/api/check-pin-compatibility", {
+      blueprint: bpName,
+      sourceNodeId: branchNodeId,
+      sourcePinName: "then",
+      targetNodeId: printStringNodeId,
+      targetPinName: "execute",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.compatible).toBe(true);
+  });
+
+  it("checks incompatible pins", async () => {
+    const data = await uePost("/api/check-pin-compatibility", {
+      blueprint: bpName,
+      sourceNodeId: branchNodeId,
+      sourcePinName: "Condition",
+      targetNodeId: printStringNodeId,
+      targetPinName: "InString",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    // bool -> string: may or may not be compatible depending on UE5's auto-conversion
+    // Just verify the response structure
+    expect(data.compatible).toBeDefined();
+    expect(data.connectionType).toBeDefined();
+    expect(data.sourcePinType).toBeDefined();
+    expect(data.targetPinType).toBeDefined();
+  });
+
+  it("rejects missing fields for compatibility check", async () => {
+    const data = await uePost("/api/check-pin-compatibility", {
+      blueprint: bpName,
+      sourceNodeId: branchNodeId,
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("rejects non-existent source node", async () => {
+    const data = await uePost("/api/check-pin-compatibility", {
+      blueprint: bpName,
+      sourceNodeId: "00000000-0000-0000-0000-000000000000",
+      sourcePinName: "then",
+      targetNodeId: printStringNodeId,
+      targetPinName: "execute",
+    });
+    expect(data.error).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- **Issue #23 (Pin type introspection)**: Added `get_pin_info` for detailed pin metadata (type, container, defaults, connections) and `check_pin_compatibility` for pre-flight compatibility checks using UE5's `CanCreateConnection` schema API — reports direct, break-connections, requires-conversion, or disallowed.
- **Issue #24 (Class and function discovery)**: Added `list_classes` (name/parent filtering, pagination), `list_functions` (Blueprint-callable functions with parameter signatures, return types, flags), and `list_properties` (class properties with types and flags).

## Changes
- **New C++ file** (`BlueprintMCPHandlers_Discovery.cpp`): 5 handler implementations (~430 lines)
- **C++ registration** (`BlueprintMCPServer.cpp/h`): Route bindings and handler map entries (read-only, no undo transactions)
- **New TypeScript file** (`discovery.ts`): 5 tool definitions with human-readable response formatting
- **TypeScript registration** (`index.ts`): Import and register discovery tools
- **Tests**: `pin-introspection.test.ts` (9 tests), `class-discovery.test.ts` (14 tests)

## Test plan
- [ ] `npm run build` passes (verified)
- [ ] C++ compiles cleanly with UBT — 16/16 actions (verified)
- [ ] `get_pin_info` returns type details, container flags, and connections
- [ ] `check_pin_compatibility` correctly reports compatible/incompatible pins
- [ ] `list_classes` filters by name and parent class with pagination
- [ ] `list_functions` lists callable functions with parameter signatures
- [ ] `list_properties` lists properties with type and flag info
- [ ] Error cases handled (missing fields, non-existent nodes/classes)

Closes #23, closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)