### PR TITLE
Add blend space tools: create, set samples, set state blend space

### DIFF
--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -781,6 +781,12 @@ bool FBlueprintMCPServer::Start(int32 InPort, bool bEditorMode)
 		QueuedHandler(TEXT("listAnimSlots")));
 	Router->BindRoute(FHttpPath(TEXT("/api/list-sync-groups")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("listSyncGroups")));
+	Router->BindRoute(FHttpPath(TEXT("/api/create-blend-space")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("createBlendSpace")));
+	Router->BindRoute(FHttpPath(TEXT("/api/set-blend-space-samples")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("setBlendSpaceSamples")));
+	Router->BindRoute(FHttpPath(TEXT("/api/set-state-blend-space")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("setStateBlendSpace")));
 
 	// Register TMap dispatch handlers
 	RegisterHandlers();
@@ -1038,6 +1044,9 @@ void FBlueprintMCPServer::RegisterHandlers()
 	HandlerMap.Add(TEXT("setStateAnimation"),       [this](const TMap<FString, FString>&, const FString& B) { return HandleSetStateAnimation(B); });
 	HandlerMap.Add(TEXT("listAnimSlots"),           [this](const TMap<FString, FString>&, const FString& B) { return HandleListAnimSlots(B); });
 	HandlerMap.Add(TEXT("listSyncGroups"),          [this](const TMap<FString, FString>&, const FString& B) { return HandleListSyncGroups(B); });
+	HandlerMap.Add(TEXT("createBlendSpace"),        [this](const TMap<FString, FString>&, const FString& B) { return HandleCreateBlendSpace(B); });
+	HandlerMap.Add(TEXT("setBlendSpaceSamples"),    [this](const TMap<FString, FString>&, const FString& B) { return HandleSetBlendSpaceSamples(B); });
+	HandlerMap.Add(TEXT("setStateBlendSpace"),      [this](const TMap<FString, FString>&, const FString& B) { return HandleSetStateBlendSpace(B); });
 }
 
 // ============================================================

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -268,6 +268,9 @@ private:
 	FString HandleSetStateAnimation(const FString& Body);
 	FString HandleListAnimSlots(const FString& Body);
 	FString HandleListSyncGroups(const FString& Body);
+	FString HandleCreateBlendSpace(const FString& Body);
+	FString HandleSetBlendSpaceSamples(const FString& Body);
+	FString HandleSetStateBlendSpace(const FString& Body);
 
 	// ----- Serialization -----
 	TSharedRef<FJsonObject> SerializeBlueprint(UBlueprint* BP);


### PR DESCRIPTION
## Summary

- Add `POST /api/create-blend-space` — creates a 2D Blend Space asset with a target skeleton
- Add `POST /api/set-blend-space-samples` — configures axis names/ranges and adds animation samples at X/Y coordinates (replaces existing samples)
- Add `POST /api/set-state-blend-space` — places a BlendSpacePlayer node in an anim state sub-graph, wires it to the Output Animation Pose, and optionally connects X/Y input pins to named Blueprint variables via K2Node_VariableGet nodes

Closes #53

## Test plan

- [ ] Open UE5 editor, verify `server_status` reports the 3 new routes
- [ ] `create_blend_space` with `__create_test_skeleton__` and verify .uasset is saved
- [ ] `set_blend_space_samples` with axis params and sample array, verify in editor
- [ ] `set_state_blend_space` on an AnimBP with a state machine, verify BlendSpacePlayer node appears wired to Output Pose
- [ ] `set_state_blend_space` with `xVariable`/`yVariable`, verify VariableGet nodes are wired to X/Y pins
- [ ] Error cases: missing fields, non-existent blend space, non-existent state

🤖 Generated with [Claude Code](https://claude.com/claude-code)