### PR TITLE
Add material asset tools (#44)

### DIFF
--- a/Source/BlueprintMCP/BlueprintMCP.Build.cs
+++ b/Source/BlueprintMCP/BlueprintMCP.Build.cs
@@ -26,7 +26,8 @@ public class BlueprintMCP : ModuleRules
 			"AssetTools",
 			"Kismet",
 			"KismetCompiler",
-			"EditorSubsystem"
+			"EditorSubsystem",
+			"MaterialEditor"
 		});
 	}
 }

--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_MaterialInstance.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_MaterialInstance.cpp
@@ -1,0 +1,736 @@
+#include "BlueprintMCPServer.h"
+#include "Materials/Material.h"
+#include "Materials/MaterialInterface.h"
+#include "Materials/MaterialInstanceConstant.h"
+#include "Materials/MaterialExpressionScalarParameter.h"
+#include "Materials/MaterialExpressionVectorParameter.h"
+#include "Materials/MaterialExpressionTextureSampleParameter2D.h"
+#include "Materials/MaterialExpressionStaticSwitchParameter.h"
+#include "Factories/MaterialInstanceConstantFactoryNew.h"
+#include "AssetToolsModule.h"
+#include "IAssetTools.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+#include "UObject/SavePackage.h"
+#include "Engine/Texture.h"
+
+// ============================================================
+// HandleCreateMaterialInstance — create a new Material Instance Constant
+// ============================================================
+
+FString FBlueprintMCPServer::HandleCreateMaterialInstance(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString Name = Json->GetStringField(TEXT("name"));
+	FString PackagePath = Json->GetStringField(TEXT("packagePath"));
+	FString ParentMaterialName = Json->GetStringField(TEXT("parentMaterial"));
+
+	if (Name.IsEmpty() || PackagePath.IsEmpty() || ParentMaterialName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: name, packagePath, parentMaterial"));
+	}
+
+	// Validate packagePath starts with /Game
+	if (!PackagePath.StartsWith(TEXT("/Game")))
+	{
+		return MakeErrorJson(TEXT("packagePath must start with '/Game'"));
+	}
+
+	// Check if asset already exists
+	FString FullAssetPath = PackagePath / Name;
+	if (FindMaterialInstanceAsset(Name) || FindMaterialInstanceAsset(FullAssetPath))
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Material Instance '%s' already exists. Use a different name or delete the existing asset first."),
+			*Name));
+	}
+
+	// Load parent material — try as Material first, then as Material Instance
+	UMaterialInterface* ParentMaterial = nullptr;
+	{
+		FString LoadError;
+		UMaterial* ParentMat = LoadMaterialByName(ParentMaterialName, LoadError);
+		if (ParentMat)
+		{
+			ParentMaterial = ParentMat;
+		}
+		else
+		{
+			FString MILoadError;
+			UMaterialInstanceConstant* ParentMI = LoadMaterialInstanceByName(ParentMaterialName, MILoadError);
+			if (ParentMI)
+			{
+				ParentMaterial = ParentMI;
+			}
+		}
+	}
+
+	if (!ParentMaterial)
+	{
+		// Also try LoadObject as a fallback with the raw path
+		ParentMaterial = LoadObject<UMaterialInterface>(nullptr, *ParentMaterialName);
+	}
+
+	if (!ParentMaterial)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Parent material '%s' not found. Provide a Material or Material Instance name/path."),
+			*ParentMaterialName));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Creating Material Instance '%s' in '%s' with parent '%s'"),
+		*Name, *PackagePath, *ParentMaterial->GetName());
+
+	// Create via factory + AssetTools
+	IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();
+	UMaterialInstanceConstantFactoryNew* Factory = NewObject<UMaterialInstanceConstantFactoryNew>();
+
+	UObject* NewAsset = AssetTools.CreateAsset(Name, PackagePath, UMaterialInstanceConstant::StaticClass(), Factory);
+	if (!NewAsset)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Failed to create Material Instance asset '%s' in '%s'"), *Name, *PackagePath));
+	}
+
+	UMaterialInstanceConstant* MI = Cast<UMaterialInstanceConstant>(NewAsset);
+	if (!MI)
+	{
+		return MakeErrorJson(TEXT("Created asset is not a UMaterialInstanceConstant"));
+	}
+
+	// Set parent
+	MI->PreEditChange(nullptr);
+	MI->Parent = ParentMaterial;
+	MI->PostEditChange();
+
+	// Save
+	bool bSaved = SaveGenericPackage(MI);
+
+	// Refresh asset cache
+	FAssetRegistryModule& ARM = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+	AllMaterialInstanceAssets.Empty();
+	ARM.Get().GetAssetsByClass(UMaterialInstanceConstant::StaticClass()->GetClassPathName(), AllMaterialInstanceAssets, false);
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Created Material Instance '%s' with parent '%s' (saved: %s)"),
+		*Name, *ParentMaterial->GetName(), bSaved ? TEXT("true") : TEXT("false"));
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("name"), Name);
+	Result->SetStringField(TEXT("path"), MI->GetPathName());
+	Result->SetStringField(TEXT("parent"), ParentMaterial->GetPathName());
+	Result->SetBoolField(TEXT("saved"), bSaved);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleSetMaterialInstanceParameter — set a parameter override on an MI
+// ============================================================
+
+FString FBlueprintMCPServer::HandleSetMaterialInstanceParameter(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString MIName = Json->GetStringField(TEXT("materialInstance"));
+	FString ParamName = Json->GetStringField(TEXT("parameterName"));
+
+	if (MIName.IsEmpty() || ParamName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: materialInstance, parameterName"));
+	}
+
+	if (!Json->HasField(TEXT("value")))
+	{
+		return MakeErrorJson(TEXT("Missing required field: value"));
+	}
+
+	bool bDryRun = false;
+	if (Json->HasField(TEXT("dryRun")))
+	{
+		bDryRun = Json->GetBoolField(TEXT("dryRun"));
+	}
+
+	// Load the Material Instance
+	FString LoadError;
+	UMaterialInstanceConstant* MI = LoadMaterialInstanceByName(MIName, LoadError);
+	if (!MI)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	// Determine the parameter type — explicit or auto-detect from parent
+	FString TypeStr;
+	if (Json->HasField(TEXT("type")))
+	{
+		TypeStr = Json->GetStringField(TEXT("type"));
+	}
+
+	// Auto-detect type from parent material's parameters if not provided
+	if (TypeStr.IsEmpty())
+	{
+		UMaterialInterface* ParentMat = MI->Parent;
+		while (ParentMat)
+		{
+			UMaterial* BaseMat = ParentMat->GetMaterial();
+			if (BaseMat)
+			{
+				// Check scalar parameters
+				for (UMaterialExpression* Expr : BaseMat->GetExpressions())
+				{
+					if (auto* SP = Cast<UMaterialExpressionScalarParameter>(Expr))
+					{
+						if (SP->ParameterName.ToString() == ParamName)
+						{
+							TypeStr = TEXT("scalar");
+							break;
+						}
+					}
+					else if (auto* VP = Cast<UMaterialExpressionVectorParameter>(Expr))
+					{
+						if (VP->ParameterName.ToString() == ParamName)
+						{
+							TypeStr = TEXT("vector");
+							break;
+						}
+					}
+					else if (auto* TP = Cast<UMaterialExpressionTextureSampleParameter2D>(Expr))
+					{
+						if (TP->ParameterName.ToString() == ParamName)
+						{
+							TypeStr = TEXT("texture");
+							break;
+						}
+					}
+					else if (auto* SSP = Cast<UMaterialExpressionStaticSwitchParameter>(Expr))
+					{
+						if (SSP->ParameterName.ToString() == ParamName)
+						{
+							TypeStr = TEXT("staticSwitch");
+							break;
+						}
+					}
+				}
+				break; // Only need to check the base material
+			}
+			// Walk up the parent chain if it's an MI parented to another MI
+			UMaterialInstanceConstant* ParentMI = Cast<UMaterialInstanceConstant>(ParentMat);
+			if (ParentMI)
+			{
+				ParentMat = ParentMI->Parent;
+			}
+			else
+			{
+				break;
+			}
+		}
+	}
+
+	if (TypeStr.IsEmpty())
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Could not determine parameter type for '%s'. Specify the 'type' field explicitly (scalar, vector, texture, staticSwitch)."),
+			*ParamName));
+	}
+
+	FString NewValueDescription;
+	FMaterialParameterInfo ParamInfo(*ParamName);
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: %s parameter '%s' (type=%s) on Material Instance '%s'"),
+		bDryRun ? TEXT("[DRY RUN] Setting") : TEXT("Setting"),
+		*ParamName, *TypeStr, *MIName);
+
+	if (TypeStr.Equals(TEXT("scalar"), ESearchCase::IgnoreCase))
+	{
+		// Scalar parameter — value is a number
+		double FloatValue = Json->GetNumberField(TEXT("value"));
+
+		if (!bDryRun)
+		{
+			MI->SetScalarParameterValueEditorOnly(ParamInfo, (float)FloatValue);
+		}
+		NewValueDescription = FString::Printf(TEXT("%f"), FloatValue);
+	}
+	else if (TypeStr.Equals(TEXT("vector"), ESearchCase::IgnoreCase))
+	{
+		// Vector parameter — value is { r, g, b, a? }
+		const TSharedPtr<FJsonObject>* ValueObj = nullptr;
+		if (!Json->TryGetObjectField(TEXT("value"), ValueObj) || !ValueObj || !(*ValueObj).IsValid())
+		{
+			return MakeErrorJson(TEXT("For vector parameters, 'value' must be an object with r, g, b (and optional a) fields."));
+		}
+
+		double R = (*ValueObj)->GetNumberField(TEXT("r"));
+		double G = (*ValueObj)->GetNumberField(TEXT("g"));
+		double B = (*ValueObj)->GetNumberField(TEXT("b"));
+		double A = (*ValueObj)->HasField(TEXT("a")) ? (*ValueObj)->GetNumberField(TEXT("a")) : 1.0;
+
+		FLinearColor Color((float)R, (float)G, (float)B, (float)A);
+
+		if (!bDryRun)
+		{
+			MI->SetVectorParameterValueEditorOnly(ParamInfo, Color);
+		}
+		NewValueDescription = FString::Printf(TEXT("(R=%f, G=%f, B=%f, A=%f)"), R, G, B, A);
+	}
+	else if (TypeStr.Equals(TEXT("texture"), ESearchCase::IgnoreCase))
+	{
+		// Texture parameter — value is a texture path string
+		FString TexturePath = Json->GetStringField(TEXT("value"));
+		if (TexturePath.IsEmpty())
+		{
+			return MakeErrorJson(TEXT("For texture parameters, 'value' must be a texture asset path string."));
+		}
+
+		UTexture* TextureObj = LoadObject<UTexture>(nullptr, *TexturePath);
+		if (!TextureObj)
+		{
+			return MakeErrorJson(FString::Printf(TEXT("Could not load texture at path '%s'"), *TexturePath));
+		}
+
+		if (!bDryRun)
+		{
+			MI->SetTextureParameterValueEditorOnly(ParamInfo, TextureObj);
+		}
+		NewValueDescription = TexturePath;
+	}
+	else if (TypeStr.Equals(TEXT("staticSwitch"), ESearchCase::IgnoreCase))
+	{
+		// Static switch parameter — value is a bool
+		bool bSwitchValue = Json->GetBoolField(TEXT("value"));
+
+		if (!bDryRun)
+		{
+			// Modify static parameters
+			FStaticParameterSet StaticParams;
+			MI->GetStaticParameterValues(StaticParams);
+
+			bool bFound = false;
+			for (FStaticSwitchParameter& Param : StaticParams.StaticSwitchParameters)
+			{
+				if (Param.ParameterInfo.Name == FName(*ParamName))
+				{
+					Param.Value = bSwitchValue;
+					Param.bOverride = true;
+					bFound = true;
+					break;
+				}
+			}
+
+			if (!bFound)
+			{
+				// Add new static switch parameter entry
+				FStaticSwitchParameter NewParam;
+				NewParam.ParameterInfo.Name = FName(*ParamName);
+				NewParam.Value = bSwitchValue;
+				NewParam.bOverride = true;
+				StaticParams.StaticSwitchParameters.Add(NewParam);
+			}
+
+			MI->UpdateStaticPermutation(StaticParams);
+		}
+		NewValueDescription = bSwitchValue ? TEXT("true") : TEXT("false");
+	}
+	else
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Unknown parameter type '%s'. Valid types: scalar, vector, texture, staticSwitch"),
+			*TypeStr));
+	}
+
+	if (!bDryRun)
+	{
+		MI->PreEditChange(nullptr);
+		MI->PostEditChange();
+		MI->MarkPackageDirty();
+		SaveGenericPackage(MI);
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: %s parameter '%s' = %s on '%s'"),
+		bDryRun ? TEXT("[DRY RUN] Would set") : TEXT("Set"),
+		*ParamName, *NewValueDescription, *MIName);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("materialInstance"), MIName);
+	Result->SetStringField(TEXT("parameterName"), ParamName);
+	Result->SetStringField(TEXT("type"), TypeStr);
+	Result->SetStringField(TEXT("newValue"), NewValueDescription);
+	if (bDryRun)
+	{
+		Result->SetBoolField(TEXT("dryRun"), true);
+	}
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleGetMaterialInstanceParameters — list all parameters on an MI
+// ============================================================
+
+FString FBlueprintMCPServer::HandleGetMaterialInstanceParameters(const TMap<FString, FString>& Params)
+{
+	const FString* NameParam = Params.Find(TEXT("name"));
+	if (!NameParam || NameParam->IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required query parameter: name"));
+	}
+
+	FString LoadError;
+	UMaterialInstanceConstant* MI = LoadMaterialInstanceByName(*NameParam, LoadError);
+	if (!MI)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("name"), MI->GetName());
+	Result->SetStringField(TEXT("path"), MI->GetPathName());
+
+	// Parent info
+	if (MI->Parent)
+	{
+		Result->SetStringField(TEXT("parent"), MI->Parent->GetPathName());
+	}
+
+	// Build parent chain
+	TArray<TSharedPtr<FJsonValue>> ParentChainArr;
+	{
+		UMaterialInterface* Current = MI->Parent;
+		while (Current)
+		{
+			TSharedRef<FJsonObject> ParentObj = MakeShared<FJsonObject>();
+			ParentObj->SetStringField(TEXT("name"), Current->GetName());
+			ParentObj->SetStringField(TEXT("path"), Current->GetPathName());
+			ParentObj->SetStringField(TEXT("class"), Current->GetClass()->GetName());
+			ParentChainArr.Add(MakeShared<FJsonValueObject>(ParentObj));
+
+			UMaterialInstanceConstant* ParentMI = Cast<UMaterialInstanceConstant>(Current);
+			if (ParentMI)
+			{
+				Current = ParentMI->Parent;
+			}
+			else
+			{
+				break; // Reached the root Material
+			}
+		}
+	}
+	Result->SetArrayField(TEXT("parentChain"), ParentChainArr);
+
+	// Scalar parameters
+	TArray<TSharedPtr<FJsonValue>> ScalarArr;
+	for (const FScalarParameterValue& Param : MI->ScalarParameterValues)
+	{
+		TSharedRef<FJsonObject> PObj = MakeShared<FJsonObject>();
+		PObj->SetStringField(TEXT("name"), Param.ParameterInfo.Name.ToString());
+		PObj->SetNumberField(TEXT("value"), Param.ParameterValue);
+		PObj->SetBoolField(TEXT("isOverridden"), true); // Present in ScalarParameterValues means it's overridden
+		ScalarArr.Add(MakeShared<FJsonValueObject>(PObj));
+	}
+	Result->SetArrayField(TEXT("scalarParameters"), ScalarArr);
+
+	// Vector parameters
+	TArray<TSharedPtr<FJsonValue>> VectorArr;
+	for (const FVectorParameterValue& Param : MI->VectorParameterValues)
+	{
+		TSharedRef<FJsonObject> PObj = MakeShared<FJsonObject>();
+		PObj->SetStringField(TEXT("name"), Param.ParameterInfo.Name.ToString());
+		PObj->SetNumberField(TEXT("r"), Param.ParameterValue.R);
+		PObj->SetNumberField(TEXT("g"), Param.ParameterValue.G);
+		PObj->SetNumberField(TEXT("b"), Param.ParameterValue.B);
+		PObj->SetNumberField(TEXT("a"), Param.ParameterValue.A);
+		PObj->SetBoolField(TEXT("isOverridden"), true);
+		VectorArr.Add(MakeShared<FJsonValueObject>(PObj));
+	}
+	Result->SetArrayField(TEXT("vectorParameters"), VectorArr);
+
+	// Texture parameters
+	TArray<TSharedPtr<FJsonValue>> TextureArr;
+	for (const FTextureParameterValue& Param : MI->TextureParameterValues)
+	{
+		TSharedRef<FJsonObject> PObj = MakeShared<FJsonObject>();
+		PObj->SetStringField(TEXT("name"), Param.ParameterInfo.Name.ToString());
+		if (Param.ParameterValue)
+		{
+			PObj->SetStringField(TEXT("texture"), Param.ParameterValue->GetPathName());
+		}
+		else
+		{
+			PObj->SetStringField(TEXT("texture"), TEXT("None"));
+		}
+		PObj->SetBoolField(TEXT("isOverridden"), true);
+		TextureArr.Add(MakeShared<FJsonValueObject>(PObj));
+	}
+	Result->SetArrayField(TEXT("textureParameters"), TextureArr);
+
+	// Static switch parameters
+	TArray<TSharedPtr<FJsonValue>> StaticSwitchArr;
+	{
+		FStaticParameterSet StaticParams;
+		MI->GetStaticParameterValues(StaticParams);
+
+		for (const FStaticSwitchParameter& Param : StaticParams.StaticSwitchParameters)
+		{
+			TSharedRef<FJsonObject> PObj = MakeShared<FJsonObject>();
+			PObj->SetStringField(TEXT("name"), Param.ParameterInfo.Name.ToString());
+			PObj->SetBoolField(TEXT("value"), Param.Value);
+			PObj->SetBoolField(TEXT("isOverridden"), Param.bOverride);
+			StaticSwitchArr.Add(MakeShared<FJsonValueObject>(PObj));
+		}
+	}
+	Result->SetArrayField(TEXT("staticSwitchParameters"), StaticSwitchArr);
+
+	// Also report inherited parameters from the parent material for discoverability
+	TArray<TSharedPtr<FJsonValue>> InheritedScalarArr;
+	TArray<TSharedPtr<FJsonValue>> InheritedVectorArr;
+	TArray<TSharedPtr<FJsonValue>> InheritedTextureArr;
+	TArray<TSharedPtr<FJsonValue>> InheritedStaticSwitchArr;
+	{
+		UMaterial* BaseMat = MI->GetMaterial();
+		if (BaseMat)
+		{
+			// Collect names of already-overridden parameters for filtering
+			TSet<FString> OverriddenScalars;
+			for (const FScalarParameterValue& P : MI->ScalarParameterValues)
+			{
+				OverriddenScalars.Add(P.ParameterInfo.Name.ToString());
+			}
+			TSet<FString> OverriddenVectors;
+			for (const FVectorParameterValue& P : MI->VectorParameterValues)
+			{
+				OverriddenVectors.Add(P.ParameterInfo.Name.ToString());
+			}
+			TSet<FString> OverriddenTextures;
+			for (const FTextureParameterValue& P : MI->TextureParameterValues)
+			{
+				OverriddenTextures.Add(P.ParameterInfo.Name.ToString());
+			}
+			TSet<FString> OverriddenStaticSwitches;
+			{
+				FStaticParameterSet SP;
+				MI->GetStaticParameterValues(SP);
+				for (const FStaticSwitchParameter& P : SP.StaticSwitchParameters)
+				{
+					if (P.bOverride)
+					{
+						OverriddenStaticSwitches.Add(P.ParameterInfo.Name.ToString());
+					}
+				}
+			}
+
+			for (UMaterialExpression* Expr : BaseMat->GetExpressions())
+			{
+				if (auto* SP = Cast<UMaterialExpressionScalarParameter>(Expr))
+				{
+					if (!OverriddenScalars.Contains(SP->ParameterName.ToString()))
+					{
+						TSharedRef<FJsonObject> PObj = MakeShared<FJsonObject>();
+						PObj->SetStringField(TEXT("name"), SP->ParameterName.ToString());
+						PObj->SetNumberField(TEXT("defaultValue"), SP->DefaultValue);
+						PObj->SetBoolField(TEXT("isOverridden"), false);
+						InheritedScalarArr.Add(MakeShared<FJsonValueObject>(PObj));
+					}
+				}
+				else if (auto* VP = Cast<UMaterialExpressionVectorParameter>(Expr))
+				{
+					if (!OverriddenVectors.Contains(VP->ParameterName.ToString()))
+					{
+						TSharedRef<FJsonObject> PObj = MakeShared<FJsonObject>();
+						PObj->SetStringField(TEXT("name"), VP->ParameterName.ToString());
+						PObj->SetNumberField(TEXT("r"), VP->DefaultValue.R);
+						PObj->SetNumberField(TEXT("g"), VP->DefaultValue.G);
+						PObj->SetNumberField(TEXT("b"), VP->DefaultValue.B);
+						PObj->SetNumberField(TEXT("a"), VP->DefaultValue.A);
+						PObj->SetBoolField(TEXT("isOverridden"), false);
+						InheritedVectorArr.Add(MakeShared<FJsonValueObject>(PObj));
+					}
+				}
+				else if (auto* TP = Cast<UMaterialExpressionTextureSampleParameter2D>(Expr))
+				{
+					if (!OverriddenTextures.Contains(TP->ParameterName.ToString()))
+					{
+						TSharedRef<FJsonObject> PObj = MakeShared<FJsonObject>();
+						PObj->SetStringField(TEXT("name"), TP->ParameterName.ToString());
+						if (TP->Texture)
+						{
+							PObj->SetStringField(TEXT("defaultTexture"), TP->Texture->GetPathName());
+						}
+						else
+						{
+							PObj->SetStringField(TEXT("defaultTexture"), TEXT("None"));
+						}
+						PObj->SetBoolField(TEXT("isOverridden"), false);
+						InheritedTextureArr.Add(MakeShared<FJsonValueObject>(PObj));
+					}
+				}
+				else if (auto* SSP = Cast<UMaterialExpressionStaticSwitchParameter>(Expr))
+				{
+					if (!OverriddenStaticSwitches.Contains(SSP->ParameterName.ToString()))
+					{
+						TSharedRef<FJsonObject> PObj = MakeShared<FJsonObject>();
+						PObj->SetStringField(TEXT("name"), SSP->ParameterName.ToString());
+						PObj->SetBoolField(TEXT("defaultValue"), SSP->DefaultValue);
+						PObj->SetBoolField(TEXT("isOverridden"), false);
+						InheritedStaticSwitchArr.Add(MakeShared<FJsonValueObject>(PObj));
+					}
+				}
+			}
+		}
+	}
+
+	// Merge inherited (non-overridden) params into the arrays
+	for (const TSharedPtr<FJsonValue>& V : InheritedScalarArr)
+	{
+		ScalarArr.Add(V);
+	}
+	for (const TSharedPtr<FJsonValue>& V : InheritedVectorArr)
+	{
+		VectorArr.Add(V);
+	}
+	for (const TSharedPtr<FJsonValue>& V : InheritedTextureArr)
+	{
+		TextureArr.Add(V);
+	}
+	for (const TSharedPtr<FJsonValue>& V : InheritedStaticSwitchArr)
+	{
+		StaticSwitchArr.Add(V);
+	}
+
+	// Update arrays with merged data
+	Result->SetArrayField(TEXT("scalarParameters"), ScalarArr);
+	Result->SetArrayField(TEXT("vectorParameters"), VectorArr);
+	Result->SetArrayField(TEXT("textureParameters"), TextureArr);
+	Result->SetArrayField(TEXT("staticSwitchParameters"), StaticSwitchArr);
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleReparentMaterialInstance — change parent of an MI
+// ============================================================
+
+FString FBlueprintMCPServer::HandleReparentMaterialInstance(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString MIName = Json->GetStringField(TEXT("materialInstance"));
+	FString NewParentName = Json->GetStringField(TEXT("newParent"));
+
+	if (MIName.IsEmpty() || NewParentName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: materialInstance, newParent"));
+	}
+
+	bool bDryRun = false;
+	if (Json->HasField(TEXT("dryRun")))
+	{
+		bDryRun = Json->GetBoolField(TEXT("dryRun"));
+	}
+
+	// Load the Material Instance
+	FString LoadError;
+	UMaterialInstanceConstant* MI = LoadMaterialInstanceByName(MIName, LoadError);
+	if (!MI)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	// Capture old parent
+	FString OldParentPath = MI->Parent ? MI->Parent->GetPathName() : TEXT("None");
+
+	// Load new parent — try as Material first, then as Material Instance
+	UMaterialInterface* NewParent = nullptr;
+	{
+		FString MatLoadError;
+		UMaterial* NewParentMat = LoadMaterialByName(NewParentName, MatLoadError);
+		if (NewParentMat)
+		{
+			NewParent = NewParentMat;
+		}
+		else
+		{
+			FString MILoadError;
+			UMaterialInstanceConstant* NewParentMI = LoadMaterialInstanceByName(NewParentName, MILoadError);
+			if (NewParentMI)
+			{
+				NewParent = NewParentMI;
+			}
+		}
+	}
+
+	if (!NewParent)
+	{
+		// Try LoadObject as a fallback
+		NewParent = LoadObject<UMaterialInterface>(nullptr, *NewParentName);
+	}
+
+	if (!NewParent)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("New parent material '%s' not found. Provide a Material or Material Instance name/path."),
+			*NewParentName));
+	}
+
+	// Prevent circular parenting — check if NewParent is this MI or has this MI in its chain
+	{
+		UMaterialInterface* Check = NewParent;
+		while (Check)
+		{
+			if (Check == MI)
+			{
+				return MakeErrorJson(FString::Printf(
+					TEXT("Cannot reparent '%s' to '%s' — this would create a circular parent chain."),
+					*MIName, *NewParentName));
+			}
+			UMaterialInstanceConstant* CheckMI = Cast<UMaterialInstanceConstant>(Check);
+			if (CheckMI)
+			{
+				Check = CheckMI->Parent;
+			}
+			else
+			{
+				break;
+			}
+		}
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: %s Material Instance '%s': parent '%s' -> '%s'"),
+		bDryRun ? TEXT("[DRY RUN] Reparenting") : TEXT("Reparenting"),
+		*MIName, *OldParentPath, *NewParent->GetPathName());
+
+	if (!bDryRun)
+	{
+		MI->PreEditChange(nullptr);
+		MI->Parent = NewParent;
+		MI->PostEditChange();
+
+		bool bSaved = SaveGenericPackage(MI);
+
+		UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Reparented Material Instance '%s' (saved: %s)"),
+			*MIName, bSaved ? TEXT("true") : TEXT("false"));
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("materialInstance"), MIName);
+	Result->SetStringField(TEXT("oldParent"), OldParentPath);
+	Result->SetStringField(TEXT("newParent"), NewParent->GetPathName());
+	if (bDryRun)
+	{
+		Result->SetBoolField(TEXT("dryRun"), true);
+	}
+	return JsonToString(Result);
+}

