### PR TITLE
Fix test infrastructure: UE version detection, material graph, SEH crash protection

### DIFF
--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_MaterialRead.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_MaterialRead.cpp
@@ -765,7 +765,7 @@ FString FBlueprintMCPServer::HandleFindMaterialReferences(const FString& Body)
 	Result->SetBoolField(TEXT("success"), true);
 	Result->SetStringField(TEXT("material"), MaterialName);
 	Result->SetStringField(TEXT("packagePath"), PackagePath);
-	Result->SetNumberField(TEXT("referencerCount"), RefArray.Num());
+	Result->SetNumberField(TEXT("totalReferencers"), RefArray.Num());
 	Result->SetArrayField(TEXT("referencers"), RefArray);
 	return JsonToString(Result);
 }

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -289,6 +289,8 @@ private:
 	static FString UrlDecode(const FString& EncodedString);
 
 	// ----- Material helpers -----
+	/** Ensure that Material->MaterialGraph exists (creates it on demand for commandlet mode). */
+	void EnsureMaterialGraph(UMaterial* Material);
 	FAssetData* FindMaterialAsset(const FString& NameOrPath);
 	UMaterial* LoadMaterialByName(const FString& NameOrPath, FString& OutError);
 	FAssetData* FindMaterialInstanceAsset(const FString& NameOrPath);


### PR DESCRIPTION
## Summary

- **Auto-detect UE engine version** in test bootstrap instead of hardcoding 5.4, fixing test failures when only UE 5.7 is installed
- **Create MaterialGraph on demand** in commandlet/headless mode via `EnsureMaterialGraph()` helper — mirrors the `MaterialEditor.cpp` pattern so material graph operations (node lookup by GUID, snapshot/diff/restore) work outside the editor
- **SEH crash protection** for `add_material_expression` — wraps the entire expression creation + registration + PostEditChange flow in a Windows SEH handler to gracefully catch crashes from effectively-abstract classes like `UMaterialExpressionParameter`, with cleanup to prevent material corruption
- **Fix field name mismatch** in `find_material_references` (`referencerCount` → `totalReferencers`)

Supersedes #51 (rebased cleanly on main).

## Test plan

- [x] `npm test` passes 370/372 tests (2 pre-existing failures: batch-set-pin-default persistence, validate_all_blueprints timeout)
- [x] All 28 material mutation tests pass
- [x] C++ build succeeds with UE 5.7
- [x] TypeScript build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)