--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_MaterialMutation.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_MaterialMutation.cpp
@@ -1,0 +1,1890 @@
+#include "BlueprintMCPServer.h"
+#include "Materials/Material.h"
+#include "Materials/MaterialInstanceConstant.h"
+#include "Materials/MaterialFunction.h"
+#include "Materials/MaterialExpression.h"
+#include "Materials/MaterialExpressionScalarParameter.h"
+#include "Materials/MaterialExpressionVectorParameter.h"
+#include "Materials/MaterialExpressionTextureObjectParameter.h"
+#include "Materials/MaterialExpressionTextureSampleParameter2D.h"
+#include "Materials/MaterialExpressionStaticSwitchParameter.h"
+#include "Materials/MaterialExpressionConstant.h"
+#include "Materials/MaterialExpressionConstant2Vector.h"
+#include "Materials/MaterialExpressionConstant3Vector.h"
+#include "Materials/MaterialExpressionConstant4Vector.h"
+#include "Materials/MaterialExpressionTextureSample.h"
+#include "Materials/MaterialExpressionTextureCoordinate.h"
+#include "Materials/MaterialExpressionComponentMask.h"
+#include "Materials/MaterialExpressionCustom.h"
+#include "Materials/MaterialExpressionAppendVector.h"
+#include "Materials/MaterialExpressionAdd.h"
+#include "Materials/MaterialExpressionMultiply.h"
+#include "Materials/MaterialExpressionLinearInterpolate.h"
+#include "Materials/MaterialExpressionClamp.h"
+#include "Materials/MaterialExpressionOneMinus.h"
+#include "Materials/MaterialExpressionPower.h"
+#include "Materials/MaterialExpressionTime.h"
+#include "Materials/MaterialExpressionWorldPosition.h"
+#include "Materials/MaterialExpressionFunctionInput.h"
+#include "Materials/MaterialExpressionFunctionOutput.h"
+#include "Materials/MaterialExpressionMaterialFunctionCall.h"
+#include "MaterialGraph/MaterialGraph.h"
+#include "MaterialGraph/MaterialGraphNode.h"
+#include "MaterialGraph/MaterialGraphSchema.h"
+#include "Factories/MaterialFactoryNew.h"
+#include "Factories/MaterialFunctionFactoryNew.h"
+#include "AssetToolsModule.h"
+#include "IAssetTools.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "EdGraph/EdGraph.h"
+#include "EdGraph/EdGraphNode.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+#include "Misc/Guid.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "UObject/SavePackage.h"
+
+// ============================================================
+// Phase 2: Material Mutations
+// ============================================================
+
+// ============================================================
+// HandleCreateMaterial — create a new UMaterial asset
+// ============================================================
+
+FString FBlueprintMCPServer::HandleCreateMaterial(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString Name = Json->GetStringField(TEXT("name"));
+	FString PackagePath = Json->GetStringField(TEXT("packagePath"));
+
+	if (Name.IsEmpty() || PackagePath.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: name, packagePath"));
+	}
+
+	if (!PackagePath.StartsWith(TEXT("/Game")))
+	{
+		return MakeErrorJson(TEXT("packagePath must start with '/Game'"));
+	}
+
+	// Check if asset already exists
+	FString FullAssetPath = PackagePath / Name;
+	if (FindMaterialAsset(Name) || FindMaterialAsset(FullAssetPath))
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Material '%s' already exists. Use a different name or delete the existing asset first."),
+			*Name));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Creating Material '%s' in '%s'"), *Name, *PackagePath);
+
+	// Create via IAssetTools + factory
+	IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();
+	UMaterialFactoryNew* Factory = NewObject<UMaterialFactoryNew>();
+	UObject* NewAsset = AssetTools.CreateAsset(Name, PackagePath, UMaterial::StaticClass(), Factory);
+
+	if (!NewAsset)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Failed to create Material '%s' in '%s'"), *Name, *PackagePath));
+	}
+
+	UMaterial* Material = Cast<UMaterial>(NewAsset);
+	if (!Material)
+	{
+		return MakeErrorJson(TEXT("Created asset is not a UMaterial"));
+	}
+
+	// Apply optional properties
+	FString DomainStr;
+	Json->TryGetStringField(TEXT("domain"), DomainStr);
+
+	FString BlendModeStr;
+	Json->TryGetStringField(TEXT("blendMode"), BlendModeStr);
+
+	bool bTwoSided = false;
+	bool bHasTwoSided = Json->TryGetBoolField(TEXT("twoSided"), bTwoSided);
+
+	Material->PreEditChange(nullptr);
+
+	// Parse domain
+	if (!DomainStr.IsEmpty())
+	{
+		if (DomainStr == TEXT("Surface"))
+			Material->MaterialDomain = MD_Surface;
+		else if (DomainStr == TEXT("DeferredDecal"))
+			Material->MaterialDomain = MD_DeferredDecal;
+		else if (DomainStr == TEXT("LightFunction"))
+			Material->MaterialDomain = MD_LightFunction;
+		else if (DomainStr == TEXT("Volume"))
+			Material->MaterialDomain = MD_Volume;
+		else if (DomainStr == TEXT("PostProcess"))
+			Material->MaterialDomain = MD_PostProcess;
+		else if (DomainStr == TEXT("UI"))
+			Material->MaterialDomain = MD_UI;
+	}
+
+	// Parse blend mode
+	if (!BlendModeStr.IsEmpty())
+	{
+		if (BlendModeStr == TEXT("Opaque"))
+			Material->BlendMode = BLEND_Opaque;
+		else if (BlendModeStr == TEXT("Masked"))
+			Material->BlendMode = BLEND_Masked;
+		else if (BlendModeStr == TEXT("Translucent"))
+			Material->BlendMode = BLEND_Translucent;
+		else if (BlendModeStr == TEXT("Additive"))
+			Material->BlendMode = BLEND_Additive;
+		else if (BlendModeStr == TEXT("Modulate"))
+			Material->BlendMode = BLEND_Modulate;
+	}
+
+	if (bHasTwoSided)
+	{
+		Material->TwoSided = bTwoSided;
+	}
+
+	Material->PostEditChange();
+
+	// Save
+	bool bSaved = SaveMaterialPackage(Material);
+
+	// Refresh asset cache
+	FAssetRegistryModule& ARM = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+	AllMaterialAssets.Empty();
+	ARM.Get().GetAssetsByClass(UMaterial::StaticClass()->GetClassPathName(), AllMaterialAssets, false);
+
+	// Map domain back to string for response
+	auto DomainToString = [](EMaterialDomain Domain) -> FString
+	{
+		switch (Domain)
+		{
+		case MD_Surface:        return TEXT("Surface");
+		case MD_DeferredDecal:  return TEXT("DeferredDecal");
+		case MD_LightFunction:  return TEXT("LightFunction");
+		case MD_Volume:         return TEXT("Volume");
+		case MD_PostProcess:    return TEXT("PostProcess");
+		case MD_UI:             return TEXT("UI");
+		default:                return TEXT("Surface");
+		}
+	};
+
+	auto BlendModeToString = [](EBlendMode Mode) -> FString
+	{
+		switch (Mode)
+		{
+		case BLEND_Opaque:      return TEXT("Opaque");
+		case BLEND_Masked:      return TEXT("Masked");
+		case BLEND_Translucent: return TEXT("Translucent");
+		case BLEND_Additive:    return TEXT("Additive");
+		case BLEND_Modulate:    return TEXT("Modulate");
+		default:                return TEXT("Opaque");
+		}
+	};
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Created Material '%s' (saved: %s)"),
+		*Name, bSaved ? TEXT("true") : TEXT("false"));
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("name"), Name);
+	Result->SetStringField(TEXT("path"), Material->GetPathName());
+	Result->SetStringField(TEXT("domain"), DomainToString(Material->MaterialDomain));
+	Result->SetStringField(TEXT("blendMode"), BlendModeToString(Material->BlendMode));
+	Result->SetBoolField(TEXT("twoSided"), Material->TwoSided != 0);
+	Result->SetBoolField(TEXT("saved"), bSaved);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleSetMaterialProperty — set a top-level material property
+// ============================================================
+
+FString FBlueprintMCPServer::HandleSetMaterialProperty(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString MaterialName = Json->GetStringField(TEXT("material"));
+	FString Property = Json->GetStringField(TEXT("property"));
+
+	if (MaterialName.IsEmpty() || Property.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: material, property"));
+	}
+
+	if (!Json->HasField(TEXT("value")))
+	{
+		return MakeErrorJson(TEXT("Missing required field: value"));
+	}
+
+	bool bDryRun = false;
+	Json->TryGetBoolField(TEXT("dryRun"), bDryRun);
+
+	// Load material
+	FString LoadError;
+	UMaterial* Material = LoadMaterialByName(MaterialName, LoadError);
+	if (!Material)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	FString OldValue;
+	FString NewValue;
+
+	// Helper lambdas for converting enum values to strings
+	auto DomainToString = [](EMaterialDomain Domain) -> FString
+	{
+		switch (Domain)
+		{
+		case MD_Surface:        return TEXT("Surface");
+		case MD_DeferredDecal:  return TEXT("DeferredDecal");
+		case MD_LightFunction:  return TEXT("LightFunction");
+		case MD_Volume:         return TEXT("Volume");
+		case MD_PostProcess:    return TEXT("PostProcess");
+		case MD_UI:             return TEXT("UI");
+		default:                return TEXT("Unknown");
+		}
+	};
+
+	auto BlendModeToString = [](EBlendMode Mode) -> FString
+	{
+		switch (Mode)
+		{
+		case BLEND_Opaque:      return TEXT("Opaque");
+		case BLEND_Masked:      return TEXT("Masked");
+		case BLEND_Translucent: return TEXT("Translucent");
+		case BLEND_Additive:    return TEXT("Additive");
+		case BLEND_Modulate:    return TEXT("Modulate");
+		default:                return TEXT("Unknown");
+		}
+	};
+
+	auto ShadingModelToString = [](EMaterialShadingModel Model) -> FString
+	{
+		switch (Model)
+		{
+		case MSM_Unlit:                return TEXT("Unlit");
+		case MSM_DefaultLit:           return TEXT("DefaultLit");
+		case MSM_Subsurface:           return TEXT("Subsurface");
+		case MSM_PreintegratedSkin:    return TEXT("PreintegratedSkin");
+		case MSM_ClearCoat:            return TEXT("ClearCoat");
+		case MSM_SubsurfaceProfile:    return TEXT("SubsurfaceProfile");
+		case MSM_TwoSidedFoliage:      return TEXT("TwoSidedFoliage");
+		case MSM_Hair:                 return TEXT("Hair");
+		case MSM_Cloth:                return TEXT("Cloth");
+		case MSM_Eye:                  return TEXT("Eye");
+		default:                       return TEXT("DefaultLit");
+		}
+	};
+
+	if (Property == TEXT("domain"))
+	{
+		FString ValueStr = Json->GetStringField(TEXT("value"));
+		OldValue = DomainToString(Material->MaterialDomain);
+
+		EMaterialDomain NewDomain = Material->MaterialDomain;
+		if (ValueStr == TEXT("Surface"))            NewDomain = MD_Surface;
+		else if (ValueStr == TEXT("DeferredDecal")) NewDomain = MD_DeferredDecal;
+		else if (ValueStr == TEXT("LightFunction")) NewDomain = MD_LightFunction;
+		else if (ValueStr == TEXT("Volume"))         NewDomain = MD_Volume;
+		else if (ValueStr == TEXT("PostProcess"))    NewDomain = MD_PostProcess;
+		else if (ValueStr == TEXT("UI"))             NewDomain = MD_UI;
+		else
+		{
+			return MakeErrorJson(FString::Printf(
+				TEXT("Invalid domain '%s'. Valid values: Surface, DeferredDecal, LightFunction, Volume, PostProcess, UI"),
+				*ValueStr));
+		}
+
+		NewValue = ValueStr;
+
+		if (!bDryRun)
+		{
+			Material->PreEditChange(nullptr);
+			Material->MaterialDomain = NewDomain;
+			Material->PostEditChange();
+		}
+	}
+	else if (Property == TEXT("blendMode"))
+	{
+		FString ValueStr = Json->GetStringField(TEXT("value"));
+		OldValue = BlendModeToString(Material->BlendMode);
+
+		EBlendMode NewBlend = Material->BlendMode;
+		if (ValueStr == TEXT("Opaque"))           NewBlend = BLEND_Opaque;
+		else if (ValueStr == TEXT("Masked"))      NewBlend = BLEND_Masked;
+		else if (ValueStr == TEXT("Translucent")) NewBlend = BLEND_Translucent;
+		else if (ValueStr == TEXT("Additive"))    NewBlend = BLEND_Additive;
+		else if (ValueStr == TEXT("Modulate"))    NewBlend = BLEND_Modulate;
+		else
+		{
+			return MakeErrorJson(FString::Printf(
+				TEXT("Invalid blendMode '%s'. Valid values: Opaque, Masked, Translucent, Additive, Modulate"),
+				*ValueStr));
+		}
+
+		NewValue = ValueStr;
+
+		if (!bDryRun)
+		{
+			Material->PreEditChange(nullptr);
+			Material->BlendMode = NewBlend;
+			Material->PostEditChange();
+		}
+	}
+	else if (Property == TEXT("twoSided"))
+	{
+		bool bValue = Json->GetBoolField(TEXT("value"));
+		OldValue = Material->TwoSided ? TEXT("true") : TEXT("false");
+		NewValue = bValue ? TEXT("true") : TEXT("false");
+
+		if (!bDryRun)
+		{
+			Material->PreEditChange(nullptr);
+			Material->TwoSided = bValue ? 1 : 0;
+			Material->PostEditChange();
+		}
+	}
+	else if (Property == TEXT("shadingModel"))
+	{
+		FString ValueStr = Json->GetStringField(TEXT("value"));
+		OldValue = ShadingModelToString(Material->GetShadingModels().GetFirstShadingModel());
+
+		EMaterialShadingModel NewModel = MSM_DefaultLit;
+		if (ValueStr == TEXT("Unlit"))                  NewModel = MSM_Unlit;
+		else if (ValueStr == TEXT("DefaultLit"))        NewModel = MSM_DefaultLit;
+		else if (ValueStr == TEXT("Subsurface"))        NewModel = MSM_Subsurface;
+		else if (ValueStr == TEXT("PreintegratedSkin")) NewModel = MSM_PreintegratedSkin;
+		else if (ValueStr == TEXT("ClearCoat"))         NewModel = MSM_ClearCoat;
+		else if (ValueStr == TEXT("SubsurfaceProfile")) NewModel = MSM_SubsurfaceProfile;
+		else if (ValueStr == TEXT("TwoSidedFoliage"))   NewModel = MSM_TwoSidedFoliage;
+		else if (ValueStr == TEXT("Hair"))              NewModel = MSM_Hair;
+		else if (ValueStr == TEXT("Cloth"))             NewModel = MSM_Cloth;
+		else if (ValueStr == TEXT("Eye"))               NewModel = MSM_Eye;
+		else
+		{
+			return MakeErrorJson(FString::Printf(
+				TEXT("Invalid shadingModel '%s'. Valid values: Unlit, DefaultLit, Subsurface, PreintegratedSkin, ClearCoat, SubsurfaceProfile, TwoSidedFoliage, Hair, Cloth, Eye"),
+				*ValueStr));
+		}
+
+		NewValue = ValueStr;
+
+		if (!bDryRun)
+		{
+			Material->PreEditChange(nullptr);
+			Material->SetShadingModel(NewModel);
+			Material->PostEditChange();
+		}
+	}
+	else if (Property == TEXT("opacity"))
+	{
+		double OpacityValue = Json->GetNumberField(TEXT("value"));
+		OldValue = FString::Printf(TEXT("%f"), Material->OpacityMaskClipValue);
+		NewValue = FString::Printf(TEXT("%f"), OpacityValue);
+
+		if (!bDryRun)
+		{
+			Material->PreEditChange(nullptr);
+			Material->OpacityMaskClipValue = (float)OpacityValue;
+			Material->PostEditChange();
+		}
+	}
+	else
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Unknown property '%s'. Valid properties: domain, blendMode, twoSided, shadingModel, opacity"),
+			*Property));
+	}
+
+	// Save if not dry run
+	bool bSaved = false;
+	if (!bDryRun)
+	{
+		bSaved = SaveMaterialPackage(Material);
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: %sSet material property '%s' on '%s': '%s' -> '%s'"),
+		bDryRun ? TEXT("[DRY RUN] ") : TEXT(""),
+		*Property, *MaterialName, *OldValue, *NewValue);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("material"), Material->GetName());
+	Result->SetStringField(TEXT("property"), Property);
+	Result->SetStringField(TEXT("oldValue"), OldValue);
+	Result->SetStringField(TEXT("newValue"), NewValue);
+	Result->SetBoolField(TEXT("dryRun"), bDryRun);
+	if (!bDryRun)
+	{
+		Result->SetBoolField(TEXT("saved"), bSaved);
+	}
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleAddMaterialExpression — add a new expression to a material
+// ============================================================
+
+FString FBlueprintMCPServer::HandleAddMaterialExpression(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString MaterialName = Json->GetStringField(TEXT("material"));
+	FString ExpressionClassName = Json->GetStringField(TEXT("expressionClass"));
+
+	if (MaterialName.IsEmpty() || ExpressionClassName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: material, expressionClass"));
+	}
+
+	int32 PosX = 0, PosY = 0;
+	if (Json->HasField(TEXT("posX")))
+		PosX = (int32)Json->GetNumberField(TEXT("posX"));
+	if (Json->HasField(TEXT("posY")))
+		PosY = (int32)Json->GetNumberField(TEXT("posY"));
+
+	bool bDryRun = false;
+	Json->TryGetBoolField(TEXT("dryRun"), bDryRun);
+
+	// Map string class name to UClass
+	UClass* ExprClass = nullptr;
+
+	if (ExpressionClassName == TEXT("Constant"))
+		ExprClass = UMaterialExpressionConstant::StaticClass();
+	else if (ExpressionClassName == TEXT("Constant3Vector"))
+		ExprClass = UMaterialExpressionConstant3Vector::StaticClass();
+	else if (ExpressionClassName == TEXT("Constant4Vector"))
+		ExprClass = UMaterialExpressionConstant4Vector::StaticClass();
+	else if (ExpressionClassName == TEXT("ScalarParameter"))
+		ExprClass = UMaterialExpressionScalarParameter::StaticClass();
+	else if (ExpressionClassName == TEXT("VectorParameter"))
+		ExprClass = UMaterialExpressionVectorParameter::StaticClass();
+	else if (ExpressionClassName == TEXT("TextureSample"))
+		ExprClass = UMaterialExpressionTextureSample::StaticClass();
+	else if (ExpressionClassName == TEXT("TextureSampleParameter2D"))
+		ExprClass = UMaterialExpressionTextureSampleParameter2D::StaticClass();
+	else if (ExpressionClassName == TEXT("TextureCoordinate"))
+		ExprClass = UMaterialExpressionTextureCoordinate::StaticClass();
+	else if (ExpressionClassName == TEXT("ComponentMask"))
+		ExprClass = UMaterialExpressionComponentMask::StaticClass();
+	else if (ExpressionClassName == TEXT("Add"))
+		ExprClass = UMaterialExpressionAdd::StaticClass();
+	else if (ExpressionClassName == TEXT("Multiply"))
+		ExprClass = UMaterialExpressionMultiply::StaticClass();
+	else if (ExpressionClassName == TEXT("LinearInterpolate") || ExpressionClassName == TEXT("Lerp"))
+		ExprClass = UMaterialExpressionLinearInterpolate::StaticClass();
+	else if (ExpressionClassName == TEXT("Clamp"))
+		ExprClass = UMaterialExpressionClamp::StaticClass();
+	else if (ExpressionClassName == TEXT("OneMinus"))
+		ExprClass = UMaterialExpressionOneMinus::StaticClass();
+	else if (ExpressionClassName == TEXT("Power"))
+		ExprClass = UMaterialExpressionPower::StaticClass();
+	else if (ExpressionClassName == TEXT("Time"))
+		ExprClass = UMaterialExpressionTime::StaticClass();
+	else if (ExpressionClassName == TEXT("WorldPosition"))
+		ExprClass = UMaterialExpressionWorldPosition::StaticClass();
+	else if (ExpressionClassName == TEXT("AppendVector"))
+		ExprClass = UMaterialExpressionAppendVector::StaticClass();
+	else if (ExpressionClassName == TEXT("Custom"))
+		ExprClass = UMaterialExpressionCustom::StaticClass();
+	else if (ExpressionClassName == TEXT("StaticSwitchParameter"))
+		ExprClass = UMaterialExpressionStaticSwitchParameter::StaticClass();
+	else if (ExpressionClassName == TEXT("MaterialFunctionCall"))
+		ExprClass = UMaterialExpressionMaterialFunctionCall::StaticClass();
+	else
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Unknown expression class '%s'. Valid classes: Constant, Constant3Vector, Constant4Vector, "
+				"ScalarParameter, VectorParameter, TextureSample, TextureSampleParameter2D, TextureCoordinate, "
+				"ComponentMask, Add, Multiply, LinearInterpolate, Lerp, Clamp, OneMinus, Power, Time, "
+				"WorldPosition, AppendVector, Custom, StaticSwitchParameter, MaterialFunctionCall"),
+			*ExpressionClassName));
+	}
+
+	// Load material
+	FString LoadError;
+	UMaterial* Material = LoadMaterialByName(MaterialName, LoadError);
+	if (!Material)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	if (bDryRun)
+	{
+		UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: [DRY RUN] Would add expression '%s' to material '%s' at (%d, %d)"),
+			*ExpressionClassName, *MaterialName, PosX, PosY);
+
+		TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+		Result->SetBoolField(TEXT("success"), true);
+		Result->SetBoolField(TEXT("dryRun"), true);
+		Result->SetStringField(TEXT("material"), Material->GetName());
+		Result->SetStringField(TEXT("expressionClass"), ExpressionClassName);
+		Result->SetNumberField(TEXT("posX"), PosX);
+		Result->SetNumberField(TEXT("posY"), PosY);
+		return JsonToString(Result);
+	}
+
+	// Create the expression
+	UMaterialExpression* NewExpr = NewObject<UMaterialExpression>(Material, ExprClass);
+	if (!NewExpr)
+	{
+		return MakeErrorJson(TEXT("Failed to create material expression object"));
+	}
+
+	// Set position
+	NewExpr->MaterialExpressionEditorX = PosX;
+	NewExpr->MaterialExpressionEditorY = PosY;
+
+	// Add to material (UE 5.4 compatible)
+	Material->GetExpressionCollection().AddExpression(NewExpr);
+
+	// Rebuild material graph if it exists
+	if (Material->MaterialGraph)
+	{
+		Material->MaterialGraph->RebuildGraph();
+	}
+
+	Material->PreEditChange(nullptr);
+	Material->PostEditChange();
+	Material->MarkPackageDirty();
+
+	// Save
+	bool bSaved = SaveMaterialPackage(Material);
+
+	// Find the node GUID from the material graph
+	FString NodeGuid;
+	if (Material->MaterialGraph)
+	{
+		for (UEdGraphNode* Node : Material->MaterialGraph->Nodes)
+		{
+			UMaterialGraphNode* MatNode = Cast<UMaterialGraphNode>(Node);
+			if (MatNode && MatNode->MaterialExpression == NewExpr)
+			{
+				NodeGuid = Node->NodeGuid.ToString();
+				break;
+			}
+		}
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Added expression '%s' to material '%s' (nodeId: %s, saved: %s)"),
+		*ExpressionClassName, *MaterialName, *NodeGuid, bSaved ? TEXT("true") : TEXT("false"));
+
+	// Serialize the expression details
+	TSharedPtr<FJsonObject> ExprDetails = SerializeMaterialExpression(NewExpr);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("material"), Material->GetName());
+	Result->SetStringField(TEXT("expressionClass"), ExpressionClassName);
+	Result->SetStringField(TEXT("nodeId"), NodeGuid);
+	Result->SetNumberField(TEXT("posX"), PosX);
+	Result->SetNumberField(TEXT("posY"), PosY);
+	if (ExprDetails.IsValid())
+	{
+		Result->SetObjectField(TEXT("expression"), ExprDetails);
+	}
+	Result->SetBoolField(TEXT("saved"), bSaved);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleDeleteMaterialExpression — remove an expression from a material
+// ============================================================
+
+FString FBlueprintMCPServer::HandleDeleteMaterialExpression(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString MaterialName = Json->GetStringField(TEXT("material"));
+	FString NodeId = Json->GetStringField(TEXT("nodeId"));
+
+	if (MaterialName.IsEmpty() || NodeId.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: material, nodeId"));
+	}
+
+	bool bDryRun = false;
+	Json->TryGetBoolField(TEXT("dryRun"), bDryRun);
+
+	// Load material
+	FString LoadError;
+	UMaterial* Material = LoadMaterialByName(MaterialName, LoadError);
+	if (!Material)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	if (!Material->MaterialGraph)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Material '%s' has no material graph"), *MaterialName));
+	}
+
+	// Find the node by GUID
+	UMaterialGraphNode* TargetMatNode = nullptr;
+	for (UEdGraphNode* Node : Material->MaterialGraph->Nodes)
+	{
+		if (!Node) continue;
+		if (Node->NodeGuid.ToString() == NodeId)
+		{
+			TargetMatNode = Cast<UMaterialGraphNode>(Node);
+			break;
+		}
+	}
+
+	if (!TargetMatNode)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Node '%s' not found in material graph"), *NodeId));
+	}
+
+	if (!TargetMatNode->MaterialExpression)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Node '%s' has no associated material expression"), *NodeId));
+	}
+
+	// Capture info before deletion
+	FString DeletedNodeTitle = TargetMatNode->GetNodeTitle(ENodeTitleType::FullTitle).ToString();
+	FString DeletedExprClass = TargetMatNode->MaterialExpression->GetClass()->GetName();
+
+	if (bDryRun)
+	{
+		UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: [DRY RUN] Would delete expression '%s' (nodeId: %s) from material '%s'"),
+			*DeletedExprClass, *NodeId, *MaterialName);
+
+		TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+		Result->SetBoolField(TEXT("success"), true);
+		Result->SetBoolField(TEXT("dryRun"), true);
+		Result->SetStringField(TEXT("material"), Material->GetName());
+		Result->SetStringField(TEXT("deletedNode"), NodeId);
+		Result->SetStringField(TEXT("deletedNodeTitle"), DeletedNodeTitle);
+		Result->SetStringField(TEXT("deletedExpressionClass"), DeletedExprClass);
+		return JsonToString(Result);
+	}
+
+	// Remove the expression from the material
+	UMaterialExpression* ExprToRemove = TargetMatNode->MaterialExpression;
+	Material->GetExpressionCollection().RemoveExpression(ExprToRemove);
+	ExprToRemove->MarkAsGarbage();
+
+	// Rebuild graph
+	Material->MaterialGraph->RebuildGraph();
+
+	Material->PreEditChange(nullptr);
+	Material->PostEditChange();
+	Material->MarkPackageDirty();
+
+	// Save
+	bool bSaved = SaveMaterialPackage(Material);
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Deleted expression '%s' (nodeId: %s) from material '%s' (saved: %s)"),
+		*DeletedExprClass, *NodeId, *MaterialName, bSaved ? TEXT("true") : TEXT("false"));
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("material"), Material->GetName());
+	Result->SetStringField(TEXT("deletedNode"), NodeId);
+	Result->SetStringField(TEXT("deletedNodeTitle"), DeletedNodeTitle);
+	Result->SetStringField(TEXT("deletedExpressionClass"), DeletedExprClass);
+	Result->SetBoolField(TEXT("saved"), bSaved);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleConnectMaterialPins — connect two pins in a material graph
+// ============================================================
+
+FString FBlueprintMCPServer::HandleConnectMaterialPins(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString MaterialName = Json->GetStringField(TEXT("material"));
+	FString SourceNodeId = Json->GetStringField(TEXT("sourceNodeId"));
+	FString SourcePinName = Json->GetStringField(TEXT("sourcePinName"));
+	FString TargetNodeId = Json->GetStringField(TEXT("targetNodeId"));
+	FString TargetPinName = Json->GetStringField(TEXT("targetPinName"));
+
+	if (MaterialName.IsEmpty() || SourceNodeId.IsEmpty() || SourcePinName.IsEmpty() ||
+		TargetNodeId.IsEmpty() || TargetPinName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: material, sourceNodeId, sourcePinName, targetNodeId, targetPinName"));
+	}
+
+	bool bDryRun = false;
+	Json->TryGetBoolField(TEXT("dryRun"), bDryRun);
+
+	// Load material
+	FString LoadError;
+	UMaterial* Material = LoadMaterialByName(MaterialName, LoadError);
+	if (!Material)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	if (!Material->MaterialGraph)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Material '%s' has no material graph"), *MaterialName));
+	}
+
+	// Find source and target nodes by GUID
+	UEdGraphNode* SourceNode = nullptr;
+	UEdGraphNode* TargetNode = nullptr;
+
+	for (UEdGraphNode* Node : Material->MaterialGraph->Nodes)
+	{
+		if (!Node) continue;
+		if (Node->NodeGuid.ToString() == SourceNodeId)
+			SourceNode = Node;
+		if (Node->NodeGuid.ToString() == TargetNodeId)
+			TargetNode = Node;
+		if (SourceNode && TargetNode)
+			break;
+	}
+
+	if (!SourceNode)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Source node '%s' not found in material graph"), *SourceNodeId));
+	}
+	if (!TargetNode)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Target node '%s' not found in material graph"), *TargetNodeId));
+	}
+
+	// Find pins
+	UEdGraphPin* SourcePin = SourceNode->FindPin(FName(*SourcePinName));
+	if (!SourcePin)
+	{
+		// List available pins for debugging
+		TArray<TSharedPtr<FJsonValue>> PinNames;
+		for (UEdGraphPin* P : SourceNode->Pins)
+		{
+			if (P) PinNames.Add(MakeShared<FJsonValueString>(
+				FString::Printf(TEXT("%s (%s)"), *P->PinName.ToString(),
+					P->Direction == EGPD_Input ? TEXT("Input") : TEXT("Output"))));
+		}
+		TSharedRef<FJsonObject> E = MakeShared<FJsonObject>();
+		E->SetStringField(TEXT("error"), FString::Printf(TEXT("Source pin '%s' not found on node '%s'"),
+			*SourcePinName, *SourceNodeId));
+		E->SetArrayField(TEXT("availablePins"), PinNames);
+		return JsonToString(E);
+	}
+
+	UEdGraphPin* TargetPin = TargetNode->FindPin(FName(*TargetPinName));
+	if (!TargetPin)
+	{
+		TArray<TSharedPtr<FJsonValue>> PinNames;
+		for (UEdGraphPin* P : TargetNode->Pins)
+		{
+			if (P) PinNames.Add(MakeShared<FJsonValueString>(
+				FString::Printf(TEXT("%s (%s)"), *P->PinName.ToString(),
+					P->Direction == EGPD_Input ? TEXT("Input") : TEXT("Output"))));
+		}
+		TSharedRef<FJsonObject> E = MakeShared<FJsonObject>();
+		E->SetStringField(TEXT("error"), FString::Printf(TEXT("Target pin '%s' not found on node '%s'"),
+			*TargetPinName, *TargetNodeId));
+		E->SetArrayField(TEXT("availablePins"), PinNames);
+		return JsonToString(E);
+	}
+
+	if (bDryRun)
+	{
+		UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: [DRY RUN] Would connect %s.%s -> %s.%s in material '%s'"),
+			*SourceNodeId, *SourcePinName, *TargetNodeId, *TargetPinName, *MaterialName);
+
+		TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+		Result->SetBoolField(TEXT("success"), true);
+		Result->SetBoolField(TEXT("dryRun"), true);
+		Result->SetBoolField(TEXT("connected"), false);
+		Result->SetStringField(TEXT("material"), Material->GetName());
+		return JsonToString(Result);
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Connecting %s.%s -> %s.%s in material '%s'"),
+		*SourceNodeId, *SourcePinName, *TargetNodeId, *TargetPinName, *MaterialName);
+
+	// Try to connect via the schema
+	const UEdGraphSchema* Schema = Material->MaterialGraph->GetSchema();
+	if (!Schema)
+	{
+		return MakeErrorJson(TEXT("Material graph schema not found"));
+	}
+
+	bool bConnected = Schema->TryCreateConnection(SourcePin, TargetPin);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), bConnected);
+	Result->SetBoolField(TEXT("connected"), bConnected);
+	Result->SetStringField(TEXT("material"), Material->GetName());
+
+	if (!bConnected)
+	{
+		Result->SetStringField(TEXT("error"), FString::Printf(
+			TEXT("Cannot connect %s.%s to %s.%s — types may be incompatible"),
+			*SourceNodeId, *SourcePinName, *TargetNodeId, *TargetPinName));
+		return JsonToString(Result);
+	}
+
+	// Save
+	Material->PreEditChange(nullptr);
+	Material->PostEditChange();
+	bool bSaved = SaveMaterialPackage(Material);
+	Result->SetBoolField(TEXT("saved"), bSaved);
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleDisconnectMaterialPin — break connections on a pin in a material graph
+// ============================================================
+
+FString FBlueprintMCPServer::HandleDisconnectMaterialPin(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString MaterialName = Json->GetStringField(TEXT("material"));
+	FString NodeId = Json->GetStringField(TEXT("nodeId"));
+	FString PinName = Json->GetStringField(TEXT("pinName"));
+
+	if (MaterialName.IsEmpty() || NodeId.IsEmpty() || PinName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: material, nodeId, pinName"));
+	}
+
+	bool bDryRun = false;
+	Json->TryGetBoolField(TEXT("dryRun"), bDryRun);
+
+	// Load material
+	FString LoadError;
+	UMaterial* Material = LoadMaterialByName(MaterialName, LoadError);
+	if (!Material)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	if (!Material->MaterialGraph)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Material '%s' has no material graph"), *MaterialName));
+	}
+
+	// Find node by GUID
+	UEdGraphNode* TargetNode = nullptr;
+	for (UEdGraphNode* Node : Material->MaterialGraph->Nodes)
+	{
+		if (!Node) continue;
+		if (Node->NodeGuid.ToString() == NodeId)
+		{
+			TargetNode = Node;
+			break;
+		}
+	}
+
+	if (!TargetNode)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Node '%s' not found in material graph"), *NodeId));
+	}
+
+	// Find pin
+	UEdGraphPin* Pin = TargetNode->FindPin(FName(*PinName));
+	if (!Pin)
+	{
+		TArray<TSharedPtr<FJsonValue>> PinNames;
+		for (UEdGraphPin* P : TargetNode->Pins)
+		{
+			if (P) PinNames.Add(MakeShared<FJsonValueString>(
+				FString::Printf(TEXT("%s (%s)"), *P->PinName.ToString(),
+					P->Direction == EGPD_Input ? TEXT("Input") : TEXT("Output"))));
+		}
+		TSharedRef<FJsonObject> E = MakeShared<FJsonObject>();
+		E->SetStringField(TEXT("error"), FString::Printf(TEXT("Pin '%s' not found on node '%s'"),
+			*PinName, *NodeId));
+		E->SetArrayField(TEXT("availablePins"), PinNames);
+		return JsonToString(E);
+	}
+
+	int32 BrokenCount = Pin->LinkedTo.Num();
+
+	if (bDryRun)
+	{
+		UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: [DRY RUN] Would disconnect pin '%s' on node '%s' in material '%s' (%d links)"),
+			*PinName, *NodeId, *MaterialName, BrokenCount);
+
+		TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+		Result->SetBoolField(TEXT("success"), true);
+		Result->SetBoolField(TEXT("dryRun"), true);
+		Result->SetStringField(TEXT("material"), Material->GetName());
+		Result->SetStringField(TEXT("nodeId"), NodeId);
+		Result->SetStringField(TEXT("pinName"), PinName);
+		Result->SetNumberField(TEXT("brokenLinkCount"), BrokenCount);
+		return JsonToString(Result);
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Disconnecting pin '%s' on node '%s' in material '%s' (%d links)"),
+		*PinName, *NodeId, *MaterialName, BrokenCount);
+
+	// Break all links
+	Pin->BreakAllPinLinks();
+
+	Material->PreEditChange(nullptr);
+	Material->PostEditChange();
+
+	// Save
+	bool bSaved = SaveMaterialPackage(Material);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("material"), Material->GetName());
+	Result->SetStringField(TEXT("nodeId"), NodeId);
+	Result->SetStringField(TEXT("pinName"), PinName);
+	Result->SetNumberField(TEXT("brokenLinkCount"), BrokenCount);
+	Result->SetBoolField(TEXT("saved"), bSaved);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleSetExpressionValue — set value on a material expression
+// ============================================================
+
+FString FBlueprintMCPServer::HandleSetExpressionValue(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString MaterialName = Json->GetStringField(TEXT("material"));
+	FString NodeId = Json->GetStringField(TEXT("nodeId"));
+
+	if (MaterialName.IsEmpty() || NodeId.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: material, nodeId"));
+	}
+
+	if (!Json->HasField(TEXT("value")))
+	{
+		return MakeErrorJson(TEXT("Missing required field: value"));
+	}
+
+	// Load material
+	FString LoadError;
+	UMaterial* Material = LoadMaterialByName(MaterialName, LoadError);
+	if (!Material)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	if (!Material->MaterialGraph)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Material '%s' has no material graph"), *MaterialName));
+	}
+
+	// Find the node by GUID
+	UMaterialGraphNode* TargetMatNode = nullptr;
+	for (UEdGraphNode* Node : Material->MaterialGraph->Nodes)
+	{
+		if (!Node) continue;
+		if (Node->NodeGuid.ToString() == NodeId)
+		{
+			TargetMatNode = Cast<UMaterialGraphNode>(Node);
+			break;
+		}
+	}
+
+	if (!TargetMatNode)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Node '%s' not found in material graph"), *NodeId));
+	}
+
+	UMaterialExpression* Expr = TargetMatNode->MaterialExpression;
+	if (!Expr)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Node '%s' has no associated material expression"), *NodeId));
+	}
+
+	FString ExprType;
+	FString NewValueStr;
+
+	Material->PreEditChange(nullptr);
+
+	// Handle based on expression type
+	if (UMaterialExpressionConstant* ConstExpr = Cast<UMaterialExpressionConstant>(Expr))
+	{
+		ExprType = TEXT("Constant");
+		double Value = Json->GetNumberField(TEXT("value"));
+		ConstExpr->R = (float)Value;
+		NewValueStr = FString::Printf(TEXT("%f"), Value);
+	}
+	else if (UMaterialExpressionConstant3Vector* C3Expr = Cast<UMaterialExpressionConstant3Vector>(Expr))
+	{
+		ExprType = TEXT("Constant3Vector");
+		const TSharedPtr<FJsonObject>* ValueObj = nullptr;
+		if (Json->TryGetObjectField(TEXT("value"), ValueObj) && ValueObj && (*ValueObj).IsValid())
+		{
+			double R = 0, G = 0, B = 0;
+			(*ValueObj)->TryGetNumberField(TEXT("r"), R);
+			(*ValueObj)->TryGetNumberField(TEXT("g"), G);
+			(*ValueObj)->TryGetNumberField(TEXT("b"), B);
+			C3Expr->Constant = FLinearColor((float)R, (float)G, (float)B);
+			NewValueStr = FString::Printf(TEXT("(%f, %f, %f)"), R, G, B);
+		}
+		else
+		{
+			Material->PostEditChange();
+			return MakeErrorJson(TEXT("Constant3Vector requires value as object {r, g, b}"));
+		}
+	}
+	else if (UMaterialExpressionConstant4Vector* C4Expr = Cast<UMaterialExpressionConstant4Vector>(Expr))
+	{
+		ExprType = TEXT("Constant4Vector");
+		const TSharedPtr<FJsonObject>* ValueObj = nullptr;
+		if (Json->TryGetObjectField(TEXT("value"), ValueObj) && ValueObj && (*ValueObj).IsValid())
+		{
+			double R = 0, G = 0, B = 0, A = 1;
+			(*ValueObj)->TryGetNumberField(TEXT("r"), R);
+			(*ValueObj)->TryGetNumberField(TEXT("g"), G);
+			(*ValueObj)->TryGetNumberField(TEXT("b"), B);
+			(*ValueObj)->TryGetNumberField(TEXT("a"), A);
+			C4Expr->Constant = FLinearColor((float)R, (float)G, (float)B, (float)A);
+			NewValueStr = FString::Printf(TEXT("(%f, %f, %f, %f)"), R, G, B, A);
+		}
+		else
+		{
+			Material->PostEditChange();
+			return MakeErrorJson(TEXT("Constant4Vector requires value as object {r, g, b, a}"));
+		}
+	}
+	else if (UMaterialExpressionScalarParameter* SPExpr = Cast<UMaterialExpressionScalarParameter>(Expr))
+	{
+		ExprType = TEXT("ScalarParameter");
+		double Value = Json->GetNumberField(TEXT("value"));
+		SPExpr->DefaultValue = (float)Value;
+		NewValueStr = FString::Printf(TEXT("%f"), Value);
+
+		FString ParamName;
+		if (Json->TryGetStringField(TEXT("parameterName"), ParamName) && !ParamName.IsEmpty())
+		{
+			SPExpr->ParameterName = FName(*ParamName);
+		}
+	}
+	else if (UMaterialExpressionVectorParameter* VPExpr = Cast<UMaterialExpressionVectorParameter>(Expr))
+	{
+		ExprType = TEXT("VectorParameter");
+		const TSharedPtr<FJsonObject>* ValueObj = nullptr;
+		if (Json->TryGetObjectField(TEXT("value"), ValueObj) && ValueObj && (*ValueObj).IsValid())
+		{
+			double R = 0, G = 0, B = 0, A = 1;
+			(*ValueObj)->TryGetNumberField(TEXT("r"), R);
+			(*ValueObj)->TryGetNumberField(TEXT("g"), G);
+			(*ValueObj)->TryGetNumberField(TEXT("b"), B);
+			(*ValueObj)->TryGetNumberField(TEXT("a"), A);
+			VPExpr->DefaultValue = FLinearColor((float)R, (float)G, (float)B, (float)A);
+			NewValueStr = FString::Printf(TEXT("(%f, %f, %f, %f)"), R, G, B, A);
+		}
+		else
+		{
+			Material->PostEditChange();
+			return MakeErrorJson(TEXT("VectorParameter requires value as object {r, g, b, a}"));
+		}
+
+		FString ParamName;
+		if (Json->TryGetStringField(TEXT("parameterName"), ParamName) && !ParamName.IsEmpty())
+		{
+			VPExpr->ParameterName = FName(*ParamName);
+		}
+	}
+	else if (UMaterialExpressionTextureCoordinate* TCExpr = Cast<UMaterialExpressionTextureCoordinate>(Expr))
+	{
+		ExprType = TEXT("TextureCoordinate");
+		const TSharedPtr<FJsonObject>* ValueObj = nullptr;
+		if (Json->TryGetObjectField(TEXT("value"), ValueObj) && ValueObj && (*ValueObj).IsValid())
+		{
+			double CoordIndex = 0, UTiling = 1, VTiling = 1;
+			(*ValueObj)->TryGetNumberField(TEXT("coordinateIndex"), CoordIndex);
+			(*ValueObj)->TryGetNumberField(TEXT("uTiling"), UTiling);
+			(*ValueObj)->TryGetNumberField(TEXT("vTiling"), VTiling);
+			TCExpr->CoordinateIndex = (int32)CoordIndex;
+			TCExpr->UTiling = (float)UTiling;
+			TCExpr->VTiling = (float)VTiling;
+			NewValueStr = FString::Printf(TEXT("(index=%d, uTiling=%f, vTiling=%f)"), (int32)CoordIndex, UTiling, VTiling);
+		}
+		else
+		{
+			Material->PostEditChange();
+			return MakeErrorJson(TEXT("TextureCoordinate requires value as object {coordinateIndex, uTiling, vTiling}"));
+		}
+	}
+	else if (UMaterialExpressionCustom* CustomExpr = Cast<UMaterialExpressionCustom>(Expr))
+	{
+		ExprType = TEXT("Custom");
+		FString Code;
+		if (Json->TryGetStringField(TEXT("code"), Code))
+		{
+			CustomExpr->Code = Code;
+			NewValueStr = FString::Printf(TEXT("Code: %d chars"), Code.Len());
+		}
+		else if (Json->HasField(TEXT("value")))
+		{
+			// Also accept code via value field as string
+			FString ValueStr = Json->GetStringField(TEXT("value"));
+			if (!ValueStr.IsEmpty())
+			{
+				CustomExpr->Code = ValueStr;
+				NewValueStr = FString::Printf(TEXT("Code: %d chars"), ValueStr.Len());
+			}
+		}
+
+		FString OutputTypeStr;
+		if (Json->TryGetStringField(TEXT("outputType"), OutputTypeStr) && !OutputTypeStr.IsEmpty())
+		{
+			int64 EnumVal = StaticEnum<ECustomMaterialOutputType>()->GetValueByNameString(OutputTypeStr);
+			if (EnumVal != INDEX_NONE)
+			{
+				CustomExpr->OutputType = (ECustomMaterialOutputType)EnumVal;
+			}
+		}
+	}
+	else if (UMaterialExpressionComponentMask* CMExpr = Cast<UMaterialExpressionComponentMask>(Expr))
+	{
+		ExprType = TEXT("ComponentMask");
+		const TSharedPtr<FJsonObject>* ValueObj = nullptr;
+		if (Json->TryGetObjectField(TEXT("value"), ValueObj) && ValueObj && (*ValueObj).IsValid())
+		{
+			bool bR = false, bG = false, bB = false, bA = false;
+			(*ValueObj)->TryGetBoolField(TEXT("r"), bR);
+			(*ValueObj)->TryGetBoolField(TEXT("g"), bG);
+			(*ValueObj)->TryGetBoolField(TEXT("b"), bB);
+			(*ValueObj)->TryGetBoolField(TEXT("a"), bA);
+			CMExpr->R = bR ? 1 : 0;
+			CMExpr->G = bG ? 1 : 0;
+			CMExpr->B = bB ? 1 : 0;
+			CMExpr->A = bA ? 1 : 0;
+			NewValueStr = FString::Printf(TEXT("(R=%s, G=%s, B=%s, A=%s)"),
+				bR ? TEXT("true") : TEXT("false"),
+				bG ? TEXT("true") : TEXT("false"),
+				bB ? TEXT("true") : TEXT("false"),
+				bA ? TEXT("true") : TEXT("false"));
+		}
+		else
+		{
+			Material->PostEditChange();
+			return MakeErrorJson(TEXT("ComponentMask requires value as object {r, g, b, a} (booleans)"));
+		}
+	}
+	else
+	{
+		Material->PostEditChange();
+		return MakeErrorJson(FString::Printf(
+			TEXT("Expression type '%s' does not support direct value setting. Supported types: Constant, "
+				"Constant3Vector, Constant4Vector, ScalarParameter, VectorParameter, TextureCoordinate, "
+				"Custom, ComponentMask"),
+			*Expr->GetClass()->GetName()));
+	}
+
+	Material->PostEditChange();
+	Material->MarkPackageDirty();
+
+	// Save
+	bool bSaved = SaveMaterialPackage(Material);
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Set expression value on node '%s' (%s) in material '%s': %s"),
+		*NodeId, *ExprType, *MaterialName, *NewValueStr);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("material"), Material->GetName());
+	Result->SetStringField(TEXT("nodeId"), NodeId);
+	Result->SetStringField(TEXT("expressionType"), ExprType);
+	Result->SetStringField(TEXT("newValue"), NewValueStr);
+	Result->SetBoolField(TEXT("saved"), bSaved);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleMoveMaterialExpression — reposition a material graph node
+// ============================================================
+
+FString FBlueprintMCPServer::HandleMoveMaterialExpression(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString MaterialName = Json->GetStringField(TEXT("material"));
+	FString NodeId = Json->GetStringField(TEXT("nodeId"));
+
+	if (MaterialName.IsEmpty() || NodeId.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: material, nodeId"));
+	}
+
+	if (!Json->HasField(TEXT("posX")) || !Json->HasField(TEXT("posY")))
+	{
+		return MakeErrorJson(TEXT("Missing required fields: posX, posY"));
+	}
+
+	int32 PosX = (int32)Json->GetNumberField(TEXT("posX"));
+	int32 PosY = (int32)Json->GetNumberField(TEXT("posY"));
+
+	bool bDryRun = false;
+	Json->TryGetBoolField(TEXT("dryRun"), bDryRun);
+
+	// Load material
+	FString LoadError;
+	UMaterial* Material = LoadMaterialByName(MaterialName, LoadError);
+	if (!Material)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	if (!Material->MaterialGraph)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Material '%s' has no material graph"), *MaterialName));
+	}
+
+	// Find node by GUID
+	UMaterialGraphNode* TargetMatNode = nullptr;
+	for (UEdGraphNode* Node : Material->MaterialGraph->Nodes)
+	{
+		if (!Node) continue;
+		if (Node->NodeGuid.ToString() == NodeId)
+		{
+			TargetMatNode = Cast<UMaterialGraphNode>(Node);
+			break;
+		}
+	}
+
+	if (!TargetMatNode)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Node '%s' not found in material graph"), *NodeId));
+	}
+
+	if (bDryRun)
+	{
+		UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: [DRY RUN] Would move node '%s' to (%d, %d) in material '%s'"),
+			*NodeId, PosX, PosY, *MaterialName);
+
+		TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+		Result->SetBoolField(TEXT("success"), true);
+		Result->SetBoolField(TEXT("dryRun"), true);
+		Result->SetStringField(TEXT("material"), Material->GetName());
+		Result->SetStringField(TEXT("nodeId"), NodeId);
+		Result->SetNumberField(TEXT("posX"), PosX);
+		Result->SetNumberField(TEXT("posY"), PosY);
+		return JsonToString(Result);
+	}
+
+	// Set position on the graph node
+	TargetMatNode->NodePosX = PosX;
+	TargetMatNode->NodePosY = PosY;
+
+	// Also update the underlying expression position
+	if (TargetMatNode->MaterialExpression)
+	{
+		TargetMatNode->MaterialExpression->MaterialExpressionEditorX = PosX;
+		TargetMatNode->MaterialExpression->MaterialExpressionEditorY = PosY;
+	}
+
+	Material->PreEditChange(nullptr);
+	Material->PostEditChange();
+
+	// Save
+	bool bSaved = SaveMaterialPackage(Material);
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Moved node '%s' to (%d, %d) in material '%s' (saved: %s)"),
+		*NodeId, PosX, PosY, *MaterialName, bSaved ? TEXT("true") : TEXT("false"));
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("material"), Material->GetName());
+	Result->SetStringField(TEXT("nodeId"), NodeId);
+	Result->SetNumberField(TEXT("posX"), PosX);
+	Result->SetNumberField(TEXT("posY"), PosY);
+	Result->SetBoolField(TEXT("saved"), bSaved);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// Phase 4: Create Material Function
+// ============================================================
+
+// ============================================================
+// HandleCreateMaterialFunction — create a new UMaterialFunction asset
+// ============================================================
+
+FString FBlueprintMCPServer::HandleCreateMaterialFunction(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString Name = Json->GetStringField(TEXT("name"));
+	FString PackagePath = Json->GetStringField(TEXT("packagePath"));
+
+	if (Name.IsEmpty() || PackagePath.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: name, packagePath"));
+	}
+
+	if (!PackagePath.StartsWith(TEXT("/Game")))
+	{
+		return MakeErrorJson(TEXT("packagePath must start with '/Game'"));
+	}
+
+	// Check if asset already exists
+	FString FullAssetPath = PackagePath / Name;
+	if (FindMaterialFunctionAsset(Name) || FindMaterialFunctionAsset(FullAssetPath))
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Material Function '%s' already exists. Use a different name or delete the existing asset first."),
+			*Name));
+	}
+
+	FString Description;
+	Json->TryGetStringField(TEXT("description"), Description);
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Creating Material Function '%s' in '%s'"), *Name, *PackagePath);
+
+	// Create via IAssetTools + factory
+	IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();
+	UMaterialFunctionFactoryNew* Factory = NewObject<UMaterialFunctionFactoryNew>();
+	UObject* NewAsset = AssetTools.CreateAsset(Name, PackagePath, UMaterialFunction::StaticClass(), Factory);
+
+	if (!NewAsset)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Failed to create Material Function '%s' in '%s'"), *Name, *PackagePath));
+	}
+
+	UMaterialFunction* MF = Cast<UMaterialFunction>(NewAsset);
+	if (!MF)
+	{
+		return MakeErrorJson(TEXT("Created asset is not a UMaterialFunction"));
+	}
+
+	// Set optional description
+	if (!Description.IsEmpty())
+	{
+		MF->Description = Description;
+	}
+
+	// Save
+	bool bSaved = SaveGenericPackage(MF);
+
+	// Refresh asset cache
+	FAssetRegistryModule& ARM = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+	AllMaterialFunctionAssets.Empty();
+	ARM.Get().GetAssetsByClass(UMaterialFunction::StaticClass()->GetClassPathName(), AllMaterialFunctionAssets, false);
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Created Material Function '%s' (saved: %s)"),
+		*Name, bSaved ? TEXT("true") : TEXT("false"));
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("name"), Name);
+	Result->SetStringField(TEXT("path"), MF->GetPathName());
+	if (!Description.IsEmpty())
+	{
+		Result->SetStringField(TEXT("description"), Description);
+	}
+	Result->SetBoolField(TEXT("saved"), bSaved);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// Phase 5: Material Snapshot/Diff/Restore
+// ============================================================
+
+// ============================================================
+// HandleSnapshotMaterialGraph — snapshot current material graph state
+// ============================================================
+
+FString FBlueprintMCPServer::HandleSnapshotMaterialGraph(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString MaterialName = Json->GetStringField(TEXT("material"));
+	if (MaterialName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: material"));
+	}
+
+	// Load material
+	FString LoadError;
+	UMaterial* Material = LoadMaterialByName(MaterialName, LoadError);
+	if (!Material)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	if (!Material->MaterialGraph)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Material '%s' has no material graph"), *MaterialName));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Creating snapshot for material '%s'"), *MaterialName);
+
+	// Build the snapshot
+	FGraphSnapshot Snapshot;
+	Snapshot.SnapshotId = GenerateSnapshotId(MaterialName);
+	Snapshot.BlueprintName = Material->GetName();
+	Snapshot.BlueprintPath = Material->GetPathName();
+	Snapshot.CreatedAt = FDateTime::Now();
+
+	// Capture the material graph
+	FGraphSnapshotData GraphData = CaptureGraphSnapshot(Material->MaterialGraph);
+
+	int32 NodeCount = GraphData.Nodes.Num();
+	int32 ConnectionCount = GraphData.Connections.Num();
+
+	Snapshot.Graphs.Add(TEXT("MaterialGraph"), MoveTemp(GraphData));
+
+	// Store in material snapshots (separate from blueprint snapshots)
+	MaterialSnapshots.Add(Snapshot.SnapshotId, Snapshot);
+
+	// Prune old material snapshots
+	while (MaterialSnapshots.Num() > MaxSnapshots)
+	{
+		FString OldestId;
+		FDateTime OldestTime = FDateTime::MaxValue();
+
+		for (const auto& Pair : MaterialSnapshots)
+		{
+			if (Pair.Value.CreatedAt < OldestTime)
+			{
+				OldestTime = Pair.Value.CreatedAt;
+				OldestId = Pair.Key;
+			}
+		}
+
+		if (!OldestId.IsEmpty())
+		{
+			UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Pruning old material snapshot '%s'"), *OldestId);
+			MaterialSnapshots.Remove(OldestId);
+		}
+		else
+		{
+			break;
+		}
+	}
+
+	// Save to disk
+	SaveSnapshotToDisk(Snapshot.SnapshotId, Snapshot);
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Material snapshot '%s' created with %d nodes, %d connections"),
+		*Snapshot.SnapshotId, NodeCount, ConnectionCount);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("status"), TEXT("ok"));
+	Result->SetStringField(TEXT("snapshotId"), Snapshot.SnapshotId);
+	Result->SetStringField(TEXT("material"), Material->GetName());
+	Result->SetNumberField(TEXT("nodeCount"), NodeCount);
+	Result->SetNumberField(TEXT("connectionCount"), ConnectionCount);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleDiffMaterialGraph — diff current material graph against snapshot
+// ============================================================
+
+FString FBlueprintMCPServer::HandleDiffMaterialGraph(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString MaterialName = Json->GetStringField(TEXT("material"));
+	FString SnapshotId = Json->GetStringField(TEXT("snapshotId"));
+
+	if (MaterialName.IsEmpty() || SnapshotId.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: material, snapshotId"));
+	}
+
+	// Load snapshot from material snapshots (memory or disk)
+	FGraphSnapshot* SnapshotPtr = MaterialSnapshots.Find(SnapshotId);
+	FGraphSnapshot LoadedSnapshot;
+	if (!SnapshotPtr)
+	{
+		if (!LoadSnapshotFromDisk(SnapshotId, LoadedSnapshot))
+		{
+			return MakeErrorJson(FString::Printf(TEXT("Snapshot '%s' not found in memory or on disk"), *SnapshotId));
+		}
+		SnapshotPtr = &LoadedSnapshot;
+	}
+
+	// Load material
+	FString LoadError;
+	UMaterial* Material = LoadMaterialByName(MaterialName, LoadError);
+	if (!Material)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	if (!Material->MaterialGraph)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Material '%s' has no material graph"), *MaterialName));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Diffing material '%s' against snapshot '%s'"), *MaterialName, *SnapshotId);
+
+	// Capture current state
+	FGraphSnapshotData CurrentData = CaptureGraphSnapshot(Material->MaterialGraph);
+
+	auto MakeConnKey = [](const FString& SrcGuid, const FString& SrcPin, const FString& TgtGuid, const FString& TgtPin) -> FString
+	{
+		return FString::Printf(TEXT("%s|%s|%s|%s"), *SrcGuid, *SrcPin, *TgtGuid, *TgtPin);
+	};
+
+	TArray<TSharedPtr<FJsonValue>> SeveredArr;
+	TArray<TSharedPtr<FJsonValue>> NewConnsArr;
+	TArray<TSharedPtr<FJsonValue>> MissingNodesArr;
+
+	// Process the MaterialGraph from the snapshot
+	const FGraphSnapshotData* SnapDataPtr = SnapshotPtr->Graphs.Find(TEXT("MaterialGraph"));
+	if (!SnapDataPtr)
+	{
+		return MakeErrorJson(TEXT("Snapshot does not contain a MaterialGraph"));
+	}
+
+	const FGraphSnapshotData& SnapData = *SnapDataPtr;
+
+	// Build node lookup maps
+	TMap<FString, const FNodeRecord*> SnapNodeLookup;
+	for (const FNodeRecord& NR : SnapData.Nodes)
+	{
+		SnapNodeLookup.Add(NR.NodeGuid, &NR);
+	}
+
+	TMap<FString, const FNodeRecord*> CurNodeLookup;
+	for (const FNodeRecord& NR : CurrentData.Nodes)
+	{
+		CurNodeLookup.Add(NR.NodeGuid, &NR);
+	}
+
+	// Build connection sets
+	TSet<FString> SnapConnSet;
+	for (const FPinConnectionRecord& Conn : SnapData.Connections)
+	{
+		SnapConnSet.Add(MakeConnKey(Conn.SourceNodeGuid, Conn.SourcePinName, Conn.TargetNodeGuid, Conn.TargetPinName));
+	}
+
+	TSet<FString> CurrentConnSet;
+	for (const FPinConnectionRecord& Conn : CurrentData.Connections)
+	{
+		CurrentConnSet.Add(MakeConnKey(Conn.SourceNodeGuid, Conn.SourcePinName, Conn.TargetNodeGuid, Conn.TargetPinName));
+	}
+
+	// Find severed connections: in snapshot but not in current
+	for (const FPinConnectionRecord& Conn : SnapData.Connections)
+	{
+		FString Key = MakeConnKey(Conn.SourceNodeGuid, Conn.SourcePinName, Conn.TargetNodeGuid, Conn.TargetPinName);
+		if (!CurrentConnSet.Contains(Key))
+		{
+			TSharedRef<FJsonObject> SJ = MakeShared<FJsonObject>();
+			SJ->SetStringField(TEXT("sourceNodeGuid"), Conn.SourceNodeGuid);
+			SJ->SetStringField(TEXT("sourcePinName"), Conn.SourcePinName);
+			SJ->SetStringField(TEXT("targetNodeGuid"), Conn.TargetNodeGuid);
+			SJ->SetStringField(TEXT("targetPinName"), Conn.TargetPinName);
+
+			const FNodeRecord** SrcRec = SnapNodeLookup.Find(Conn.SourceNodeGuid);
+			if (SrcRec) SJ->SetStringField(TEXT("sourceNodeName"), (*SrcRec)->NodeTitle);
+			const FNodeRecord** TgtRec = SnapNodeLookup.Find(Conn.TargetNodeGuid);
+			if (TgtRec) SJ->SetStringField(TEXT("targetNodeName"), (*TgtRec)->NodeTitle);
+
+			SeveredArr.Add(MakeShared<FJsonValueObject>(SJ));
+		}
+	}
+
+	// Find new connections: in current but not in snapshot
+	for (const FPinConnectionRecord& Conn : CurrentData.Connections)
+	{
+		FString Key = MakeConnKey(Conn.SourceNodeGuid, Conn.SourcePinName, Conn.TargetNodeGuid, Conn.TargetPinName);
+		if (!SnapConnSet.Contains(Key))
+		{
+			TSharedRef<FJsonObject> NJ = MakeShared<FJsonObject>();
+			NJ->SetStringField(TEXT("sourceNodeGuid"), Conn.SourceNodeGuid);
+			NJ->SetStringField(TEXT("sourcePinName"), Conn.SourcePinName);
+			NJ->SetStringField(TEXT("targetNodeGuid"), Conn.TargetNodeGuid);
+			NJ->SetStringField(TEXT("targetPinName"), Conn.TargetPinName);
+
+			const FNodeRecord** SrcRec = CurNodeLookup.Find(Conn.SourceNodeGuid);
+			if (SrcRec) NJ->SetStringField(TEXT("sourceNodeName"), (*SrcRec)->NodeTitle);
+			const FNodeRecord** TgtRec = CurNodeLookup.Find(Conn.TargetNodeGuid);
+			if (TgtRec) NJ->SetStringField(TEXT("targetNodeName"), (*TgtRec)->NodeTitle);
+
+			NewConnsArr.Add(MakeShared<FJsonValueObject>(NJ));
+		}
+	}
+
+	// Find missing nodes: in snapshot but not in current
+	for (const FNodeRecord& SnapNode : SnapData.Nodes)
+	{
+		const FNodeRecord** CurNodePtr = CurNodeLookup.Find(SnapNode.NodeGuid);
+		if (!CurNodePtr)
+		{
+			TSharedRef<FJsonObject> MJ = MakeShared<FJsonObject>();
+			MJ->SetStringField(TEXT("nodeGuid"), SnapNode.NodeGuid);
+			MJ->SetStringField(TEXT("nodeClass"), SnapNode.NodeClass);
+			MJ->SetStringField(TEXT("nodeTitle"), SnapNode.NodeTitle);
+			MissingNodesArr.Add(MakeShared<FJsonValueObject>(MJ));
+		}
+	}
+
+	// Build result
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("status"), TEXT("ok"));
+	Result->SetStringField(TEXT("material"), Material->GetName());
+	Result->SetStringField(TEXT("snapshotId"), SnapshotId);
+	Result->SetArrayField(TEXT("severedConnections"), SeveredArr);
+	Result->SetArrayField(TEXT("newConnections"), NewConnsArr);
+	Result->SetArrayField(TEXT("missingNodes"), MissingNodesArr);
+
+	TSharedRef<FJsonObject> Summary = MakeShared<FJsonObject>();
+	Summary->SetNumberField(TEXT("severedConnections"), SeveredArr.Num());
+	Summary->SetNumberField(TEXT("newConnections"), NewConnsArr.Num());
+	Summary->SetNumberField(TEXT("missingNodes"), MissingNodesArr.Num());
+	Result->SetObjectField(TEXT("summary"), Summary);
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Material diff complete — %d severed, %d new, %d missing nodes"),
+		SeveredArr.Num(), NewConnsArr.Num(), MissingNodesArr.Num());
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleRestoreMaterialGraph — restore material graph connections from snapshot
+// ============================================================
+
+FString FBlueprintMCPServer::HandleRestoreMaterialGraph(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString MaterialName = Json->GetStringField(TEXT("material"));
+	FString SnapshotId = Json->GetStringField(TEXT("snapshotId"));
+
+	if (MaterialName.IsEmpty() || SnapshotId.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: material, snapshotId"));
+	}
+
+	bool bDryRun = false;
+	Json->TryGetBoolField(TEXT("dryRun"), bDryRun);
+
+	// Load snapshot from material snapshots (memory or disk)
+	FGraphSnapshot* SnapshotPtr = MaterialSnapshots.Find(SnapshotId);
+	FGraphSnapshot LoadedSnapshot;
+	if (!SnapshotPtr)
+	{
+		if (!LoadSnapshotFromDisk(SnapshotId, LoadedSnapshot))
+		{
+			return MakeErrorJson(FString::Printf(TEXT("Snapshot '%s' not found in memory or on disk"), *SnapshotId));
+		}
+		SnapshotPtr = &LoadedSnapshot;
+	}
+
+	// Load material
+	FString LoadError;
+	UMaterial* Material = LoadMaterialByName(MaterialName, LoadError);
+	if (!Material)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	if (!Material->MaterialGraph)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Material '%s' has no material graph"), *MaterialName));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Restoring material connections from snapshot '%s' for material '%s' (dryRun=%s)"),
+		*SnapshotId, *MaterialName, bDryRun ? TEXT("true") : TEXT("false"));
+
+	// Capture current state for comparison
+	FGraphSnapshotData CurrentData = CaptureGraphSnapshot(Material->MaterialGraph);
+
+	auto MakeConnKey = [](const FString& SrcGuid, const FString& SrcPin, const FString& TgtGuid, const FString& TgtPin) -> FString
+	{
+		return FString::Printf(TEXT("%s|%s|%s|%s"), *SrcGuid, *SrcPin, *TgtGuid, *TgtPin);
+	};
+
+	// Build current connection set
+	TSet<FString> CurrentConnSet;
+	for (const FPinConnectionRecord& Conn : CurrentData.Connections)
+	{
+		CurrentConnSet.Add(MakeConnKey(Conn.SourceNodeGuid, Conn.SourcePinName, Conn.TargetNodeGuid, Conn.TargetPinName));
+	}
+
+	// Build node lookup for the material graph
+	TMap<FString, UEdGraphNode*> NodeLookup;
+	for (UEdGraphNode* Node : Material->MaterialGraph->Nodes)
+	{
+		if (Node)
+		{
+			NodeLookup.Add(Node->NodeGuid.ToString(), Node);
+		}
+	}
+
+	const FGraphSnapshotData* SnapDataPtr = SnapshotPtr->Graphs.Find(TEXT("MaterialGraph"));
+	if (!SnapDataPtr)
+	{
+		return MakeErrorJson(TEXT("Snapshot does not contain a MaterialGraph"));
+	}
+
+	int32 Reconnected = 0;
+	int32 Failed = 0;
+	TArray<TSharedPtr<FJsonValue>> DetailsArr;
+
+	for (const FPinConnectionRecord& Conn : SnapDataPtr->Connections)
+	{
+		FString Key = MakeConnKey(Conn.SourceNodeGuid, Conn.SourcePinName, Conn.TargetNodeGuid, Conn.TargetPinName);
+		if (CurrentConnSet.Contains(Key)) continue; // Still connected, skip
+
+		TSharedRef<FJsonObject> Detail = MakeShared<FJsonObject>();
+		Detail->SetStringField(TEXT("sourcePinName"), Conn.SourcePinName);
+		Detail->SetStringField(TEXT("targetPinName"), Conn.TargetPinName);
+		Detail->SetStringField(TEXT("sourceNodeGuid"), Conn.SourceNodeGuid);
+		Detail->SetStringField(TEXT("targetNodeGuid"), Conn.TargetNodeGuid);
+
+		// Find source and target nodes
+		UEdGraphNode** SourceNodePtr = NodeLookup.Find(Conn.SourceNodeGuid);
+		UEdGraphNode** TargetNodePtr = NodeLookup.Find(Conn.TargetNodeGuid);
+
+		if (!SourceNodePtr || !*SourceNodePtr)
+		{
+			Detail->SetStringField(TEXT("result"), TEXT("failed"));
+			Detail->SetStringField(TEXT("reason"), FString::Printf(TEXT("Source node '%s' no longer exists"), *Conn.SourceNodeGuid));
+			Failed++;
+			DetailsArr.Add(MakeShared<FJsonValueObject>(Detail));
+			continue;
+		}
+		if (!TargetNodePtr || !*TargetNodePtr)
+		{
+			Detail->SetStringField(TEXT("result"), TEXT("failed"));
+			Detail->SetStringField(TEXT("reason"), FString::Printf(TEXT("Target node '%s' no longer exists"), *Conn.TargetNodeGuid));
+			Failed++;
+			DetailsArr.Add(MakeShared<FJsonValueObject>(Detail));
+			continue;
+		}
+
+		UEdGraphNode* SourceNode = *SourceNodePtr;
+		UEdGraphNode* TargetNode = *TargetNodePtr;
+
+		Detail->SetStringField(TEXT("sourceNodeName"), SourceNode->GetNodeTitle(ENodeTitleType::FullTitle).ToString());
+		Detail->SetStringField(TEXT("targetNodeName"), TargetNode->GetNodeTitle(ENodeTitleType::FullTitle).ToString());
+
+		// Find pins
+		UEdGraphPin* SourcePin = SourceNode->FindPin(FName(*Conn.SourcePinName));
+		UEdGraphPin* TargetPin = TargetNode->FindPin(FName(*Conn.TargetPinName));
+
+		if (!SourcePin)
+		{
+			Detail->SetStringField(TEXT("result"), TEXT("failed"));
+			Detail->SetStringField(TEXT("reason"), FString::Printf(TEXT("Source pin '%s' not found on node"), *Conn.SourcePinName));
+			Failed++;
+			DetailsArr.Add(MakeShared<FJsonValueObject>(Detail));
+			continue;
+		}
+		if (!TargetPin)
+		{
+			Detail->SetStringField(TEXT("result"), TEXT("failed"));
+			Detail->SetStringField(TEXT("reason"), FString::Printf(TEXT("Target pin '%s' not found on node"), *Conn.TargetPinName));
+			Failed++;
+			DetailsArr.Add(MakeShared<FJsonValueObject>(Detail));
+			continue;
+		}
+
+		if (bDryRun)
+		{
+			Detail->SetStringField(TEXT("result"), TEXT("would_reconnect"));
+			Reconnected++;
+			DetailsArr.Add(MakeShared<FJsonValueObject>(Detail));
+			continue;
+		}
+
+		// Try to reconnect via the schema
+		const UEdGraphSchema* Schema = Material->MaterialGraph->GetSchema();
+		if (!Schema)
+		{
+			Detail->SetStringField(TEXT("result"), TEXT("failed"));
+			Detail->SetStringField(TEXT("reason"), TEXT("Material graph schema not found"));
+			Failed++;
+			DetailsArr.Add(MakeShared<FJsonValueObject>(Detail));
+			continue;
+		}
+
+		bool bConnected = Schema->TryCreateConnection(SourcePin, TargetPin);
+		if (bConnected)
+		{
+			Detail->SetStringField(TEXT("result"), TEXT("reconnected"));
+			Reconnected++;
+		}
+		else
+		{
+			Detail->SetStringField(TEXT("result"), TEXT("failed"));
+			Detail->SetStringField(TEXT("reason"), TEXT("TryCreateConnection failed — types may be incompatible"));
+			Failed++;
+		}
+		DetailsArr.Add(MakeShared<FJsonValueObject>(Detail));
+	}
+
+	// Save if not dry run and we reconnected something
+	bool bSaved = false;
+	if (!bDryRun && Reconnected > 0)
+	{
+		Material->PreEditChange(nullptr);
+		Material->PostEditChange();
+		bSaved = SaveMaterialPackage(Material);
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Material restore complete — %d reconnected, %d failed, saved=%s"),
+		Reconnected, Failed, bSaved ? TEXT("true") : TEXT("false"));
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("status"), TEXT("ok"));
+	Result->SetStringField(TEXT("material"), Material->GetName());
+	Result->SetStringField(TEXT("snapshotId"), SnapshotId);
+	Result->SetNumberField(TEXT("reconnected"), Reconnected);
+	Result->SetNumberField(TEXT("failed"), Failed);
+	Result->SetArrayField(TEXT("details"), DetailsArr);
+	Result->SetBoolField(TEXT("saved"), bSaved);
+	Result->SetBoolField(TEXT("dryRun"), bDryRun);
+	return JsonToString(Result);
+}

--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_MaterialRead.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_MaterialRead.cpp
@@ -1,0 +1,869 @@
+#include "BlueprintMCPServer.h"
+#include "Materials/Material.h"
+#include "Materials/MaterialInstanceConstant.h"
+#include "Materials/MaterialFunction.h"
+#include "Materials/MaterialExpression.h"
+#include "Materials/MaterialExpressionScalarParameter.h"
+#include "Materials/MaterialExpressionVectorParameter.h"
+#include "Materials/MaterialExpressionTextureObjectParameter.h"
+#include "Materials/MaterialExpressionTextureSampleParameter2D.h"
+#include "Materials/MaterialExpressionStaticSwitchParameter.h"
+#include "Materials/MaterialExpressionConstant.h"
+#include "Materials/MaterialExpressionConstant3Vector.h"
+#include "Materials/MaterialExpressionConstant4Vector.h"
+#include "Materials/MaterialExpressionTextureSample.h"
+#include "Materials/MaterialExpressionTextureCoordinate.h"
+#include "Materials/MaterialExpressionComponentMask.h"
+#include "Materials/MaterialExpressionCustom.h"
+#include "Materials/MaterialExpressionFunctionInput.h"
+#include "Materials/MaterialExpressionFunctionOutput.h"
+#include "Materials/MaterialExpressionMaterialFunctionCall.h"
+#include "MaterialGraph/MaterialGraph.h"
+#include "MaterialGraph/MaterialGraphNode.h"
+#include "MaterialGraph/MaterialGraphNode_Root.h"
+#include "MaterialGraph/MaterialGraphSchema.h"
+#include "Kismet2/BlueprintEditorUtils.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "AssetRegistry/IAssetRegistry.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+#include "EdGraph/EdGraph.h"
+#include "EdGraph/EdGraphNode.h"
+
+// ============================================================
+// HandleListMaterials — list Material and MaterialInstance assets
+// ============================================================
+
+FString FBlueprintMCPServer::HandleListMaterials(const TMap<FString, FString>& Params)
+{
+	const FString* Filter = Params.Find(TEXT("filter"));
+	const FString* TypeFilter = Params.Find(TEXT("type"));
+
+	bool bIncludeMaterials = !TypeFilter || TypeFilter->IsEmpty() || *TypeFilter == TEXT("all") || *TypeFilter == TEXT("material");
+	bool bIncludeInstances = !TypeFilter || TypeFilter->IsEmpty() || *TypeFilter == TEXT("all") || *TypeFilter == TEXT("instance");
+
+	TArray<TSharedPtr<FJsonValue>> Entries;
+
+	if (bIncludeMaterials)
+	{
+		for (const FAssetData& Asset : AllMaterialAssets)
+		{
+			FString Name = Asset.AssetName.ToString();
+			FString Path = Asset.PackageName.ToString();
+
+			if (Filter && !Filter->IsEmpty())
+			{
+				if (!Name.Contains(*Filter, ESearchCase::IgnoreCase) &&
+					!Path.Contains(*Filter, ESearchCase::IgnoreCase))
+				{
+					continue;
+				}
+			}
+
+			TSharedRef<FJsonObject> Entry = MakeShared<FJsonObject>();
+			Entry->SetStringField(TEXT("name"), Name);
+			Entry->SetStringField(TEXT("path"), Path);
+			Entry->SetStringField(TEXT("type"), TEXT("Material"));
+			Entries.Add(MakeShared<FJsonValueObject>(Entry));
+		}
+	}
+
+	if (bIncludeInstances)
+	{
+		for (const FAssetData& Asset : AllMaterialInstanceAssets)
+		{
+			FString Name = Asset.AssetName.ToString();
+			FString Path = Asset.PackageName.ToString();
+
+			if (Filter && !Filter->IsEmpty())
+			{
+				if (!Name.Contains(*Filter, ESearchCase::IgnoreCase) &&
+					!Path.Contains(*Filter, ESearchCase::IgnoreCase))
+				{
+					continue;
+				}
+			}
+
+			TSharedRef<FJsonObject> Entry = MakeShared<FJsonObject>();
+			Entry->SetStringField(TEXT("name"), Name);
+			Entry->SetStringField(TEXT("path"), Path);
+			Entry->SetStringField(TEXT("type"), TEXT("MaterialInstance"));
+			Entries.Add(MakeShared<FJsonValueObject>(Entry));
+		}
+	}
+
+	int32 Total = AllMaterialAssets.Num() + AllMaterialInstanceAssets.Num();
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetNumberField(TEXT("count"), Entries.Num());
+	Result->SetNumberField(TEXT("total"), Total);
+	Result->SetArrayField(TEXT("materials"), Entries);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleGetMaterial — detailed info about a material or instance
+// ============================================================
+
+FString FBlueprintMCPServer::HandleGetMaterial(const TMap<FString, FString>& Params)
+{
+	const FString* Name = Params.Find(TEXT("name"));
+	if (!Name || Name->IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing 'name' parameter"));
+	}
+
+	FString DecodedName = UrlDecode(*Name);
+
+	// Try loading as UMaterial first
+	FString LoadError;
+	UMaterial* Material = LoadMaterialByName(DecodedName, LoadError);
+	if (Material)
+	{
+		UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: GetMaterial — loaded material '%s'"), *Material->GetName());
+
+		TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+		Result->SetStringField(TEXT("name"), Material->GetName());
+		Result->SetStringField(TEXT("path"), Material->GetPathName());
+		Result->SetStringField(TEXT("type"), TEXT("Material"));
+
+		// Material domain
+		FString DomainStr = TEXT("Unknown");
+		if (const UEnum* DomainEnum = StaticEnum<EMaterialDomain>())
+		{
+			DomainStr = DomainEnum->GetNameStringByValue((int64)Material->MaterialDomain);
+		}
+		Result->SetStringField(TEXT("domain"), DomainStr);
+
+		// Blend mode
+		FString BlendModeStr = TEXT("Unknown");
+		if (const UEnum* BlendEnum = StaticEnum<EBlendMode>())
+		{
+			BlendModeStr = BlendEnum->GetNameStringByValue((int64)Material->BlendMode);
+		}
+		Result->SetStringField(TEXT("blendMode"), BlendModeStr);
+
+		// Shading models
+		TArray<TSharedPtr<FJsonValue>> ShadingModels;
+		FMaterialShadingModelField SMField = Material->GetShadingModels();
+		if (const UEnum* SMEnum = StaticEnum<EMaterialShadingModel>())
+		{
+			for (int32 i = 0; i < SMEnum->NumEnums() - 1; ++i)
+			{
+				EMaterialShadingModel SM = (EMaterialShadingModel)SMEnum->GetValueByIndex(i);
+				if (SMField.HasShadingModel(SM))
+				{
+					ShadingModels.Add(MakeShared<FJsonValueString>(SMEnum->GetNameStringByIndex(i)));
+				}
+			}
+		}
+		Result->SetArrayField(TEXT("shadingModels"), ShadingModels);
+
+		// Two-sided
+		Result->SetBoolField(TEXT("twoSided"), Material->IsTwoSided());
+
+		// Expression count
+		auto Expressions = Material->GetExpressions();
+		Result->SetNumberField(TEXT("expressionCount"), Expressions.Num());
+
+		// Parameters — iterate expressions for parameter types
+		TArray<TSharedPtr<FJsonValue>> Parameters;
+		for (UMaterialExpression* Expr : Expressions)
+		{
+			if (!Expr) continue;
+
+			TSharedRef<FJsonObject> ParamObj = MakeShared<FJsonObject>();
+			bool bIsParam = false;
+
+			if (auto* SP = Cast<UMaterialExpressionScalarParameter>(Expr))
+			{
+				bIsParam = true;
+				ParamObj->SetStringField(TEXT("name"), SP->ParameterName.ToString());
+				ParamObj->SetStringField(TEXT("type"), TEXT("Scalar"));
+				ParamObj->SetStringField(TEXT("group"), SP->Group.ToString());
+				ParamObj->SetNumberField(TEXT("defaultValue"), SP->DefaultValue);
+			}
+			else if (auto* VP = Cast<UMaterialExpressionVectorParameter>(Expr))
+			{
+				bIsParam = true;
+				ParamObj->SetStringField(TEXT("name"), VP->ParameterName.ToString());
+				ParamObj->SetStringField(TEXT("type"), TEXT("Vector"));
+				ParamObj->SetStringField(TEXT("group"), VP->Group.ToString());
+				TSharedRef<FJsonObject> DefVal = MakeShared<FJsonObject>();
+				DefVal->SetNumberField(TEXT("r"), VP->DefaultValue.R);
+				DefVal->SetNumberField(TEXT("g"), VP->DefaultValue.G);
+				DefVal->SetNumberField(TEXT("b"), VP->DefaultValue.B);
+				DefVal->SetNumberField(TEXT("a"), VP->DefaultValue.A);
+				ParamObj->SetObjectField(TEXT("defaultValue"), DefVal);
+			}
+			else if (auto* TP = Cast<UMaterialExpressionTextureSampleParameter2D>(Expr))
+			{
+				bIsParam = true;
+				ParamObj->SetStringField(TEXT("name"), TP->ParameterName.ToString());
+				ParamObj->SetStringField(TEXT("type"), TEXT("Texture"));
+				ParamObj->SetStringField(TEXT("group"), TP->Group.ToString());
+				if (TP->Texture)
+					ParamObj->SetStringField(TEXT("defaultValue"), TP->Texture->GetPathName());
+			}
+			else if (auto* SSP = Cast<UMaterialExpressionStaticSwitchParameter>(Expr))
+			{
+				bIsParam = true;
+				ParamObj->SetStringField(TEXT("name"), SSP->ParameterName.ToString());
+				ParamObj->SetStringField(TEXT("type"), TEXT("StaticSwitch"));
+				ParamObj->SetStringField(TEXT("group"), SSP->Group.ToString());
+				ParamObj->SetBoolField(TEXT("defaultValue"), SSP->DefaultValue);
+			}
+
+			if (bIsParam)
+			{
+				Parameters.Add(MakeShared<FJsonValueObject>(ParamObj));
+			}
+		}
+		Result->SetArrayField(TEXT("parameters"), Parameters);
+
+		// Referenced textures
+		TArray<TSharedPtr<FJsonValue>> ReferencedTextures;
+		auto RefTexObjs = Material->GetReferencedTextures();
+		for (const TObjectPtr<UObject>& TexObj : RefTexObjs)
+		{
+			if (TexObj)
+			{
+				ReferencedTextures.Add(MakeShared<FJsonValueString>(TexObj->GetPathName()));
+			}
+		}
+		Result->SetArrayField(TEXT("referencedTextures"), ReferencedTextures);
+
+		// Graph node count
+		int32 GraphNodeCount = 0;
+		if (Material->MaterialGraph)
+		{
+			GraphNodeCount = Material->MaterialGraph->Nodes.Num();
+		}
+		Result->SetNumberField(TEXT("graphNodeCount"), GraphNodeCount);
+
+		return JsonToString(Result);
+	}
+
+	// Try loading as MaterialInstance
+	FString MILoadError;
+	UMaterialInstanceConstant* MI = LoadMaterialInstanceByName(DecodedName, MILoadError);
+	if (MI)
+	{
+		UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: GetMaterial — loaded material instance '%s'"), *MI->GetName());
+
+		TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+		Result->SetStringField(TEXT("name"), MI->GetName());
+		Result->SetStringField(TEXT("path"), MI->GetPathName());
+		Result->SetStringField(TEXT("type"), TEXT("MaterialInstance"));
+
+		if (MI->Parent)
+		{
+			Result->SetStringField(TEXT("parent"), MI->Parent->GetName());
+			Result->SetStringField(TEXT("parentPath"), MI->Parent->GetPathName());
+		}
+
+		// Overridden parameters
+		TArray<TSharedPtr<FJsonValue>> OverriddenParams;
+
+		// Scalar parameters
+		for (const FScalarParameterValue& Param : MI->ScalarParameterValues)
+		{
+			TSharedRef<FJsonObject> PObj = MakeShared<FJsonObject>();
+			PObj->SetStringField(TEXT("name"), Param.ParameterInfo.Name.ToString());
+			PObj->SetStringField(TEXT("type"), TEXT("Scalar"));
+			PObj->SetNumberField(TEXT("value"), Param.ParameterValue);
+			OverriddenParams.Add(MakeShared<FJsonValueObject>(PObj));
+		}
+
+		// Vector parameters
+		for (const FVectorParameterValue& Param : MI->VectorParameterValues)
+		{
+			TSharedRef<FJsonObject> PObj = MakeShared<FJsonObject>();
+			PObj->SetStringField(TEXT("name"), Param.ParameterInfo.Name.ToString());
+			PObj->SetStringField(TEXT("type"), TEXT("Vector"));
+			TSharedRef<FJsonObject> Val = MakeShared<FJsonObject>();
+			Val->SetNumberField(TEXT("r"), Param.ParameterValue.R);
+			Val->SetNumberField(TEXT("g"), Param.ParameterValue.G);
+			Val->SetNumberField(TEXT("b"), Param.ParameterValue.B);
+			Val->SetNumberField(TEXT("a"), Param.ParameterValue.A);
+			PObj->SetObjectField(TEXT("value"), Val);
+			OverriddenParams.Add(MakeShared<FJsonValueObject>(PObj));
+		}
+
+		// Texture parameters
+		for (const FTextureParameterValue& Param : MI->TextureParameterValues)
+		{
+			TSharedRef<FJsonObject> PObj = MakeShared<FJsonObject>();
+			PObj->SetStringField(TEXT("name"), Param.ParameterInfo.Name.ToString());
+			PObj->SetStringField(TEXT("type"), TEXT("Texture"));
+			if (Param.ParameterValue)
+				PObj->SetStringField(TEXT("value"), Param.ParameterValue->GetPathName());
+			else
+				PObj->SetStringField(TEXT("value"), TEXT("None"));
+			OverriddenParams.Add(MakeShared<FJsonValueObject>(PObj));
+		}
+
+		// Static switch parameters
+		for (const FStaticSwitchParameter& Param : MI->GetStaticParameters().StaticSwitchParameters)
+		{
+			TSharedRef<FJsonObject> PObj = MakeShared<FJsonObject>();
+			PObj->SetStringField(TEXT("name"), Param.ParameterInfo.Name.ToString());
+			PObj->SetStringField(TEXT("type"), TEXT("StaticSwitch"));
+			PObj->SetBoolField(TEXT("value"), Param.Value);
+			PObj->SetBoolField(TEXT("overridden"), Param.bOverride);
+			OverriddenParams.Add(MakeShared<FJsonValueObject>(PObj));
+		}
+
+		Result->SetArrayField(TEXT("overriddenParameters"), OverriddenParams);
+
+		return JsonToString(Result);
+	}
+
+	return MakeErrorJson(FString::Printf(TEXT("Material or MaterialInstance '%s' not found. Use list_materials to see available assets."), *DecodedName));
+}
+
+// ============================================================
+// HandleGetMaterialGraph — serialized graph for a material
+// ============================================================
+
+FString FBlueprintMCPServer::HandleGetMaterialGraph(const TMap<FString, FString>& Params)
+{
+	const FString* Name = Params.Find(TEXT("name"));
+	if (!Name || Name->IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing 'name' parameter"));
+	}
+
+	FString DecodedName = UrlDecode(*Name);
+
+	FString LoadError;
+	UMaterial* Material = LoadMaterialByName(DecodedName, LoadError);
+	if (!Material)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: GetMaterialGraph — material '%s'"), *Material->GetName());
+
+	// Ensure the material graph is built
+	if (!Material->MaterialGraph)
+	{
+		UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: GetMaterialGraph — MaterialGraph is null, attempting rebuild"));
+		// The material graph is built lazily by the material editor; force-create it
+		Material->MaterialGraph = CastChecked<UMaterialGraph>(
+			FBlueprintEditorUtils::CreateNewGraph(Material, NAME_None, UMaterialGraph::StaticClass(), UMaterialGraphSchema::StaticClass()));
+		Material->MaterialGraph->Material = Material;
+		Material->MaterialGraph->RebuildGraph();
+	}
+
+	if (!Material->MaterialGraph)
+	{
+		return MakeErrorJson(TEXT("Could not build MaterialGraph for this material"));
+	}
+
+	TSharedPtr<FJsonObject> GraphJson = SerializeGraph(Material->MaterialGraph);
+	if (!GraphJson.IsValid())
+	{
+		return MakeErrorJson(TEXT("Failed to serialize material graph"));
+	}
+
+	// Add material name context
+	GraphJson->SetStringField(TEXT("material"), Material->GetName());
+	GraphJson->SetStringField(TEXT("materialPath"), Material->GetPathName());
+
+	return JsonToString(GraphJson.ToSharedRef());
+}
+
+// ============================================================
+// HandleDescribeMaterial — human-readable material description
+// ============================================================
+
+FString FBlueprintMCPServer::HandleDescribeMaterial(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString MaterialName = Json->GetStringField(TEXT("material"));
+	if (MaterialName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: material"));
+	}
+
+	FString LoadError;
+	UMaterial* Material = LoadMaterialByName(MaterialName, LoadError);
+	if (!Material)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: DescribeMaterial — '%s'"), *Material->GetName());
+
+	// Ensure material graph is built
+	if (!Material->MaterialGraph)
+	{
+		Material->MaterialGraph = CastChecked<UMaterialGraph>(
+			FBlueprintEditorUtils::CreateNewGraph(Material, NAME_None, UMaterialGraph::StaticClass(), UMaterialGraphSchema::StaticClass()));
+		Material->MaterialGraph->Material = Material;
+		Material->MaterialGraph->RebuildGraph();
+	}
+
+	if (!Material->MaterialGraph)
+	{
+		return MakeErrorJson(TEXT("Could not build MaterialGraph for this material"));
+	}
+
+	// Recursive helper: trace backwards from a pin and build a description string
+	TFunction<FString(UEdGraphPin*, int32)> TracePin = [&TracePin](UEdGraphPin* Pin, int32 Depth) -> FString
+	{
+		if (!Pin || Depth > 10)
+			return TEXT("(unknown)");
+
+		// If no connections, report as unconnected
+		if (Pin->LinkedTo.Num() == 0)
+		{
+			if (!Pin->DefaultValue.IsEmpty())
+				return FString::Printf(TEXT("(default: %s)"), *Pin->DefaultValue);
+			return TEXT("(unconnected)");
+		}
+
+		TArray<FString> Sources;
+		for (UEdGraphPin* LinkedPin : Pin->LinkedTo)
+		{
+			if (!LinkedPin || !LinkedPin->GetOwningNode()) continue;
+
+			UEdGraphNode* SourceNode = LinkedPin->GetOwningNode();
+			FString NodeDesc;
+
+			// Check if this is a material graph node
+			if (UMaterialGraphNode* MatNode = Cast<UMaterialGraphNode>(SourceNode))
+			{
+				UMaterialExpression* Expr = MatNode->MaterialExpression;
+				if (!Expr)
+				{
+					NodeDesc = TEXT("(null expression)");
+				}
+				else if (auto* SP = Cast<UMaterialExpressionScalarParameter>(Expr))
+				{
+					NodeDesc = FString::Printf(TEXT("ScalarParam \"%s\" (default: %.4f)"), *SP->ParameterName.ToString(), SP->DefaultValue);
+				}
+				else if (auto* VP = Cast<UMaterialExpressionVectorParameter>(Expr))
+				{
+					NodeDesc = FString::Printf(TEXT("VectorParam \"%s\" (default: R=%.2f G=%.2f B=%.2f A=%.2f)"),
+						*VP->ParameterName.ToString(), VP->DefaultValue.R, VP->DefaultValue.G, VP->DefaultValue.B, VP->DefaultValue.A);
+				}
+				else if (auto* TP = Cast<UMaterialExpressionTextureSampleParameter2D>(Expr))
+				{
+					FString TexName = TP->Texture ? TP->Texture->GetName() : TEXT("None");
+					NodeDesc = FString::Printf(TEXT("TextureParam \"%s\" (%s)"), *TP->ParameterName.ToString(), *TexName);
+				}
+				else if (auto* SSP = Cast<UMaterialExpressionStaticSwitchParameter>(Expr))
+				{
+					NodeDesc = FString::Printf(TEXT("StaticSwitchParam \"%s\" (default: %s)"),
+						*SSP->ParameterName.ToString(), SSP->DefaultValue ? TEXT("true") : TEXT("false"));
+				}
+				else if (auto* SC = Cast<UMaterialExpressionConstant>(Expr))
+				{
+					NodeDesc = FString::Printf(TEXT("Constant(%.4f)"), SC->R);
+				}
+				else if (auto* C3 = Cast<UMaterialExpressionConstant3Vector>(Expr))
+				{
+					NodeDesc = FString::Printf(TEXT("Constant3(R=%.2f G=%.2f B=%.2f)"), C3->Constant.R, C3->Constant.G, C3->Constant.B);
+				}
+				else if (auto* C4 = Cast<UMaterialExpressionConstant4Vector>(Expr))
+				{
+					NodeDesc = FString::Printf(TEXT("Constant4(R=%.2f G=%.2f B=%.2f A=%.2f)"), C4->Constant.R, C4->Constant.G, C4->Constant.B, C4->Constant.A);
+				}
+				else if (auto* TS = Cast<UMaterialExpressionTextureSample>(Expr))
+				{
+					FString TexName = TS->Texture ? TS->Texture->GetName() : TEXT("None");
+					NodeDesc = FString::Printf(TEXT("TextureSample(%s)"), *TexName);
+				}
+				else if (auto* MFC = Cast<UMaterialExpressionMaterialFunctionCall>(Expr))
+				{
+					FString FuncName = MFC->MaterialFunction ? MFC->MaterialFunction->GetName() : TEXT("None");
+					NodeDesc = FString::Printf(TEXT("FunctionCall(%s)"), *FuncName);
+				}
+				else
+				{
+					NodeDesc = Expr->GetClass()->GetName();
+				}
+
+				// If the source node has input pins with connections, recurse
+				TArray<FString> InputDescs;
+				for (UEdGraphPin* InputPin : SourceNode->Pins)
+				{
+					if (!InputPin || InputPin->Direction != EGPD_Input || InputPin->LinkedTo.Num() == 0) continue;
+					FString InputDesc = TracePin(InputPin, Depth + 1);
+					InputDescs.Add(InputDesc);
+				}
+
+				if (InputDescs.Num() > 0)
+				{
+					NodeDesc += TEXT(" <- (") + FString::Join(InputDescs, TEXT(", ")) + TEXT(")");
+				}
+			}
+			else
+			{
+				// Non-material node (e.g., root, comment), just use title
+				NodeDesc = SourceNode->GetNodeTitle(ENodeTitleType::FullTitle).ToString();
+			}
+
+			Sources.Add(NodeDesc);
+		}
+
+		if (Sources.Num() == 1)
+			return Sources[0];
+
+		return TEXT("(") + FString::Join(Sources, TEXT(", ")) + TEXT(")");
+	};
+
+	// Find root node and trace each input
+	TArray<TSharedPtr<FJsonValue>> InputDescriptions;
+
+	UMaterialGraphNode_Root* RootNode = nullptr;
+	for (UEdGraphNode* Node : Material->MaterialGraph->Nodes)
+	{
+		RootNode = Cast<UMaterialGraphNode_Root>(Node);
+		if (RootNode) break;
+	}
+
+	if (!RootNode)
+	{
+		return MakeErrorJson(TEXT("Could not find root node in material graph"));
+	}
+
+	for (UEdGraphPin* Pin : RootNode->Pins)
+	{
+		if (!Pin || Pin->Direction != EGPD_Input) continue;
+
+		FString PinName = Pin->PinName.ToString();
+		FString Description;
+
+		if (Pin->LinkedTo.Num() == 0)
+		{
+			Description = TEXT("(unconnected)");
+		}
+		else
+		{
+			Description = TracePin(Pin, 0);
+		}
+
+		TSharedRef<FJsonObject> InputObj = MakeShared<FJsonObject>();
+		InputObj->SetStringField(TEXT("input"), PinName);
+		InputObj->SetStringField(TEXT("chain"), Description);
+		InputObj->SetBoolField(TEXT("connected"), Pin->LinkedTo.Num() > 0);
+		InputDescriptions.Add(MakeShared<FJsonValueObject>(InputObj));
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("material"), Material->GetName());
+	Result->SetStringField(TEXT("materialPath"), Material->GetPathName());
+	Result->SetArrayField(TEXT("inputs"), InputDescriptions);
+
+	// Also include a compact text description
+	FString TextDesc;
+	for (const TSharedPtr<FJsonValue>& Val : InputDescriptions)
+	{
+		TSharedPtr<FJsonObject> Obj = Val->AsObject();
+		if (!Obj.IsValid()) continue;
+		FString InputName = Obj->GetStringField(TEXT("input"));
+		FString Chain = Obj->GetStringField(TEXT("chain"));
+		bool bConnected = Obj->GetBoolField(TEXT("connected"));
+		if (bConnected)
+		{
+			TextDesc += FString::Printf(TEXT("%s <- %s\n"), *InputName, *Chain);
+		}
+	}
+	if (!TextDesc.IsEmpty())
+	{
+		Result->SetStringField(TEXT("description"), TextDesc);
+	}
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleSearchMaterials — search expressions and parameters
+// ============================================================
+
+FString FBlueprintMCPServer::HandleSearchMaterials(const TMap<FString, FString>& Params)
+{
+	const FString* Query = Params.Find(TEXT("query"));
+	if (!Query || Query->IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing 'query' parameter"));
+	}
+
+	FString DecodedQuery = UrlDecode(*Query);
+
+	int32 MaxResults = 50;
+	if (const FString* M = Params.Find(TEXT("maxResults")))
+	{
+		MaxResults = FMath::Clamp(FCString::Atoi(**M), 1, 200);
+	}
+
+	TArray<TSharedPtr<FJsonValue>> Results;
+
+	for (const FAssetData& Asset : AllMaterialAssets)
+	{
+		if (Results.Num() >= MaxResults) break;
+
+		FString MatName = Asset.AssetName.ToString();
+
+		// Check material name first
+		bool bNameMatch = MatName.Contains(DecodedQuery, ESearchCase::IgnoreCase);
+
+		UMaterial* Material = Cast<UMaterial>(const_cast<FAssetData&>(Asset).GetAsset());
+		if (!Material) continue;
+
+		auto Expressions = Material->GetExpressions();
+
+		if (bNameMatch)
+		{
+			// Add a match for the material itself
+			TSharedRef<FJsonObject> R = MakeShared<FJsonObject>();
+			R->SetStringField(TEXT("material"), MatName);
+			R->SetStringField(TEXT("materialPath"), Asset.PackageName.ToString());
+			R->SetStringField(TEXT("matchType"), TEXT("materialName"));
+			Results.Add(MakeShared<FJsonValueObject>(R));
+		}
+
+		// Search expressions
+		for (UMaterialExpression* Expr : Expressions)
+		{
+			if (!Expr || Results.Num() >= MaxResults) continue;
+
+			FString ExprDesc = Expr->GetDescription();
+			FString ExprClass = Expr->GetClass()->GetName();
+
+			// Check parameter name
+			FString ParamName;
+			if (auto* SP = Cast<UMaterialExpressionScalarParameter>(Expr))
+				ParamName = SP->ParameterName.ToString();
+			else if (auto* VP = Cast<UMaterialExpressionVectorParameter>(Expr))
+				ParamName = VP->ParameterName.ToString();
+			else if (auto* TP = Cast<UMaterialExpressionTextureSampleParameter2D>(Expr))
+				ParamName = TP->ParameterName.ToString();
+			else if (auto* SSP = Cast<UMaterialExpressionStaticSwitchParameter>(Expr))
+				ParamName = SSP->ParameterName.ToString();
+
+			bool bExprMatch = ExprDesc.Contains(DecodedQuery, ESearchCase::IgnoreCase) ||
+				ExprClass.Contains(DecodedQuery, ESearchCase::IgnoreCase) ||
+				(!ParamName.IsEmpty() && ParamName.Contains(DecodedQuery, ESearchCase::IgnoreCase));
+
+			if (bExprMatch)
+			{
+				TSharedRef<FJsonObject> R = MakeShared<FJsonObject>();
+				R->SetStringField(TEXT("material"), MatName);
+				R->SetStringField(TEXT("materialPath"), Asset.PackageName.ToString());
+				R->SetStringField(TEXT("matchType"), TEXT("expression"));
+				R->SetStringField(TEXT("expressionClass"), ExprClass);
+				if (!ExprDesc.IsEmpty())
+					R->SetStringField(TEXT("description"), ExprDesc);
+				if (!ParamName.IsEmpty())
+					R->SetStringField(TEXT("parameterName"), ParamName);
+				Results.Add(MakeShared<FJsonValueObject>(R));
+			}
+		}
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("query"), DecodedQuery);
+	Result->SetNumberField(TEXT("resultCount"), Results.Num());
+	Result->SetArrayField(TEXT("results"), Results);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleFindMaterialReferences — find assets referencing a material
+// ============================================================
+
+FString FBlueprintMCPServer::HandleFindMaterialReferences(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString MaterialName = Json->GetStringField(TEXT("material"));
+	if (MaterialName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: material"));
+	}
+
+	// Try to find the material's package path
+	FString PackagePath;
+	FAssetData* MatAsset = FindMaterialAsset(MaterialName);
+	if (MatAsset)
+	{
+		PackagePath = MatAsset->PackageName.ToString();
+	}
+	else
+	{
+		// Try material instance
+		FAssetData* MIAsset = FindMaterialInstanceAsset(MaterialName);
+		if (MIAsset)
+		{
+			PackagePath = MIAsset->PackageName.ToString();
+		}
+	}
+
+	if (PackagePath.IsEmpty())
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Material '%s' not found. Use list_materials to see available assets."), *MaterialName));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: FindMaterialReferences — '%s' (package: %s)"), *MaterialName, *PackagePath);
+
+	IAssetRegistry& Registry = *IAssetRegistry::Get();
+
+	TArray<FName> Referencers;
+	Registry.GetReferencers(FName(*PackagePath), Referencers);
+
+	TArray<TSharedPtr<FJsonValue>> RefArray;
+	for (const FName& Ref : Referencers)
+	{
+		FString RefStr = Ref.ToString();
+		// Skip self-reference
+		if (RefStr == PackagePath) continue;
+		RefArray.Add(MakeShared<FJsonValueString>(RefStr));
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("material"), MaterialName);
+	Result->SetStringField(TEXT("packagePath"), PackagePath);
+	Result->SetNumberField(TEXT("referencerCount"), RefArray.Num());
+	Result->SetArrayField(TEXT("referencers"), RefArray);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleListMaterialFunctions — list MaterialFunction assets
+// ============================================================
+
+FString FBlueprintMCPServer::HandleListMaterialFunctions(const TMap<FString, FString>& Params)
+{
+	const FString* Filter = Params.Find(TEXT("filter"));
+
+	TArray<TSharedPtr<FJsonValue>> Entries;
+
+	for (const FAssetData& Asset : AllMaterialFunctionAssets)
+	{
+		FString Name = Asset.AssetName.ToString();
+		FString Path = Asset.PackageName.ToString();
+
+		if (Filter && !Filter->IsEmpty())
+		{
+			if (!Name.Contains(*Filter, ESearchCase::IgnoreCase) &&
+				!Path.Contains(*Filter, ESearchCase::IgnoreCase))
+			{
+				continue;
+			}
+		}
+
+		TSharedRef<FJsonObject> Entry = MakeShared<FJsonObject>();
+		Entry->SetStringField(TEXT("name"), Name);
+		Entry->SetStringField(TEXT("path"), Path);
+		Entries.Add(MakeShared<FJsonValueObject>(Entry));
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetNumberField(TEXT("count"), Entries.Num());
+	Result->SetNumberField(TEXT("total"), AllMaterialFunctionAssets.Num());
+	Result->SetArrayField(TEXT("functions"), Entries);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleGetMaterialFunction — detailed info about a material function
+// ============================================================
+
+FString FBlueprintMCPServer::HandleGetMaterialFunction(const TMap<FString, FString>& Params)
+{
+	const FString* Name = Params.Find(TEXT("name"));
+	if (!Name || Name->IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing 'name' parameter"));
+	}
+
+	FString DecodedName = UrlDecode(*Name);
+
+	FString LoadError;
+	UMaterialFunction* MF = LoadMaterialFunctionByName(DecodedName, LoadError);
+	if (!MF)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: GetMaterialFunction — '%s'"), *MF->GetName());
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("name"), MF->GetName());
+	Result->SetStringField(TEXT("path"), MF->GetPathName());
+	Result->SetStringField(TEXT("description"), MF->GetDescription());
+
+	// Expression count
+	auto Expressions = MF->GetExpressions();
+	Result->SetNumberField(TEXT("expressionCount"), Expressions.Num());
+
+	// List function inputs and outputs from expressions
+	TArray<TSharedPtr<FJsonValue>> Inputs;
+	TArray<TSharedPtr<FJsonValue>> Outputs;
+	TArray<TSharedPtr<FJsonValue>> ExpressionList;
+
+	{
+		for (UMaterialExpression* Expr : Expressions)
+		{
+			if (!Expr) continue;
+
+			if (auto* FI = Cast<UMaterialExpressionFunctionInput>(Expr))
+			{
+				TSharedRef<FJsonObject> InputObj = MakeShared<FJsonObject>();
+				InputObj->SetStringField(TEXT("name"), FI->InputName.ToString());
+				InputObj->SetStringField(TEXT("type"), TEXT("FunctionInput"));
+				InputObj->SetNumberField(TEXT("posX"), FI->MaterialExpressionEditorX);
+				InputObj->SetNumberField(TEXT("posY"), FI->MaterialExpressionEditorY);
+				Inputs.Add(MakeShared<FJsonValueObject>(InputObj));
+			}
+			else if (auto* FO = Cast<UMaterialExpressionFunctionOutput>(Expr))
+			{
+				TSharedRef<FJsonObject> OutputObj = MakeShared<FJsonObject>();
+				OutputObj->SetStringField(TEXT("name"), FO->OutputName.ToString());
+				OutputObj->SetStringField(TEXT("type"), TEXT("FunctionOutput"));
+				OutputObj->SetNumberField(TEXT("posX"), FO->MaterialExpressionEditorX);
+				OutputObj->SetNumberField(TEXT("posY"), FO->MaterialExpressionEditorY);
+				Outputs.Add(MakeShared<FJsonValueObject>(OutputObj));
+			}
+
+			// Serialize every expression
+			TSharedPtr<FJsonObject> ExprJson = SerializeMaterialExpression(Expr);
+			if (ExprJson.IsValid())
+			{
+				ExpressionList.Add(MakeShared<FJsonValueObject>(ExprJson.ToSharedRef()));
+			}
+		}
+	}
+
+	Result->SetArrayField(TEXT("inputs"), Inputs);
+	Result->SetArrayField(TEXT("outputs"), Outputs);
+	Result->SetArrayField(TEXT("expressions"), ExpressionList);
+
+	// If the function has an editor graph, serialize it
+	UEdGraph* FuncGraph = MF->MaterialGraph;
+	if (FuncGraph)
+	{
+		TSharedPtr<FJsonObject> GraphJson = SerializeGraph(FuncGraph);
+		if (GraphJson.IsValid())
+		{
+			Result->SetObjectField(TEXT("graph"), GraphJson);
+		}
+	}
+
+	return JsonToString(Result);
+}

--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_Params.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_Params.cpp
@@ -231,8 +231,14 @@ FString FBlueprintMCPServer::HandleChangeFunctionParamType(const FString& Body)
 	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Changing param '%s' in %s '%s' of '%s' to %s"),
 		*ParamName, *FoundNodeType, *FunctionName, *BlueprintName, *NewTypeName);
 
-	// Reconstruct the node to update output pins with the new type
-	EntryNode->ReconstructNode();
+	// Reconstruct the node to update output pins with the new type (use schema for MinimalAPI compat)
+	if (UEdGraph* OwningGraph = EntryNode->GetGraph())
+	{
+		if (const UEdGraphSchema* Schema = OwningGraph->GetSchema())
+		{
+			Schema->ReconstructNode(*EntryNode);
+		}
+	}
 
 	// Save
 	bool bSaved = SaveBlueprintPackage(BP);
@@ -403,8 +409,14 @@ FString FBlueprintMCPServer::HandleRemoveFunctionParameter(const FString& Body)
 	// Remove the pin
 	EntryNode->UserDefinedPins.RemoveAt(RemovedIndex);
 
-	// Reconstruct the node to update output pins
-	EntryNode->ReconstructNode();
+	// Reconstruct the node to update output pins (use schema for MinimalAPI compat)
+	if (UEdGraph* OwningGraph = EntryNode->GetGraph())
+	{
+		if (const UEdGraphSchema* Schema = OwningGraph->GetSchema())
+		{
+			Schema->ReconstructNode(*EntryNode);
+		}
+	}
 
 	// Save
 	bool bSaved = SaveBlueprintPackage(BP);

--- a/Tools/src/index.ts
+++ b/Tools/src/index.ts
@@ -17,6 +17,8 @@ import { registerUtilityTools } from "./tools/utility.js";
 import { registerDiscoveryTools } from "./tools/discovery.js";
 import { registerDiffBlueprintsTools } from "./tools/diff-blueprints.js";
 import { registerUserTypeTools } from "./tools/user-types.js";
+import { registerMaterialReadTools } from "./tools/material-read.js";
+import { registerMaterialMutationTools } from "./tools/material-mutation.js";
 
 // Resource registrations
 import { registerBlueprintListResource } from "./resources/blueprint-list.js";
@@ -42,6 +44,8 @@ registerUtilityTools(server);
 registerDiscoveryTools(server);
 registerDiffBlueprintsTools(server);
 registerUserTypeTools(server);
+registerMaterialReadTools(server);
+registerMaterialMutationTools(server);
 
 // Register resources
 registerBlueprintListResource(server);

--- a/Tools/src/material-describe.ts
+++ b/Tools/src/material-describe.ts
@@ -1,0 +1,26 @@
+export function describeMaterial(data: any): string {
+  const lines: string[] = [];
+
+  if (data.name) {
+    lines.push(`# Material: ${data.name}`);
+  }
+
+  if (data.description) {
+    lines.push(data.description);
+    return lines.join("\n");
+  }
+
+  // Format inputs array if present
+  if (data.inputs && Array.isArray(data.inputs)) {
+    for (const input of data.inputs) {
+      const connected = input.connected ? "" : " (disconnected)";
+      lines.push(`${input.input}: ${input.chain || "empty"}${connected}`);
+    }
+  }
+
+  if (lines.length <= 1) {
+    lines.push("No material input data available.");
+  }
+
+  return lines.join("\n");
+}

--- a/Tools/src/tools/material-mutation.ts
+++ b/Tools/src/tools/material-mutation.ts
@@ -1,0 +1,689 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ensureUE, uePost, ueGet } from "../ue-bridge.js";
+
+export function registerMaterialMutationTools(server: McpServer): void {
+  // ---------------------------------------------------------------------------
+  // Phase 2: Material Mutations
+  // ---------------------------------------------------------------------------
+
+  server.tool(
+    "create_material",
+    "Create a new Material asset.",
+    {
+      name: z.string().describe("Material asset name (e.g. 'M_MyMaterial')"),
+      packagePath: z.string().default("/Game").describe("Package path to create the material in (e.g. '/Game/Materials')"),
+      domain: z.enum(["Surface", "DeferredDecal", "LightFunction", "Volume", "PostProcess", "UI"]).optional().describe("Material domain"),
+      blendMode: z.enum(["Opaque", "Masked", "Translucent", "Additive", "Modulate"]).optional().describe("Blend mode"),
+      twoSided: z.boolean().optional().describe("Whether the material is two-sided"),
+    },
+    async ({ name, packagePath, domain, blendMode, twoSided }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { name, packagePath };
+      if (domain) body.domain = domain;
+      if (blendMode) body.blendMode = blendMode;
+      if (twoSided !== undefined) body.twoSided = twoSided;
+
+      const data = await uePost("/api/create-material", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Created material ${data.name || name} at ${data.packagePath || packagePath}`);
+      if (data.domain) lines.push(`Domain: ${data.domain}`);
+      if (data.blendMode) lines.push(`Blend mode: ${data.blendMode}`);
+      if (data.twoSided !== undefined) lines.push(`Two-sided: ${data.twoSided}`);
+      if (data.saved !== undefined) lines.push(`Saved: ${data.saved}`);
+
+      lines.push(`\nNext steps:`);
+      lines.push(`  1. Use add_material_expression to add nodes to the material graph`);
+      lines.push(`  2. Use connect_material_pins to wire expressions together`);
+      lines.push(`  3. Use set_material_property to adjust material settings`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "set_material_property",
+    "Set a top-level property on a Material (domain, blendMode, twoSided, shadingModel).",
+    {
+      material: z.string().describe("Material name or package path (e.g. 'M_MyMaterial')"),
+      property: z.string().describe("Property name to set (e.g. 'domain', 'blendMode', 'twoSided', 'shadingModel')"),
+      value: z.string().describe("New value for the property"),
+      dryRun: z.boolean().optional().describe("If true, preview changes without modifying the Material"),
+    },
+    async ({ material, property, value, dryRun }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { material, property, value };
+      if (dryRun) body.dryRun = true;
+
+      const data = await uePost("/api/set-material-property", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      if (dryRun) lines.push(`[DRY RUN - no changes saved]`);
+      lines.push(`Material: ${data.material || material}`);
+      lines.push(`Property: ${data.property || property}`);
+      lines.push(`Old value: ${data.oldValue ?? "(empty)"} -> New value: ${data.newValue ?? value}`);
+      if (data.saved !== undefined) lines.push(`Saved: ${data.saved}`);
+
+      if (!dryRun) {
+        lines.push(`\nNext steps:`);
+        lines.push(`  1. Use get_material_graph to verify the changes`);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "add_material_expression",
+    "Add a new expression node to a Material's graph.",
+    {
+      material: z.string().describe("Material name or package path (e.g. 'M_MyMaterial')"),
+      expressionClass: z.string().describe("Expression type: Constant, ScalarParameter, VectorParameter, TextureSample, TextureSampleParameter2D, TextureCoordinate, Add, Multiply, Lerp, Clamp, OneMinus, Power, Time, WorldPosition, AppendVector, ComponentMask, Custom, StaticSwitchParameter, MaterialFunctionCall, Constant3Vector, Constant4Vector"),
+      posX: z.number().default(0).describe("X position in the graph editor"),
+      posY: z.number().default(0).describe("Y position in the graph editor"),
+      dryRun: z.boolean().optional().describe("If true, preview changes without modifying the Material"),
+    },
+    async ({ material, expressionClass, posX, posY, dryRun }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { material, expressionClass, posX, posY };
+      if (dryRun) body.dryRun = true;
+
+      const data = await uePost("/api/add-material-expression", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      if (dryRun) lines.push(`[DRY RUN - no changes saved]`);
+      lines.push(`Expression added: ${data.expressionClass || expressionClass}`);
+      lines.push(`Material: ${data.material || material}`);
+      if (data.nodeId) lines.push(`Node ID: ${data.nodeId}`);
+      if (data.posX !== undefined && data.posY !== undefined) lines.push(`Position: (${data.posX}, ${data.posY})`);
+      if (data.saved !== undefined) lines.push(`Saved: ${data.saved}`);
+
+      if (data.pins?.length) {
+        lines.push(`\nPins:`);
+        for (const pin of data.pins) {
+          const dir = pin.direction === "Output" ? "\u2192" : "\u2190";
+          lines.push(`  ${dir} ${pin.name}: ${pin.type}${pin.subtype ? ` (${pin.subtype})` : ""}`);
+        }
+      }
+
+      if (!dryRun) {
+        lines.push(`\nNext steps:`);
+        lines.push(`  1. Use set_expression_value to configure the expression`);
+        lines.push(`  2. Use connect_material_pins to wire it to other nodes`);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "delete_material_expression",
+    "Delete an expression node from a Material's graph.",
+    {
+      material: z.string().describe("Material name or package path (e.g. 'M_MyMaterial')"),
+      nodeId: z.string().describe("GUID of the expression node to delete"),
+      dryRun: z.boolean().optional().describe("If true, preview changes without modifying the Material"),
+    },
+    async ({ material, nodeId, dryRun }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { material, nodeId };
+      if (dryRun) body.dryRun = true;
+
+      const data = await uePost("/api/delete-material-expression", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      if (dryRun) lines.push(`[DRY RUN - no changes saved]`);
+      lines.push(`Expression deleted.`);
+      lines.push(`Material: ${data.material || material}`);
+      if (data.nodeId) lines.push(`Node ID: ${data.nodeId}`);
+      if (data.expressionClass) lines.push(`Expression class: ${data.expressionClass}`);
+      if (data.disconnectedPins !== undefined) lines.push(`Disconnected pins: ${data.disconnectedPins}`);
+      if (data.saved !== undefined) lines.push(`Saved: ${data.saved}`);
+
+      if (!dryRun) {
+        lines.push(`\nNext steps:`);
+        lines.push(`  1. Use get_material_graph to verify the changes`);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "connect_material_pins",
+    "Connect two pins in a Material's graph.",
+    {
+      material: z.string().describe("Material name or package path (e.g. 'M_MyMaterial')"),
+      sourceNodeId: z.string().describe("GUID of the source expression node"),
+      sourcePinName: z.string().describe("Name of the output pin on the source node"),
+      targetNodeId: z.string().describe("GUID of the target expression node (or 'Result' for the material result node)"),
+      targetPinName: z.string().describe("Name of the input pin on the target node"),
+      dryRun: z.boolean().optional().describe("If true, preview changes without modifying the Material"),
+    },
+    async ({ material, sourceNodeId, sourcePinName, targetNodeId, targetPinName, dryRun }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { material, sourceNodeId, sourcePinName, targetNodeId, targetPinName };
+      if (dryRun) body.dryRun = true;
+
+      const data = await uePost("/api/connect-material-pins", body);
+      if (data.error) {
+        let msg = `Error: ${data.error}`;
+        if (data.availablePins) {
+          msg += `\nAvailable pins: ${data.availablePins.join(", ")}`;
+        }
+        return { content: [{ type: "text" as const, text: msg }] };
+      }
+
+      const lines: string[] = [];
+      if (dryRun) lines.push(`[DRY RUN - no changes saved]`);
+      lines.push(`Connection ${data.success ? "succeeded" : "failed"}.`);
+      lines.push(`Material: ${data.material || material}`);
+      lines.push(`${sourcePinName} \u2192 ${targetPinName}`);
+      if (data.saved !== undefined) lines.push(`Saved: ${data.saved}`);
+
+      if (!dryRun) {
+        lines.push(`\nNext steps:`);
+        lines.push(`  1. Use get_material_graph to verify the connection`);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "disconnect_material_pin",
+    "Disconnect all links from a specific pin in a Material's graph.",
+    {
+      material: z.string().describe("Material name or package path (e.g. 'M_MyMaterial')"),
+      nodeId: z.string().describe("GUID of the expression node containing the pin"),
+      pinName: z.string().describe("Name of the pin to disconnect"),
+      dryRun: z.boolean().optional().describe("If true, preview changes without modifying the Material"),
+    },
+    async ({ material, nodeId, pinName, dryRun }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { material, nodeId, pinName };
+      if (dryRun) body.dryRun = true;
+
+      const data = await uePost("/api/disconnect-material-pin", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      if (dryRun) lines.push(`[DRY RUN - no changes saved]`);
+      lines.push(`Disconnected ${data.disconnectedCount ?? 0} link(s).`);
+      lines.push(`Material: ${data.material || material}`);
+      if (data.saved !== undefined) lines.push(`Saved: ${data.saved}`);
+
+      if (!dryRun) {
+        lines.push(`\nNext steps:`);
+        lines.push(`  1. Use get_material_graph to verify the changes`);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "set_expression_value",
+    "Set the value of a material expression (constants, parameter defaults, custom code, etc.).",
+    {
+      material: z.string().describe("Material name or package path (e.g. 'M_MyMaterial')"),
+      nodeId: z.string().describe("GUID of the expression node"),
+      value: z.union([
+        z.number(),
+        z.object({ r: z.number(), g: z.number(), b: z.number(), a: z.number().optional() }),
+        z.string(),
+      ]).describe("Value to set: number (for scalar), {r,g,b,a?} (for vector/color), or string"),
+      parameterName: z.string().optional().describe("Parameter name override (for parameter expressions)"),
+      code: z.string().optional().describe("Custom HLSL code (for Custom expression nodes)"),
+      dryRun: z.boolean().optional().describe("If true, preview changes without modifying the Material"),
+    },
+    async ({ material, nodeId, value, parameterName, code, dryRun }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { material, nodeId, value };
+      if (parameterName) body.parameterName = parameterName;
+      if (code) body.code = code;
+      if (dryRun) body.dryRun = true;
+
+      const data = await uePost("/api/set-expression-value", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      if (dryRun) lines.push(`[DRY RUN - no changes saved]`);
+      lines.push(`Expression value set.`);
+      lines.push(`Material: ${data.material || material}`);
+      if (data.nodeId) lines.push(`Node ID: ${data.nodeId}`);
+      if (data.expressionClass) lines.push(`Expression class: ${data.expressionClass}`);
+      if (data.oldValue !== undefined) lines.push(`Old value: ${typeof data.oldValue === "object" ? JSON.stringify(data.oldValue) : data.oldValue}`);
+      if (data.newValue !== undefined) lines.push(`New value: ${typeof data.newValue === "object" ? JSON.stringify(data.newValue) : data.newValue}`);
+      if (data.saved !== undefined) lines.push(`Saved: ${data.saved}`);
+
+      if (!dryRun) {
+        lines.push(`\nNext steps:`);
+        lines.push(`  1. Use get_material_graph to verify the changes`);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "move_material_expression",
+    "Move a material expression node to a new position in the graph editor.",
+    {
+      material: z.string().describe("Material name or package path (e.g. 'M_MyMaterial')"),
+      nodeId: z.string().describe("GUID of the expression node to move"),
+      posX: z.number().describe("New X position"),
+      posY: z.number().describe("New Y position"),
+      dryRun: z.boolean().optional().describe("If true, preview changes without modifying the Material"),
+    },
+    async ({ material, nodeId, posX, posY, dryRun }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { material, nodeId, posX, posY };
+      if (dryRun) body.dryRun = true;
+
+      const data = await uePost("/api/move-material-expression", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      if (dryRun) lines.push(`[DRY RUN - no changes saved]`);
+      lines.push(`Expression repositioned.`);
+      lines.push(`Material: ${data.material || material}`);
+      if (data.nodeId) lines.push(`Node ID: ${data.nodeId}`);
+      if (data.oldPosX !== undefined && data.oldPosY !== undefined) {
+        lines.push(`Position: (${data.oldPosX}, ${data.oldPosY}) -> (${data.newPosX ?? posX}, ${data.newPosY ?? posY})`);
+      } else {
+        lines.push(`Position: (${data.newPosX ?? posX}, ${data.newPosY ?? posY})`);
+      }
+      if (data.saved !== undefined) lines.push(`Saved: ${data.saved}`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Phase 3: Material Instances
+  // ---------------------------------------------------------------------------
+
+  server.tool(
+    "create_material_instance",
+    "Create a new Material Instance asset with a specified parent material.",
+    {
+      name: z.string().describe("Material Instance asset name (e.g. 'MI_MyMaterial')"),
+      packagePath: z.string().default("/Game").describe("Package path to create the instance in (e.g. '/Game/Materials')"),
+      parentMaterial: z.string().describe("Parent material name or package path (e.g. 'M_MyMaterial')"),
+    },
+    async ({ name, packagePath, parentMaterial }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { name, packagePath, parentMaterial };
+
+      const data = await uePost("/api/create-material-instance", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Created material instance ${data.name || name} at ${data.packagePath || packagePath}`);
+      if (data.parentMaterial) lines.push(`Parent: ${data.parentMaterial}`);
+      if (data.saved !== undefined) lines.push(`Saved: ${data.saved}`);
+
+      lines.push(`\nNext steps:`);
+      lines.push(`  1. Use set_material_instance_parameter to override parameter values`);
+      lines.push(`  2. Use get_material_instance_parameters to inspect available parameters`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "set_material_instance_parameter",
+    "Override a parameter value in a Material Instance.",
+    {
+      materialInstance: z.string().describe("Material Instance name or package path (e.g. 'MI_MyMaterial')"),
+      parameterName: z.string().describe("Name of the parameter to override"),
+      value: z.union([
+        z.number(),
+        z.object({ r: z.number(), g: z.number(), b: z.number(), a: z.number().optional() }),
+        z.string(),
+        z.boolean(),
+      ]).describe("Value to set: number (scalar), {r,g,b,a?} (vector/color), string (texture path), or boolean (static switch)"),
+      type: z.enum(["scalar", "vector", "texture", "staticSwitch"]).optional().describe("Parameter type hint (auto-detected if omitted)"),
+      dryRun: z.boolean().optional().describe("If true, preview changes without modifying the Material Instance"),
+    },
+    async ({ materialInstance, parameterName, value, type, dryRun }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { materialInstance, parameterName, value };
+      if (type) body.type = type;
+      if (dryRun) body.dryRun = true;
+
+      const data = await uePost("/api/set-material-instance-parameter", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      if (dryRun) lines.push(`[DRY RUN - no changes saved]`);
+      lines.push(`Parameter override set.`);
+      lines.push(`Material Instance: ${data.materialInstance || materialInstance}`);
+      lines.push(`Parameter: ${data.parameterName || parameterName}`);
+      if (data.type) lines.push(`Type: ${data.type}`);
+      if (data.oldValue !== undefined) lines.push(`Old value: ${typeof data.oldValue === "object" ? JSON.stringify(data.oldValue) : data.oldValue}`);
+      if (data.newValue !== undefined) lines.push(`New value: ${typeof data.newValue === "object" ? JSON.stringify(data.newValue) : data.newValue}`);
+      if (data.saved !== undefined) lines.push(`Saved: ${data.saved}`);
+
+      if (!dryRun) {
+        lines.push(`\nNext steps:`);
+        lines.push(`  1. Use get_material_instance_parameters to verify all overrides`);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "get_material_instance_parameters",
+    "Get all parameters of a Material Instance, showing which are overridden vs inherited from parent.",
+    {
+      name: z.string().describe("Material Instance name or package path (e.g. 'MI_MyMaterial')"),
+    },
+    async ({ name }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await ueGet("/api/material-instance-params", { name });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Material Instance: ${data.name || name}`);
+      if (data.parentMaterial) lines.push(`Parent: ${data.parentMaterial}`);
+      if (data.parentChain?.length) {
+        lines.push(`Parent chain: ${data.parentChain.join(" -> ")}`);
+      }
+
+      const formatParamValue = (val: any): string => {
+        if (val === undefined || val === null) return "(default)";
+        if (typeof val === "object") return JSON.stringify(val);
+        return String(val);
+      };
+
+      if (data.scalarParameters?.length) {
+        lines.push(`\nScalar Parameters:`);
+        for (const p of data.scalarParameters) {
+          const override = p.overridden ? " [OVERRIDDEN]" : "";
+          lines.push(`  ${p.name}: ${formatParamValue(p.value)}${override}`);
+        }
+      }
+
+      if (data.vectorParameters?.length) {
+        lines.push(`\nVector Parameters:`);
+        for (const p of data.vectorParameters) {
+          const override = p.overridden ? " [OVERRIDDEN]" : "";
+          lines.push(`  ${p.name}: ${formatParamValue(p.value)}${override}`);
+        }
+      }
+
+      if (data.textureParameters?.length) {
+        lines.push(`\nTexture Parameters:`);
+        for (const p of data.textureParameters) {
+          const override = p.overridden ? " [OVERRIDDEN]" : "";
+          lines.push(`  ${p.name}: ${formatParamValue(p.value)}${override}`);
+        }
+      }
+
+      if (data.staticSwitchParameters?.length) {
+        lines.push(`\nStatic Switch Parameters:`);
+        for (const p of data.staticSwitchParameters) {
+          const override = p.overridden ? " [OVERRIDDEN]" : "";
+          lines.push(`  ${p.name}: ${formatParamValue(p.value)}${override}`);
+        }
+      }
+
+      if (!data.scalarParameters?.length && !data.vectorParameters?.length &&
+          !data.textureParameters?.length && !data.staticSwitchParameters?.length) {
+        lines.push(`\nNo parameters found.`);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "reparent_material_instance",
+    "Change the parent of a Material Instance to a different Material or Material Instance.",
+    {
+      materialInstance: z.string().describe("Material Instance name or package path (e.g. 'MI_MyMaterial')"),
+      newParent: z.string().describe("New parent material name or package path (e.g. 'M_NewParent')"),
+      dryRun: z.boolean().optional().describe("If true, preview changes without modifying the Material Instance"),
+    },
+    async ({ materialInstance, newParent, dryRun }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { materialInstance, newParent };
+      if (dryRun) body.dryRun = true;
+
+      const data = await uePost("/api/reparent-material-instance", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      if (dryRun) lines.push(`[DRY RUN - no changes saved]`);
+      lines.push(`Material Instance reparented.`);
+      lines.push(`Material Instance: ${data.materialInstance || materialInstance}`);
+      if (data.oldParent) lines.push(`Old parent: ${data.oldParent}`);
+      lines.push(`New parent: ${data.newParent || newParent}`);
+      if (data.saved !== undefined) lines.push(`Saved: ${data.saved}`);
+
+      if (!dryRun) {
+        lines.push(`\nNext steps:`);
+        lines.push(`  1. Use get_material_instance_parameters to check parameter compatibility`);
+        lines.push(`  2. Use set_material_instance_parameter to update overrides if needed`);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Phase 4: Create Material Function
+  // ---------------------------------------------------------------------------
+
+  server.tool(
+    "create_material_function",
+    "Create a new Material Function asset.",
+    {
+      name: z.string().describe("Material Function asset name (e.g. 'MF_MyFunction')"),
+      packagePath: z.string().default("/Game").describe("Package path to create the function in (e.g. '/Game/Materials/Functions')"),
+      description: z.string().optional().describe("Description of the material function"),
+    },
+    async ({ name, packagePath, description }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { name, packagePath };
+      if (description) body.description = description;
+
+      const data = await uePost("/api/create-material-function", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Created material function ${data.name || name} at ${data.packagePath || packagePath}`);
+      if (data.description) lines.push(`Description: ${data.description}`);
+      if (data.saved !== undefined) lines.push(`Saved: ${data.saved}`);
+
+      lines.push(`\nNext steps:`);
+      lines.push(`  1. Use add_material_expression to add expression nodes to the function`);
+      lines.push(`  2. Use connect_material_pins to wire expressions together`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  // ---------------------------------------------------------------------------
+  // Phase 5: Snapshot/Diff/Restore
+  // ---------------------------------------------------------------------------
+
+  server.tool(
+    "snapshot_material_graph",
+    "Take a snapshot of a Material's graph for later comparison or restoration.",
+    {
+      material: z.string().describe("Material name or package path (e.g. 'M_MyMaterial')"),
+    },
+    async ({ material }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/snapshot-material-graph", { material });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Snapshot ${data.snapshotId} created for material ${data.material || material}`);
+      if (data.expressionCount !== undefined) lines.push(`Expressions captured: ${data.expressionCount}`);
+      if (data.connectionCount !== undefined) lines.push(`Connections captured: ${data.connectionCount}`);
+
+      lines.push(`\nNext steps:`);
+      lines.push(`  1. Make your changes to the material`);
+      lines.push(`  2. Use diff_material_graph to see what changed`);
+      lines.push(`  3. Use restore_material_graph to reconnect severed pins`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "diff_material_graph",
+    "Compare a Material's current graph against a previously taken snapshot.",
+    {
+      material: z.string().describe("Material name or package path (e.g. 'M_MyMaterial')"),
+      snapshotId: z.string().describe("Snapshot ID from snapshot_material_graph"),
+    },
+    async ({ material, snapshotId }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/diff-material-graph", { material, snapshotId });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`# Diff: ${data.material || material} vs ${data.snapshotId || snapshotId}`);
+
+      if (data.severedConnections?.length) {
+        lines.push(`\nSevered connections (${data.severedConnections.length}):`);
+        for (const sc of data.severedConnections) {
+          lines.push(`  ${sc.sourceNodeTitle || sc.sourceNodeId}.${sc.sourcePinName} was -> ${sc.targetNodeTitle || sc.targetNodeId}.${sc.targetPinName}`);
+        }
+      }
+
+      if (data.newConnections?.length) {
+        lines.push(`\nNew connections (${data.newConnections.length}):`);
+        for (const nc of data.newConnections) {
+          lines.push(`  ${nc.sourceNodeTitle || nc.sourceNodeId}.${nc.sourcePinName} -> ${nc.targetNodeTitle || nc.targetNodeId}.${nc.targetPinName}`);
+        }
+      }
+
+      if (data.missingNodes?.length) {
+        lines.push(`\nMissing nodes (${data.missingNodes.length}):`);
+        for (const mn of data.missingNodes) {
+          lines.push(`  ${mn.nodeId} (${mn.nodeTitle || mn.expressionClass || "unknown"})`);
+        }
+      }
+
+      if (data.newNodes?.length) {
+        lines.push(`\nNew nodes (${data.newNodes.length}):`);
+        for (const nn of data.newNodes) {
+          lines.push(`  ${nn.nodeId} (${nn.nodeTitle || nn.expressionClass || "unknown"})`);
+        }
+      }
+
+      if (!data.severedConnections?.length && !data.newConnections?.length &&
+          !data.missingNodes?.length && !data.newNodes?.length) {
+        lines.push(`\nNo changes detected.`);
+      }
+
+      if (data.summary) {
+        lines.push(`\nSummary: ${data.summary.severed ?? 0} severed, ${data.summary.new ?? 0} new connections, ${data.summary.missingNodes ?? 0} missing nodes`);
+      }
+
+      lines.push(`\nNext steps:`);
+      if (data.severedConnections?.length) {
+        lines.push(`  1. Use restore_material_graph to reconnect severed pins`);
+      } else {
+        lines.push(`  1. No action needed \u2014 graph is intact`);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "restore_material_graph",
+    "Restore severed connections in a Material's graph from a snapshot.",
+    {
+      material: z.string().describe("Material name or package path (e.g. 'M_MyMaterial')"),
+      snapshotId: z.string().describe("Snapshot ID from snapshot_material_graph"),
+      dryRun: z.boolean().optional().describe("If true, preview reconnections without making changes"),
+    },
+    async ({ material, snapshotId, dryRun }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { material, snapshotId };
+      if (dryRun) body.dryRun = true;
+
+      const data = await uePost("/api/restore-material-graph", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      if (dryRun) lines.push(`[DRY RUN - no changes saved]\n`);
+
+      lines.push(`Restore: ${data.material || material} from ${data.snapshotId || snapshotId}`);
+      lines.push(`Reconnected: ${data.reconnected ?? 0}/${(data.reconnected ?? 0) + (data.failed ?? 0)}`);
+      if ((data.failed ?? 0) > 0) {
+        lines.push(`Failed: ${data.failed}`);
+      }
+
+      if (data.details?.length) {
+        lines.push(`\nDetails:`);
+        for (const d of data.details) {
+          const status = d.result === "ok" ? "OK" : "FAILED";
+          const reason = d.reason ? ` (${d.reason})` : "";
+          lines.push(`  ${status}: ${d.sourcePinName} -> ${d.targetNodeTitle || d.targetNodeId}.${d.targetPinName}${reason}`);
+        }
+      }
+
+      if (!dryRun && data.saved !== undefined) {
+        lines.push(`\nSaved: ${data.saved}`);
+      }
+
+      lines.push(`\nNext steps:`);
+      if (dryRun) {
+        lines.push(`  1. Re-run restore_material_graph without dryRun to apply changes`);
+      }
+      if ((data.failed ?? 0) > 0) {
+        lines.push(`  1. Fix ${data.failed} failed reconnection(s) manually with connect_material_pins`);
+      }
+      lines.push(`  2. Use get_material_graph to verify the final state`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+}

--- a/Tools/src/tools/material-read.ts
+++ b/Tools/src/tools/material-read.ts
@@ -1,0 +1,191 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ensureUE, ueGet, uePost } from "../ue-bridge.js";
+import { describeMaterial } from "../material-describe.js";
+
+export function registerMaterialReadTools(server: McpServer): void {
+  server.tool(
+    "list_materials",
+    "List all Material and Material Instance assets in the UE5 project. Filter by name/path and type.",
+    {
+      filter: z.string().optional().describe("Substring to match against material name or path"),
+      type: z.enum(["all", "material", "instance"]).optional().default("all").describe("Filter by type: 'all' (default), 'material' (base materials only), 'instance' (material instances only)"),
+    },
+    async ({ filter, type: matType }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await ueGet("/api/materials", {
+        filter: filter || "",
+        type: matType || "all",
+      });
+
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = data.materials.map(
+        (mat: any) => `${mat.name} (${mat.path}) [${mat.type}]`
+      );
+      const summary = `Found ${data.count} of ${data.total} materials.\n\n${lines.join("\n")}`;
+      return { content: [{ type: "text" as const, text: summary }] };
+    }
+  );
+
+  server.tool(
+    "get_material",
+    "Get full details of a Material or Material Instance: domain, blend mode, shading model, parameters, expressions, referenced textures.",
+    {
+      name: z.string().describe("Material name or package path"),
+    },
+    async ({ name }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await ueGet("/api/material", { name });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
+    }
+  );
+
+  server.tool(
+    "get_material_graph",
+    "Get the material editor graph for a Material, with all expression nodes and connections.",
+    {
+      name: z.string().describe("Material name or package path"),
+    },
+    async ({ name }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await ueGet("/api/material-graph", { name });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
+    }
+  );
+
+  server.tool(
+    "describe_material",
+    "Get a human-readable description of a Material's graph, showing what feeds into each material input (BaseColor, Roughness, Normal, etc.).",
+    {
+      name: z.string().describe("Material name or package path"),
+    },
+    async ({ name }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/describe-material", { material: name });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const text = data.description ? data.description : describeMaterial(data);
+      return { content: [{ type: "text" as const, text }] };
+    }
+  );
+
+  server.tool(
+    "search_materials",
+    "Search across Materials for expressions matching a query (parameter names, expression types).",
+    {
+      query: z.string().describe("Search term to match against expression types, parameter names, texture names"),
+      maxResults: z.number().optional().default(50).describe("Maximum results to return"),
+    },
+    async ({ query, maxResults }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await ueGet("/api/search-materials", {
+        query,
+        maxResults: String(maxResults),
+      });
+
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Found ${data.resultCount} results for "${query}":\n`);
+
+      for (const r of data.results) {
+        let line = `[${r.material}] ${r.matchType}: ${r.matchValue}`;
+        if (r.expressionType) line += ` (${r.expressionType})`;
+        if (r.parameterName) line += ` param:${r.parameterName}`;
+        lines.push(line);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "find_material_references",
+    "Find all assets that reference a given Material or Material Instance.",
+    {
+      material: z.string().describe("Material name or package path"),
+    },
+    async ({ material }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/material-references", { material });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`References to: ${data.material || material}`);
+      lines.push(`Total referencers: ${data.totalReferencers}`);
+
+      if (data.referencers?.length) {
+        lines.push("");
+        for (const ref of data.referencers) {
+          lines.push(`  ${ref}`);
+        }
+      }
+
+      if (data.totalReferencers === 0) {
+        lines.push("\nNo referencers found.");
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "list_material_functions",
+    "List all Material Function assets in the project.",
+    {
+      filter: z.string().optional().describe("Substring to match against function name or path"),
+    },
+    async ({ filter }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await ueGet("/api/material-functions", { filter: filter || "" });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Found ${data.count} material functions.\n`);
+
+      for (const fn of data.functions) {
+        let line = `${fn.name} (${fn.path})`;
+        if (fn.description) line += ` — ${fn.description}`;
+        lines.push(line);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "get_material_function",
+    "Get details of a Material Function: description, inputs, outputs, expressions.",
+    {
+      name: z.string().describe("Material Function name or package path"),
+    },
+    async ({ name }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await ueGet("/api/material-function", { name });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      return { content: [{ type: "text" as const, text: JSON.stringify(data) }] };
+    }
+  );
+}

--- a/Tools/test/helpers.ts
+++ b/Tools/test/helpers.ts
@@ -74,3 +74,45 @@ export async function deleteTestBlueprint(
     force: true,
   });
 }
+
+/**
+ * Create a test Material via the HTTP API.
+ */
+export async function createTestMaterial(opts: {
+  name: string;
+  packagePath?: string;
+  domain?: string;
+  blendMode?: string;
+}): Promise<any> {
+  return uePost("/api/create-material", {
+    name: opts.name,
+    packagePath: opts.packagePath ?? "/Game/Test",
+    domain: opts.domain ?? "Surface",
+    blendMode: opts.blendMode ?? "Opaque",
+  });
+}
+
+/**
+ * Delete a test Material via the HTTP API.
+ */
+export async function deleteTestMaterial(assetPath: string): Promise<any> {
+  return uePost("/api/delete-asset", {
+    assetPath,
+    force: true,
+  });
+}
+
+/**
+ * Create a test Material Instance via the HTTP API.
+ */
+export async function createTestMaterialInstance(opts: {
+  name: string;
+  packagePath?: string;
+  parentMaterial: string;
+}): Promise<any> {
+  return uePost("/api/create-material-instance", {
+    name: opts.name,
+    packagePath: opts.packagePath ?? "/Game/Test",
+    parentMaterial: opts.parentMaterial,
+  });
+}

--- a/Tools/test/tools/material-instance.test.ts
+++ b/Tools/test/tools/material-instance.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { uePost, ueGet, createTestMaterial, createTestMaterialInstance, deleteTestMaterial, uniqueName } from "../helpers.js";
+
+describe("material instance tools", () => {
+  const parentName = uniqueName("M_MIParent");
+  const miName = uniqueName("MI_Test");
+  const packagePath = "/Game/Test";
+
+  beforeAll(async () => {
+    // Create parent material first
+    const parentResult = await createTestMaterial({ name: parentName });
+    expect(parentResult.error).toBeUndefined();
+
+    // Add a scalar parameter to the parent so we can test instance overrides
+    await uePost("/api/add-material-expression", {
+      material: parentName,
+      expressionClass: "ScalarParameter",
+      posX: -200,
+      posY: 0,
+    });
+  });
+
+  afterAll(async () => {
+    await deleteTestMaterial(`${packagePath}/${miName}`);
+    await deleteTestMaterial(`${packagePath}/${parentName}`);
+  });
+
+  describe("create_material_instance", () => {
+    it("creates a material instance", async () => {
+      const data = await uePost("/api/create-material-instance", {
+        name: miName,
+        packagePath,
+        parentMaterial: parentName,
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+      expect(data.name).toBe(miName);
+    });
+
+    it("rejects missing parent", async () => {
+      const data = await uePost("/api/create-material-instance", {
+        name: "MI_NoParent",
+        packagePath,
+        parentMaterial: "M_NonExistent_XYZ_999",
+      });
+      expect(data.error).toBeDefined();
+    });
+  });
+
+  describe("get_material_instance_parameters", () => {
+    it("returns parameter info", async () => {
+      const data = await ueGet("/api/material-instance-params", { name: miName });
+      expect(data.error).toBeUndefined();
+      expect(data.name).toBe(miName);
+      expect(data.parentChain).toBeDefined();
+    });
+
+    it("returns error for non-existent MI", async () => {
+      const data = await ueGet("/api/material-instance-params", { name: "MI_NonExistent_XYZ_999" });
+      expect(data.error).toBeDefined();
+    });
+  });
+
+  describe("reparent_material_instance", () => {
+    const newParentName = uniqueName("M_NewParent");
+
+    beforeAll(async () => {
+      await createTestMaterial({ name: newParentName });
+    });
+
+    afterAll(async () => {
+      await deleteTestMaterial(`${packagePath}/${newParentName}`);
+    });
+
+    it("changes the parent material", async () => {
+      const data = await uePost("/api/reparent-material-instance", {
+        materialInstance: miName,
+        newParent: newParentName,
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+    });
+  });
+});

--- a/Tools/test/tools/material-mutation.test.ts
+++ b/Tools/test/tools/material-mutation.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { uePost, ueGet, createTestMaterial, deleteTestMaterial, uniqueName } from "../helpers.js";
+
+describe("material mutation tools", () => {
+  const matName = uniqueName("M_MutTest");
+  const packagePath = "/Game/Test";
+
+  beforeAll(async () => {
+    const result = await createTestMaterial({ name: matName });
+    expect(result.error).toBeUndefined();
+  });
+
+  afterAll(async () => {
+    await deleteTestMaterial(`${packagePath}/${matName}`);
+  });
+
+  describe("create_material", () => {
+    const createName = uniqueName("M_CreateTest");
+
+    afterAll(async () => {
+      await deleteTestMaterial(`/Game/Test/${createName}`);
+    });
+
+    it("creates a new material", async () => {
+      const data = await uePost("/api/create-material", {
+        name: createName,
+        packagePath: "/Game/Test",
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+      expect(data.name).toBe(createName);
+    });
+
+    it("rejects missing name", async () => {
+      const data = await uePost("/api/create-material", { packagePath: "/Game/Test" });
+      expect(data.error).toBeDefined();
+    });
+  });
+
+  describe("add_material_expression", () => {
+    it("adds a constant expression", async () => {
+      const data = await uePost("/api/add-material-expression", {
+        material: matName,
+        expressionClass: "Constant",
+        posX: 100,
+        posY: 100,
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+      expect(data.nodeId).toBeDefined();
+    });
+
+    it("adds a scalar parameter", async () => {
+      const data = await uePost("/api/add-material-expression", {
+        material: matName,
+        expressionClass: "ScalarParameter",
+        posX: -200,
+        posY: 0,
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+    });
+
+    it("rejects invalid expression class", async () => {
+      const data = await uePost("/api/add-material-expression", {
+        material: matName,
+        expressionClass: "InvalidExpressionClass",
+      });
+      expect(data.error).toBeDefined();
+    });
+
+    it("supports dry run", async () => {
+      const data = await uePost("/api/add-material-expression", {
+        material: matName,
+        expressionClass: "Constant",
+        dryRun: true,
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.dryRun).toBe(true);
+    });
+  });
+
+  describe("set_expression_value", () => {
+    let constantNodeId: string;
+
+    beforeAll(async () => {
+      const result = await uePost("/api/add-material-expression", {
+        material: matName,
+        expressionClass: "Constant",
+        posX: 300,
+        posY: 300,
+      });
+      constantNodeId = result.nodeId;
+    });
+
+    it("sets constant value", async () => {
+      const data = await uePost("/api/set-expression-value", {
+        material: matName,
+        nodeId: constantNodeId,
+        value: 0.75,
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+    });
+  });
+
+  describe("move_material_expression", () => {
+    let nodeId: string;
+
+    beforeAll(async () => {
+      const result = await uePost("/api/add-material-expression", {
+        material: matName,
+        expressionClass: "Constant",
+        posX: 0,
+        posY: 0,
+      });
+      nodeId = result.nodeId;
+    });
+
+    it("moves expression to new position", async () => {
+      const data = await uePost("/api/move-material-expression", {
+        material: matName,
+        nodeId,
+        posX: 500,
+        posY: 250,
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+    });
+  });
+
+  describe("snapshot and diff", () => {
+    let snapshotId: string;
+
+    it("takes a snapshot", async () => {
+      const data = await uePost("/api/snapshot-material-graph", {
+        material: matName,
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.snapshotId).toBeDefined();
+      snapshotId = data.snapshotId;
+    });
+
+    it("diffs against snapshot", async () => {
+      const data = await uePost("/api/diff-material-graph", {
+        material: matName,
+        snapshotId,
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.summary).toBeDefined();
+    });
+
+    it("returns error for invalid snapshot", async () => {
+      const data = await uePost("/api/diff-material-graph", {
+        material: matName,
+        snapshotId: "nonexistent_snapshot_id",
+      });
+      expect(data.error).toBeDefined();
+    });
+  });
+});

--- a/Tools/test/tools/material-read.test.ts
+++ b/Tools/test/tools/material-read.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { uePost, ueGet, createTestMaterial, deleteTestMaterial, uniqueName } from "../helpers.js";
+
+describe("material read tools", () => {
+  const matName = uniqueName("M_ReadTest");
+  const packagePath = "/Game/Test";
+
+  beforeAll(async () => {
+    const result = await createTestMaterial({ name: matName });
+    expect(result.error).toBeUndefined();
+  });
+
+  afterAll(async () => {
+    await deleteTestMaterial(`${packagePath}/${matName}`);
+  });
+
+  describe("list_materials", () => {
+    it("returns materials list", async () => {
+      const data = await ueGet("/api/materials", {});
+      expect(data.error).toBeUndefined();
+      expect(data.count).toBeGreaterThanOrEqual(1);
+      expect(data.materials).toBeDefined();
+      expect(Array.isArray(data.materials)).toBe(true);
+    });
+
+    it("filters by name", async () => {
+      const data = await ueGet("/api/materials", { filter: matName });
+      expect(data.error).toBeUndefined();
+      expect(data.count).toBeGreaterThanOrEqual(1);
+      const found = data.materials.some((m: any) => m.name === matName);
+      expect(found).toBe(true);
+    });
+
+    it("filters by type", async () => {
+      const data = await ueGet("/api/materials", { type: "material" });
+      expect(data.error).toBeUndefined();
+      for (const m of data.materials) {
+        expect(m.type).toBe("Material");
+      }
+    });
+  });
+
+  describe("get_material", () => {
+    it("returns material details", async () => {
+      const data = await ueGet("/api/material", { name: matName });
+      expect(data.error).toBeUndefined();
+      expect(data.name).toBe(matName);
+      expect(data.domain).toBeDefined();
+      expect(data.blendMode).toBeDefined();
+    });
+
+    it("returns error for non-existent material", async () => {
+      const data = await ueGet("/api/material", { name: "M_NonExistent_XYZ_999" });
+      expect(data.error).toBeDefined();
+    });
+
+    it("rejects missing name", async () => {
+      const data = await ueGet("/api/material", {});
+      expect(data.error).toBeDefined();
+    });
+  });
+
+  describe("get_material_graph", () => {
+    it("returns graph data", async () => {
+      const data = await ueGet("/api/material-graph", { name: matName });
+      expect(data.error).toBeUndefined();
+      expect(data.nodes).toBeDefined();
+    });
+
+    it("returns error for non-existent material", async () => {
+      const data = await ueGet("/api/material-graph", { name: "M_NonExistent_XYZ_999" });
+      expect(data.error).toBeDefined();
+    });
+  });
+
+  describe("describe_material", () => {
+    it("returns description", async () => {
+      const data = await uePost("/api/describe-material", { material: matName });
+      expect(data.error).toBeUndefined();
+      expect(data.material).toBe(matName);
+    });
+
+    it("returns error for missing material field", async () => {
+      const data = await uePost("/api/describe-material", {});
+      expect(data.error).toBeDefined();
+    });
+  });
+
+  describe("search_materials", () => {
+    it("returns results for query", async () => {
+      const data = await ueGet("/api/search-materials", { query: matName });
+      expect(data.error).toBeUndefined();
+      expect(data.resultCount).toBeGreaterThanOrEqual(0);
+      expect(data.results).toBeDefined();
+    });
+  });
+
+  describe("find_material_references", () => {
+    it("returns references data", async () => {
+      const data = await uePost("/api/material-references", { material: matName });
+      expect(data.error).toBeUndefined();
+      expect(data.totalReferencers).toBeDefined();
+    });
+
+    it("returns error for missing material field", async () => {
+      const data = await uePost("/api/material-references", {});
+      expect(data.error).toBeDefined();
+    });
+  });
+
+  describe("list_material_functions", () => {
+    it("returns function list", async () => {
+      const data = await ueGet("/api/material-functions", {});
+      expect(data.error).toBeUndefined();
+      expect(data.count).toBeDefined();
+      expect(data.functions).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add 24 MCP tools for inspecting, modifying, and snapshotting UE5 Material, Material Instance, and Material Function assets
- Reuses existing `UEdGraph` serialization infrastructure with a new `UMaterialGraphNode` branch in `SerializeNode()`
- 3 new C++ handler files (3,495 lines), 2 new TS tool files (880 lines), 3 test files (364 lines), plus infrastructure changes to 5 existing files

### Phase 1: Read-Only Inspection (6 tools)
`list_materials`, `get_material`, `get_material_graph`, `describe_material`, `search_materials`, `find_material_references`

### Phase 2: Material Modification (8 tools)
`create_material`, `set_material_property`, `add_material_expression`, `delete_material_expression`, `connect_material_pins`, `disconnect_material_pin`, `set_expression_value`, `move_material_expression`

### Phase 3: Material Instance Support (4 tools)
`create_material_instance`, `set_material_instance_parameter`, `get_material_instance_parameters`, `reparent_material_instance`

### Phase 4: Material Functions (3 tools)
`list_material_functions`, `get_material_function`, `create_material_function`

### Phase 5: Snapshot/Diff/Restore (3 tools)
`snapshot_material_graph`, `diff_material_graph`, `restore_material_graph`

## Test plan

- [ ] C++ build passes (verified with UE 5.7 UnrealBuildTool)
- [ ] TypeScript build passes (`npm run build` + `npx tsc --noEmit`)
- [ ] `list_materials` returns indexed material assets when editor is running
- [ ] `get_material` returns domain, blend mode, shading model, parameters, and expression count
- [ ] `create_material` creates a new material asset and returns its path
- [ ] `add_material_expression` adds expression nodes and returns pin names
- [ ] `connect_material_pins` / `disconnect_material_pin` modify material graph connections
- [ ] Material instance tools create instances, set/get parameters, and reparent
- [ ] Snapshot/diff/restore cycle works for material graphs
- [ ] `npm test` integration tests pass (material-read, material-mutation, material-instance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)