### PR TITLE
Add Widget Blueprint tools for visual UMG editing

### DIFF
--- a/Source/BlueprintMCP/BlueprintMCP.Build.cs
+++ b/Source/BlueprintMCP/BlueprintMCP.Build.cs
@@ -30,7 +30,10 @@ public class BlueprintMCP : ModuleRules
 			"MaterialEditor",
 			"AnimGraph",
 			"AnimGraphRuntime",
-			"RHI"
+			"RHI",
+			"UMG",
+			"UMGEditor",
+			"SlateCore"
 		});
 	}
 }

--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_Widgets.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_Widgets.cpp
@@ -1,0 +1,933 @@
+#include "BlueprintMCPServer.h"
+#include "Engine/Blueprint.h"
+#include "WidgetBlueprint.h"
+#include "Blueprint/WidgetTree.h"
+#include "Components/Widget.h"
+#include "Components/PanelWidget.h"
+#include "Components/PanelSlot.h"
+#include "Components/CanvasPanel.h"
+#include "Components/CanvasPanelSlot.h"
+#include "Components/VerticalBox.h"
+#include "Components/HorizontalBox.h"
+#include "Components/Overlay.h"
+#include "Components/TextBlock.h"
+#include "Components/Image.h"
+#include "Components/Button.h"
+#include "Components/Border.h"
+#include "Components/SizeBox.h"
+#include "Components/ScaleBox.h"
+#include "Components/ScrollBox.h"
+#include "Components/GridPanel.h"
+#include "Components/WrapBox.h"
+#include "Components/WidgetSwitcher.h"
+#include "Components/Spacer.h"
+#include "Components/ProgressBar.h"
+#include "Components/Slider.h"
+#include "Components/CheckBox.h"
+#include "Components/ComboBoxString.h"
+#include "Components/EditableTextBox.h"
+#include "Kismet2/BlueprintEditorUtils.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+#include "UObject/UObjectIterator.h"
+#include "UObject/PropertyIterator.h"
+#include "AssetToolsModule.h"
+#include "IAssetTools.h"
+#include "WidgetBlueprintFactory.h"
+#include "UObject/SavePackage.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "Misc/PackageName.h"
+
+// ============================================================
+// LoadWidgetBlueprintByName — load and cast to UWidgetBlueprint
+// ============================================================
+
+UWidgetBlueprint* FBlueprintMCPServer::LoadWidgetBlueprintByName(const FString& NameOrPath, FString& OutError)
+{
+	UBlueprint* BP = LoadBlueprintByName(NameOrPath, OutError);
+	if (!BP)
+	{
+		return nullptr;
+	}
+
+	UWidgetBlueprint* WidgetBP = Cast<UWidgetBlueprint>(BP);
+	if (!WidgetBP)
+	{
+		OutError = FString::Printf(
+			TEXT("Blueprint '%s' is not a Widget Blueprint (class: %s). "
+				"This tool only works on Widget Blueprints (UMG)."),
+			*NameOrPath, *BP->GetClass()->GetName());
+		return nullptr;
+	}
+
+	return WidgetBP;
+}
+
+// ============================================================
+// Helper: Find a widget by name in the widget tree
+// ============================================================
+
+static UWidget* FindWidgetByName(UWidgetTree* Tree, const FString& WidgetName)
+{
+	TArray<UWidget*> AllWidgets;
+	Tree->GetAllWidgets(AllWidgets);
+
+	// Exact match first
+	for (UWidget* W : AllWidgets)
+	{
+		if (W && W->GetName() == WidgetName)
+		{
+			return W;
+		}
+	}
+
+	// Case-insensitive fallback
+	for (UWidget* W : AllWidgets)
+	{
+		if (W && W->GetName().Equals(WidgetName, ESearchCase::IgnoreCase))
+		{
+			return W;
+		}
+	}
+
+	return nullptr;
+}
+
+// ============================================================
+// Helper: Check if Target is a descendant of Ancestor
+// ============================================================
+
+static bool IsDescendantOf(UWidget* Target, UWidget* Ancestor)
+{
+	if (!Target || !Ancestor)
+	{
+		return false;
+	}
+
+	UPanelWidget* Panel = Cast<UPanelWidget>(Ancestor);
+	if (!Panel)
+	{
+		return false;
+	}
+
+	for (int32 i = 0; i < Panel->GetChildrenCount(); ++i)
+	{
+		UWidget* Child = Panel->GetChildAt(i);
+		if (Child == Target)
+		{
+			return true;
+		}
+		if (IsDescendantOf(Target, Child))
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+// ============================================================
+// Helper: Serialize a widget to JSON (for tree listing)
+// ============================================================
+
+static TSharedRef<FJsonObject> SerializeWidgetInfo(UWidget* Widget, UPanelWidget* ParentPanel)
+{
+	TSharedRef<FJsonObject> Obj = MakeShared<FJsonObject>();
+	Obj->SetStringField(TEXT("name"), Widget->GetName());
+	Obj->SetStringField(TEXT("class"), Widget->GetClass()->GetName());
+
+	if (ParentPanel)
+	{
+		Obj->SetStringField(TEXT("parent"), ParentPanel->GetName());
+	}
+
+	// Slot info
+	UPanelSlot* Slot = Widget->Slot;
+	if (Slot)
+	{
+		Obj->SetStringField(TEXT("slotClass"), Slot->GetClass()->GetName());
+	}
+
+	// Visibility
+	Obj->SetStringField(TEXT("visibility"), StaticEnum<ESlateVisibility>()->GetNameStringByValue((int64)Widget->GetVisibility()));
+
+	// If this widget is a panel, list child count
+	UPanelWidget* AsPanel = Cast<UPanelWidget>(Widget);
+	if (AsPanel)
+	{
+		Obj->SetBoolField(TEXT("isPanel"), true);
+		Obj->SetNumberField(TEXT("childCount"), AsPanel->GetChildrenCount());
+	}
+	else
+	{
+		Obj->SetBoolField(TEXT("isPanel"), false);
+	}
+
+	return Obj;
+}
+
+// ============================================================
+// Helper: Build widget tree recursively
+// ============================================================
+
+static void BuildWidgetTreeRecursive(UWidget* Widget, UPanelWidget* ParentPanel, TArray<TSharedPtr<FJsonValue>>& OutArray, int32 Depth)
+{
+	if (!Widget)
+	{
+		return;
+	}
+
+	TSharedRef<FJsonObject> WidgetObj = SerializeWidgetInfo(Widget, ParentPanel);
+	WidgetObj->SetNumberField(TEXT("depth"), Depth);
+	OutArray.Add(MakeShared<FJsonValueObject>(WidgetObj));
+
+	UPanelWidget* Panel = Cast<UPanelWidget>(Widget);
+	if (Panel)
+	{
+		for (int32 i = 0; i < Panel->GetChildrenCount(); ++i)
+		{
+			BuildWidgetTreeRecursive(Panel->GetChildAt(i), Panel, OutArray, Depth + 1);
+		}
+	}
+}
+
+// ============================================================
+// HandleListWidgetTree
+// ============================================================
+
+FString FBlueprintMCPServer::HandleListWidgetTree(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString BlueprintName = Json->GetStringField(TEXT("blueprint"));
+	if (BlueprintName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: blueprint"));
+	}
+
+	FString LoadError;
+	UWidgetBlueprint* WidgetBP = LoadWidgetBlueprintByName(BlueprintName, LoadError);
+	if (!WidgetBP)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	UWidgetTree* Tree = WidgetBP->WidgetTree;
+	if (!Tree)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Widget Blueprint '%s' has no WidgetTree"),
+			*BlueprintName));
+	}
+
+	TArray<TSharedPtr<FJsonValue>> WidgetsArr;
+
+	UWidget* Root = Tree->RootWidget;
+	if (Root)
+	{
+		BuildWidgetTreeRecursive(Root, nullptr, WidgetsArr, 0);
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("blueprint"), BlueprintName);
+	Result->SetStringField(TEXT("rootWidget"), Root ? Root->GetName() : TEXT("(none)"));
+	Result->SetNumberField(TEXT("count"), WidgetsArr.Num());
+	Result->SetArrayField(TEXT("widgets"), WidgetsArr);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleGetWidgetProperties
+// ============================================================
+
+FString FBlueprintMCPServer::HandleGetWidgetProperties(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString BlueprintName = Json->GetStringField(TEXT("blueprint"));
+	FString WidgetName = Json->GetStringField(TEXT("widget"));
+
+	if (BlueprintName.IsEmpty() || WidgetName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: blueprint, widget"));
+	}
+
+	FString LoadError;
+	UWidgetBlueprint* WidgetBP = LoadWidgetBlueprintByName(BlueprintName, LoadError);
+	if (!WidgetBP)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	UWidgetTree* Tree = WidgetBP->WidgetTree;
+	if (!Tree)
+	{
+		return MakeErrorJson(TEXT("Widget Blueprint has no WidgetTree"));
+	}
+
+	UWidget* Widget = FindWidgetByName(Tree, WidgetName);
+	if (!Widget)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Widget '%s' not found in Widget Blueprint '%s'"),
+			*WidgetName, *BlueprintName));
+	}
+
+	// Collect editable properties from the widget
+	TArray<TSharedPtr<FJsonValue>> PropsArr;
+
+	for (TFieldIterator<FProperty> It(Widget->GetClass()); It; ++It)
+	{
+		FProperty* Prop = *It;
+		if (!Prop || !Prop->HasAnyPropertyFlags(CPF_Edit))
+		{
+			continue;
+		}
+
+		TSharedRef<FJsonObject> PropObj = MakeShared<FJsonObject>();
+		PropObj->SetStringField(TEXT("name"), Prop->GetName());
+		PropObj->SetStringField(TEXT("type"), Prop->GetCPPType());
+		PropObj->SetStringField(TEXT("source"), TEXT("widget"));
+
+		FString ValueStr;
+		const void* ValuePtr = Prop->ContainerPtrToValuePtr<void>(Widget);
+		Prop->ExportTextItem_Direct(ValueStr, ValuePtr, nullptr, nullptr, PPF_None);
+		PropObj->SetStringField(TEXT("value"), ValueStr);
+
+		PropsArr.Add(MakeShared<FJsonValueObject>(PropObj));
+	}
+
+	// Collect slot properties if the widget has a slot
+	UPanelSlot* Slot = Widget->Slot;
+	if (Slot)
+	{
+		for (TFieldIterator<FProperty> It(Slot->GetClass()); It; ++It)
+		{
+			FProperty* Prop = *It;
+			if (!Prop || !Prop->HasAnyPropertyFlags(CPF_Edit))
+			{
+				continue;
+			}
+
+			TSharedRef<FJsonObject> PropObj = MakeShared<FJsonObject>();
+			PropObj->SetStringField(TEXT("name"), Prop->GetName());
+			PropObj->SetStringField(TEXT("type"), Prop->GetCPPType());
+			PropObj->SetStringField(TEXT("source"), TEXT("slot"));
+
+			FString ValueStr;
+			const void* ValuePtr = Prop->ContainerPtrToValuePtr<void>(Slot);
+			Prop->ExportTextItem_Direct(ValueStr, ValuePtr, nullptr, nullptr, PPF_None);
+			PropObj->SetStringField(TEXT("value"), ValueStr);
+
+			PropsArr.Add(MakeShared<FJsonValueObject>(PropObj));
+		}
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("blueprint"), BlueprintName);
+	Result->SetStringField(TEXT("widget"), Widget->GetName());
+	Result->SetStringField(TEXT("widgetClass"), Widget->GetClass()->GetName());
+	if (Slot)
+	{
+		Result->SetStringField(TEXT("slotClass"), Slot->GetClass()->GetName());
+	}
+	Result->SetNumberField(TEXT("propertyCount"), PropsArr.Num());
+	Result->SetArrayField(TEXT("properties"), PropsArr);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleAddWidget
+// ============================================================
+
+FString FBlueprintMCPServer::HandleAddWidget(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString BlueprintName = Json->GetStringField(TEXT("blueprint"));
+	FString WidgetClassName = Json->GetStringField(TEXT("widgetClass"));
+	FString WidgetName = Json->GetStringField(TEXT("name"));
+
+	if (BlueprintName.IsEmpty() || WidgetClassName.IsEmpty() || WidgetName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: blueprint, widgetClass, name"));
+	}
+
+	FString ParentWidgetName;
+	if (Json->HasField(TEXT("parent")))
+	{
+		ParentWidgetName = Json->GetStringField(TEXT("parent"));
+	}
+
+	FString LoadError;
+	UWidgetBlueprint* WidgetBP = LoadWidgetBlueprintByName(BlueprintName, LoadError);
+	if (!WidgetBP)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	UWidgetTree* Tree = WidgetBP->WidgetTree;
+	if (!Tree)
+	{
+		return MakeErrorJson(TEXT("Widget Blueprint has no WidgetTree"));
+	}
+
+	// Check for duplicate widget names
+	if (FindWidgetByName(Tree, WidgetName))
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("A widget named '%s' already exists in Widget Blueprint '%s'"),
+			*WidgetName, *BlueprintName));
+	}
+
+	// Resolve the widget class
+	UClass* WidgetClass = nullptr;
+	TArray<FString> NamesToTry;
+	NamesToTry.Add(WidgetClassName);
+	if (!WidgetClassName.StartsWith(TEXT("U")))
+	{
+		NamesToTry.Add(FString::Printf(TEXT("U%s"), *WidgetClassName));
+	}
+	else
+	{
+		NamesToTry.Add(WidgetClassName.Mid(1));
+	}
+
+	for (TObjectIterator<UClass> It; It; ++It)
+	{
+		if (!It->IsChildOf(UWidget::StaticClass()))
+		{
+			continue;
+		}
+
+		FString ClassName = It->GetName();
+		for (const FString& NameToTry : NamesToTry)
+		{
+			if (ClassName.Equals(NameToTry, ESearchCase::IgnoreCase))
+			{
+				WidgetClass = *It;
+				break;
+			}
+		}
+		if (WidgetClass)
+		{
+			break;
+		}
+	}
+
+	if (!WidgetClass)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Widget class '%s' not found or is not a subclass of UWidget. "
+				"Common classes: TextBlock, Button, Image, VerticalBox, HorizontalBox, "
+				"Overlay, CanvasPanel, Border, SizeBox, ScaleBox, ScrollBox, GridPanel, "
+				"WrapBox, WidgetSwitcher, Spacer, ProgressBar, Slider, CheckBox, "
+				"ComboBoxString, EditableTextBox"),
+			*WidgetClassName));
+	}
+
+	// Find parent panel if specified
+	UPanelWidget* ParentPanel = nullptr;
+	if (!ParentWidgetName.IsEmpty())
+	{
+		UWidget* ParentWidget = FindWidgetByName(Tree, ParentWidgetName);
+		if (!ParentWidget)
+		{
+			return MakeErrorJson(FString::Printf(
+				TEXT("Parent widget '%s' not found in Widget Blueprint '%s'"),
+				*ParentWidgetName, *BlueprintName));
+		}
+
+		ParentPanel = Cast<UPanelWidget>(ParentWidget);
+		if (!ParentPanel)
+		{
+			return MakeErrorJson(FString::Printf(
+				TEXT("Parent widget '%s' (class: %s) is not a panel widget and cannot have children. "
+					"Only panel widgets (CanvasPanel, VerticalBox, HorizontalBox, Overlay, etc.) "
+					"can contain child widgets."),
+				*ParentWidgetName, *ParentWidget->GetClass()->GetName()));
+		}
+	}
+	else
+	{
+		// If no parent specified and root exists, try to add to the root if it's a panel
+		UWidget* Root = Tree->RootWidget;
+		if (Root)
+		{
+			ParentPanel = Cast<UPanelWidget>(Root);
+			if (!ParentPanel)
+			{
+				return MakeErrorJson(FString::Printf(
+					TEXT("The root widget '%s' (class: %s) is not a panel widget. "
+						"Specify a 'parent' panel widget explicitly, or set this widget as root by first removing the existing root."),
+					*Root->GetName(), *Root->GetClass()->GetName()));
+			}
+		}
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Adding widget '%s' (%s) to Widget Blueprint '%s'"),
+		*WidgetName, *WidgetClass->GetName(), *BlueprintName);
+
+	// Create the widget in the tree
+	UWidget* NewWidget = Tree->ConstructWidget<UWidget>(WidgetClass, FName(*WidgetName));
+	if (!NewWidget)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Failed to construct widget '%s' with class '%s'"),
+			*WidgetName, *WidgetClass->GetName()));
+	}
+
+	// Add to parent or set as root
+	if (ParentPanel)
+	{
+		UPanelSlot* Slot = ParentPanel->AddChild(NewWidget);
+		if (!Slot)
+		{
+			return MakeErrorJson(FString::Printf(
+				TEXT("Failed to add widget '%s' as child of '%s'"),
+				*WidgetName, *ParentPanel->GetName()));
+		}
+	}
+	else
+	{
+		// No root widget exists — set this as root
+		Tree->RootWidget = NewWidget;
+	}
+
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WidgetBP);
+	bool bSaved = SaveBlueprintPackage(WidgetBP);
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Added widget '%s' (%s) to '%s' (parent: %s, saved: %s)"),
+		*WidgetName, *WidgetClass->GetName(), *BlueprintName,
+		ParentPanel ? *ParentPanel->GetName() : TEXT("(root)"),
+		bSaved ? TEXT("true") : TEXT("false"));
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("blueprint"), BlueprintName);
+	Result->SetStringField(TEXT("name"), NewWidget->GetName());
+	Result->SetStringField(TEXT("widgetClass"), WidgetClass->GetName());
+	if (ParentPanel)
+	{
+		Result->SetStringField(TEXT("parent"), ParentPanel->GetName());
+	}
+	else
+	{
+		Result->SetStringField(TEXT("parent"), TEXT("(root)"));
+	}
+	Result->SetBoolField(TEXT("saved"), bSaved);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleRemoveWidget
+// ============================================================
+
+FString FBlueprintMCPServer::HandleRemoveWidget(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString BlueprintName = Json->GetStringField(TEXT("blueprint"));
+	FString WidgetName = Json->GetStringField(TEXT("widget"));
+
+	if (BlueprintName.IsEmpty() || WidgetName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: blueprint, widget"));
+	}
+
+	FString LoadError;
+	UWidgetBlueprint* WidgetBP = LoadWidgetBlueprintByName(BlueprintName, LoadError);
+	if (!WidgetBP)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	UWidgetTree* Tree = WidgetBP->WidgetTree;
+	if (!Tree)
+	{
+		return MakeErrorJson(TEXT("Widget Blueprint has no WidgetTree"));
+	}
+
+	UWidget* Widget = FindWidgetByName(Tree, WidgetName);
+	if (!Widget)
+	{
+		// Build list of widget names for error message
+		TArray<UWidget*> AllWidgets;
+		Tree->GetAllWidgets(AllWidgets);
+		TArray<TSharedPtr<FJsonValue>> NameList;
+		for (UWidget* W : AllWidgets)
+		{
+			if (W)
+			{
+				NameList.Add(MakeShared<FJsonValueString>(W->GetName()));
+			}
+		}
+
+		TSharedRef<FJsonObject> ErrorResult = MakeShared<FJsonObject>();
+		ErrorResult->SetStringField(TEXT("error"), FString::Printf(
+			TEXT("Widget '%s' not found in Widget Blueprint '%s'"),
+			*WidgetName, *BlueprintName));
+		ErrorResult->SetArrayField(TEXT("existingWidgets"), NameList);
+		return JsonToString(ErrorResult);
+	}
+
+	// Refuse to remove panels that have children
+	UPanelWidget* AsPanel = Cast<UPanelWidget>(Widget);
+	if (AsPanel && AsPanel->GetChildrenCount() > 0)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Cannot remove widget '%s' because it is a panel with %d child(ren). "
+				"Remove or move the children first."),
+			*WidgetName, AsPanel->GetChildrenCount()));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Removing widget '%s' from Widget Blueprint '%s'"),
+		*WidgetName, *BlueprintName);
+
+	// Remove from parent panel
+	UPanelWidget* ParentPanel = Widget->GetParent();
+	if (ParentPanel)
+	{
+		ParentPanel->RemoveChild(Widget);
+	}
+	else if (Tree->RootWidget == Widget)
+	{
+		Tree->RootWidget = nullptr;
+	}
+
+	// Remove from widget tree
+	Tree->RemoveWidget(Widget);
+
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WidgetBP);
+	bool bSaved = SaveBlueprintPackage(WidgetBP);
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Removed widget '%s' from '%s' (saved: %s)"),
+		*WidgetName, *BlueprintName, bSaved ? TEXT("true") : TEXT("false"));
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("blueprint"), BlueprintName);
+	Result->SetStringField(TEXT("widget"), WidgetName);
+	Result->SetBoolField(TEXT("saved"), bSaved);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleSetWidgetProperty
+// ============================================================
+
+FString FBlueprintMCPServer::HandleSetWidgetProperty(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString BlueprintName = Json->GetStringField(TEXT("blueprint"));
+	FString WidgetName = Json->GetStringField(TEXT("widget"));
+	FString PropertyName = Json->GetStringField(TEXT("property"));
+	FString Value = Json->GetStringField(TEXT("value"));
+
+	if (BlueprintName.IsEmpty() || WidgetName.IsEmpty() || PropertyName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: blueprint, widget, property"));
+	}
+
+	FString LoadError;
+	UWidgetBlueprint* WidgetBP = LoadWidgetBlueprintByName(BlueprintName, LoadError);
+	if (!WidgetBP)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	UWidgetTree* Tree = WidgetBP->WidgetTree;
+	if (!Tree)
+	{
+		return MakeErrorJson(TEXT("Widget Blueprint has no WidgetTree"));
+	}
+
+	UWidget* Widget = FindWidgetByName(Tree, WidgetName);
+	if (!Widget)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Widget '%s' not found in Widget Blueprint '%s'"),
+			*WidgetName, *BlueprintName));
+	}
+
+	// Try to find the property on the widget first
+	FProperty* Prop = Widget->GetClass()->FindPropertyByName(FName(*PropertyName));
+	UObject* TargetObject = Widget;
+	FString Source = TEXT("widget");
+
+	// Fall through to slot if not found on widget
+	if (!Prop && Widget->Slot)
+	{
+		Prop = Widget->Slot->GetClass()->FindPropertyByName(FName(*PropertyName));
+		if (Prop)
+		{
+			TargetObject = Widget->Slot;
+			Source = TEXT("slot");
+		}
+	}
+
+	if (!Prop)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Property '%s' not found on widget '%s' (class: %s) or its slot. "
+				"Use get_widget_properties to see all available properties."),
+			*PropertyName, *WidgetName, *Widget->GetClass()->GetName()));
+	}
+
+	// Auto-wrap bare strings in INVTEXT("...") for FText properties
+	FString ValueToSet = Value;
+	FTextProperty* TextProp = CastField<FTextProperty>(Prop);
+	if (TextProp && !Value.StartsWith(TEXT("INVTEXT(")) && !Value.StartsWith(TEXT("NSLOCTEXT(")))
+	{
+		ValueToSet = FString::Printf(TEXT("INVTEXT(\"%s\")"), *Value);
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Setting property '%s' on widget '%s' to '%s' (source: %s)"),
+		*PropertyName, *WidgetName, *ValueToSet, *Source);
+
+	void* ValuePtr = Prop->ContainerPtrToValuePtr<void>(TargetObject);
+	const TCHAR* ImportResult = Prop->ImportText_Direct(*ValueToSet, ValuePtr, TargetObject, PPF_None);
+
+	if (!ImportResult)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Failed to set property '%s' to value '%s' on widget '%s'. "
+				"The value may be in an incorrect format for type '%s'."),
+			*PropertyName, *Value, *WidgetName, *Prop->GetCPPType()));
+	}
+
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WidgetBP);
+	bool bSaved = SaveBlueprintPackage(WidgetBP);
+
+	// Read back the value
+	FString ActualValue;
+	Prop->ExportTextItem_Direct(ActualValue, ValuePtr, nullptr, nullptr, PPF_None);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("blueprint"), BlueprintName);
+	Result->SetStringField(TEXT("widget"), WidgetName);
+	Result->SetStringField(TEXT("property"), PropertyName);
+	Result->SetStringField(TEXT("value"), ActualValue);
+	Result->SetStringField(TEXT("source"), Source);
+	Result->SetBoolField(TEXT("saved"), bSaved);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleMoveWidget
+// ============================================================
+
+FString FBlueprintMCPServer::HandleMoveWidget(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString BlueprintName = Json->GetStringField(TEXT("blueprint"));
+	FString WidgetName = Json->GetStringField(TEXT("widget"));
+	FString NewParentName = Json->GetStringField(TEXT("newParent"));
+
+	if (BlueprintName.IsEmpty() || WidgetName.IsEmpty() || NewParentName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: blueprint, widget, newParent"));
+	}
+
+	FString LoadError;
+	UWidgetBlueprint* WidgetBP = LoadWidgetBlueprintByName(BlueprintName, LoadError);
+	if (!WidgetBP)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	UWidgetTree* Tree = WidgetBP->WidgetTree;
+	if (!Tree)
+	{
+		return MakeErrorJson(TEXT("Widget Blueprint has no WidgetTree"));
+	}
+
+	UWidget* Widget = FindWidgetByName(Tree, WidgetName);
+	if (!Widget)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Widget '%s' not found in Widget Blueprint '%s'"),
+			*WidgetName, *BlueprintName));
+	}
+
+	UWidget* NewParentWidget = FindWidgetByName(Tree, NewParentName);
+	if (!NewParentWidget)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Target parent widget '%s' not found in Widget Blueprint '%s'"),
+			*NewParentName, *BlueprintName));
+	}
+
+	UPanelWidget* NewParentPanel = Cast<UPanelWidget>(NewParentWidget);
+	if (!NewParentPanel)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Target parent '%s' (class: %s) is not a panel widget and cannot have children."),
+			*NewParentName, *NewParentWidget->GetClass()->GetName()));
+	}
+
+	// Cycle detection: refuse to move widget into its own descendant
+	if (IsDescendantOf(NewParentWidget, Widget))
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Cannot move widget '%s' into '%s' because '%s' is a descendant of '%s'. "
+				"This would create a cycle in the widget tree."),
+			*WidgetName, *NewParentName, *NewParentName, *WidgetName));
+	}
+
+	// Cannot move to same parent
+	if (Widget->GetParent() == NewParentPanel)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Widget '%s' is already a child of '%s'"),
+			*WidgetName, *NewParentName));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Moving widget '%s' to new parent '%s' in '%s'"),
+		*WidgetName, *NewParentName, *BlueprintName);
+
+	// Remove from current parent
+	UPanelWidget* OldParent = Widget->GetParent();
+	FString OldParentName = OldParent ? OldParent->GetName() : TEXT("(root)");
+	if (OldParent)
+	{
+		OldParent->RemoveChild(Widget);
+	}
+	else if (Tree->RootWidget == Widget)
+	{
+		Tree->RootWidget = nullptr;
+	}
+
+	// Add to new parent
+	UPanelSlot* NewSlot = NewParentPanel->AddChild(Widget);
+	if (!NewSlot)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Failed to add widget '%s' as child of '%s'"),
+			*WidgetName, *NewParentName));
+	}
+
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WidgetBP);
+	bool bSaved = SaveBlueprintPackage(WidgetBP);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("blueprint"), BlueprintName);
+	Result->SetStringField(TEXT("widget"), WidgetName);
+	Result->SetStringField(TEXT("oldParent"), OldParentName);
+	Result->SetStringField(TEXT("newParent"), NewParentName);
+	Result->SetBoolField(TEXT("saved"), bSaved);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleCreateWidgetBlueprint
+// ============================================================
+
+FString FBlueprintMCPServer::HandleCreateWidgetBlueprint(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString Name = Json->GetStringField(TEXT("name"));
+	FString PackagePath = Json->GetStringField(TEXT("packagePath"));
+
+	if (Name.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: name"));
+	}
+	if (PackagePath.IsEmpty())
+	{
+		PackagePath = TEXT("/Game");
+	}
+
+	// Check if asset already exists
+	FString FullPath = PackagePath / Name;
+	FAssetData* Existing = FindBlueprintAsset(FullPath);
+	if (!Existing)
+	{
+		Existing = FindBlueprintAsset(Name);
+	}
+	if (Existing)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("An asset named '%s' already exists at '%s'"),
+			*Name, *Existing->PackageName.ToString()));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Creating Widget Blueprint '%s' at '%s'"),
+		*Name, *PackagePath);
+
+	// Create the Widget Blueprint using the factory
+	UWidgetBlueprintFactory* Factory = NewObject<UWidgetBlueprintFactory>();
+
+	IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();
+	UObject* NewAsset = AssetTools.CreateAsset(Name, PackagePath, UWidgetBlueprint::StaticClass(), Factory);
+
+	if (!NewAsset)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Failed to create Widget Blueprint '%s' at '%s'"),
+			*Name, *PackagePath));
+	}
+
+	UWidgetBlueprint* NewWidgetBP = Cast<UWidgetBlueprint>(NewAsset);
+	if (!NewWidgetBP)
+	{
+		return MakeErrorJson(TEXT("Created asset is not a Widget Blueprint"));
+	}
+
+	// Save the package
+	bool bSaved = SaveBlueprintPackage(NewWidgetBP);
+
+	// Add to our cached asset list
+	FAssetRegistryModule& ARM = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+	FAssetData NewAssetData = ARM.Get().GetAssetByObjectPath(FSoftObjectPath(NewWidgetBP));
+	if (NewAssetData.IsValid())
+	{
+		AllBlueprintAssets.Add(NewAssetData);
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Created Widget Blueprint '%s' (saved: %s)"),
+		*Name, bSaved ? TEXT("true") : TEXT("false"));
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("name"), Name);
+	Result->SetStringField(TEXT("packagePath"), PackagePath);
+	Result->SetStringField(TEXT("fullPath"), FullPath);
+	Result->SetStringField(TEXT("class"), TEXT("WidgetBlueprint"));
+	Result->SetBoolField(TEXT("saved"), bSaved);
+	return JsonToString(Result);
+}

--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -867,16 +867,22 @@ bool FBlueprintMCPServer::ProcessOneRequest()
 	FString Response;
 	if (FRequestHandler* Handler = HandlerMap.Find(Req->Endpoint))
 	{
-		// Wrap mutation endpoints in an undo transaction so users can Ctrl+Z
+		// Wrap mutation endpoints in an undo transaction so users can Ctrl+Z.
+		// Widget Blueprint mutations are EXCLUDED because BP recompilation creates
+		// REINST_ objects whose WidgetTree references get trapped in the TransBuffer,
+		// preventing the old World from being garbage-collected (fatal "World Leak"
+		// crash in ReferenceChainSearch.cpp). Widget tools use snapshot/restore instead.
 		const bool bIsMutation = MutationEndpoints.Contains(Req->Endpoint);
-		if (bIsMutation && GEditor)
+		const bool bIsWidgetMutation = WidgetMutationEndpoints.Contains(Req->Endpoint);
+		const bool bUseTransaction = bIsMutation && !bIsWidgetMutation && GEditor != nullptr;
+		if (bUseTransaction)
 		{
 			GEditor->BeginTransaction(FText::FromString(FString::Printf(TEXT("BlueprintMCP: %s"), *Req->Endpoint)));
 		}
 
 		Response = (*Handler)(Req->QueryParams, Req->Body);
 
-		if (bIsMutation && GEditor)
+		if (bUseTransaction)
 		{
 			GEditor->EndTransaction();
 		}
@@ -955,6 +961,17 @@ void FBlueprintMCPServer::RegisterHandlers()
 		TEXT("addAnimNode"),
 		TEXT("addStateMachine"),
 		TEXT("setStateAnimation"),
+		TEXT("addWidget"),
+		TEXT("removeWidget"),
+		TEXT("setWidgetProperty"),
+		TEXT("moveWidget"),
+		TEXT("createWidgetBlueprint"),
+	};
+
+	// Widget mutations that must NOT be wrapped in undo transactions.
+	// Recompilation of Widget Blueprints creates REINST_ objects whose
+	// WidgetTree refs in the TransBuffer prevent World GC → fatal crash.
+	WidgetMutationEndpoints = {
 		TEXT("addWidget"),
 		TEXT("removeWidget"),
 		TEXT("setWidgetProperty"),

--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -788,6 +788,22 @@ bool FBlueprintMCPServer::Start(int32 InPort, bool bEditorMode)
 	Router->BindRoute(FHttpPath(TEXT("/api/set-state-blend-space")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("setStateBlendSpace")));
 
+	// Widget Blueprint tools
+	Router->BindRoute(FHttpPath(TEXT("/api/list-widget-tree")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("listWidgetTree")));
+	Router->BindRoute(FHttpPath(TEXT("/api/get-widget-properties")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("getWidgetProperties")));
+	Router->BindRoute(FHttpPath(TEXT("/api/add-widget")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("addWidget")));
+	Router->BindRoute(FHttpPath(TEXT("/api/remove-widget")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("removeWidget")));
+	Router->BindRoute(FHttpPath(TEXT("/api/set-widget-property")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("setWidgetProperty")));
+	Router->BindRoute(FHttpPath(TEXT("/api/move-widget")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("moveWidget")));
+	Router->BindRoute(FHttpPath(TEXT("/api/create-widget-blueprint")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("createWidgetBlueprint")));
+
 	// Register TMap dispatch handlers
 	RegisterHandlers();
 
@@ -939,6 +955,11 @@ void FBlueprintMCPServer::RegisterHandlers()
 		TEXT("addAnimNode"),
 		TEXT("addStateMachine"),
 		TEXT("setStateAnimation"),
+		TEXT("addWidget"),
+		TEXT("removeWidget"),
+		TEXT("setWidgetProperty"),
+		TEXT("moveWidget"),
+		TEXT("createWidgetBlueprint"),
 	};
 
 	// GET handlers (use QueryParams, ignore Body)
@@ -1047,6 +1068,15 @@ void FBlueprintMCPServer::RegisterHandlers()
 	HandlerMap.Add(TEXT("createBlendSpace"),        [this](const TMap<FString, FString>&, const FString& B) { return HandleCreateBlendSpace(B); });
 	HandlerMap.Add(TEXT("setBlendSpaceSamples"),    [this](const TMap<FString, FString>&, const FString& B) { return HandleSetBlendSpaceSamples(B); });
 	HandlerMap.Add(TEXT("setStateBlendSpace"),      [this](const TMap<FString, FString>&, const FString& B) { return HandleSetStateBlendSpace(B); });
+
+	// Widget Blueprint handlers
+	HandlerMap.Add(TEXT("listWidgetTree"),          [this](const TMap<FString, FString>&, const FString& B) { return HandleListWidgetTree(B); });
+	HandlerMap.Add(TEXT("getWidgetProperties"),     [this](const TMap<FString, FString>&, const FString& B) { return HandleGetWidgetProperties(B); });
+	HandlerMap.Add(TEXT("addWidget"),               [this](const TMap<FString, FString>&, const FString& B) { return HandleAddWidget(B); });
+	HandlerMap.Add(TEXT("removeWidget"),            [this](const TMap<FString, FString>&, const FString& B) { return HandleRemoveWidget(B); });
+	HandlerMap.Add(TEXT("setWidgetProperty"),       [this](const TMap<FString, FString>&, const FString& B) { return HandleSetWidgetProperty(B); });
+	HandlerMap.Add(TEXT("moveWidget"),              [this](const TMap<FString, FString>&, const FString& B) { return HandleMoveWidget(B); });
+	HandlerMap.Add(TEXT("createWidgetBlueprint"),   [this](const TMap<FString, FString>&, const FString& B) { return HandleCreateWidgetBlueprint(B); });
 }
 
 // ============================================================

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -14,6 +14,7 @@ class UMaterial;
 class UMaterialInstanceConstant;
 class UMaterialFunction;
 class UMaterialExpression;
+class UWidgetBlueprint;
 
 // ----- Snapshot data structures -----
 
@@ -204,6 +205,15 @@ private:
 	FString HandleRemoveComponent(const FString& Body);
 	FString HandleListComponents(const FString& Body);
 
+	// ----- Widget Blueprint tools -----
+	FString HandleListWidgetTree(const FString& Body);
+	FString HandleGetWidgetProperties(const FString& Body);
+	FString HandleAddWidget(const FString& Body);
+	FString HandleRemoveWidget(const FString& Body);
+	FString HandleSetWidgetProperty(const FString& Body);
+	FString HandleMoveWidget(const FString& Body);
+	FString HandleCreateWidgetBlueprint(const FString& Body);
+
 	// ----- Property defaults -----
 	FString HandleSetBlueprintDefault(const FString& Body);
 
@@ -290,6 +300,9 @@ private:
 	FString MakeErrorJson(const FString& Message);
 	bool SaveBlueprintPackage(UBlueprint* BP);
 	static FString UrlDecode(const FString& EncodedString);
+
+	// ----- Widget helpers -----
+	UWidgetBlueprint* LoadWidgetBlueprintByName(const FString& NameOrPath, FString& OutError);
 
 	// ----- Material helpers -----
 	/** Ensure that Material->MaterialGraph exists (creates it on demand for commandlet mode). */

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -99,6 +99,7 @@ private:
 	using FRequestHandler = TFunction<FString(const TMap<FString, FString>&, const FString&)>;
 	TMap<FString, FRequestHandler> HandlerMap;
 	TSet<FString> MutationEndpoints;
+	TSet<FString> WidgetMutationEndpoints; // excluded from undo transactions (see ProcessOneRequest)
 	void RegisterHandlers();
 	// ----- Queued request model -----
 	struct FPendingRequest

--- a/Tools/src/index.ts
+++ b/Tools/src/index.ts
@@ -20,6 +20,7 @@ import { registerUserTypeTools } from "./tools/user-types.js";
 import { registerMaterialReadTools } from "./tools/material-read.js";
 import { registerMaterialMutationTools } from "./tools/material-mutation.js";
 import { registerAnimationTools } from "./tools/animation-mutation.js";
+import { registerWidgetTools } from "./tools/widgets.js";
 
 // Resource registrations
 import { registerBlueprintListResource } from "./resources/blueprint-list.js";
@@ -48,6 +49,7 @@ registerUserTypeTools(server);
 registerMaterialReadTools(server);
 registerMaterialMutationTools(server);
 registerAnimationTools(server);
+registerWidgetTools(server);
 
 // Register resources
 registerBlueprintListResource(server);

--- a/Tools/src/tools/widgets.ts
+++ b/Tools/src/tools/widgets.ts
@@ -1,0 +1,248 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ensureUE, uePost } from "../ue-bridge.js";
+
+export function registerWidgetTools(server: McpServer): void {
+  // ---------------------------------------------------------------
+  // list_widget_tree
+  // ---------------------------------------------------------------
+  server.tool(
+    "list_widget_tree",
+    "List the full widget hierarchy of a Widget Blueprint (UMG). Shows widget names, classes, parents, slots, and panel/child relationships. Only works on Widget Blueprints.",
+    {
+      blueprint: z.string().describe("Widget Blueprint name or package path (e.g. 'WBP_PlayerHud')"),
+    },
+    async ({ blueprint }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/list-widget-tree", { blueprint });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Widget Blueprint: ${data.blueprint}`);
+      lines.push(`Root: ${data.rootWidget}`);
+      lines.push(`Widgets (${data.count || 0}):`);
+
+      for (const w of data.widgets || []) {
+        const indent = "  ".repeat((w.depth || 0) + 1);
+        const parent = w.parent ? ` (parent: ${w.parent})` : " [Root]";
+        const panel = w.isPanel ? ` [Panel, ${w.childCount} children]` : "";
+        const slot = w.slotClass ? ` slot:${w.slotClass}` : "";
+        lines.push(`${indent}${w.name}: ${w.class}${parent}${panel}${slot}`);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  // ---------------------------------------------------------------
+  // get_widget_properties
+  // ---------------------------------------------------------------
+  server.tool(
+    "get_widget_properties",
+    "Get all editable properties of a specific widget in a Widget Blueprint, including slot properties (anchors, alignment, padding, etc.). Use this to inspect current values before calling set_widget_property.",
+    {
+      blueprint: z.string().describe("Widget Blueprint name or package path"),
+      widget: z.string().describe("Name of the widget to inspect"),
+    },
+    async ({ blueprint, widget }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/get-widget-properties", { blueprint, widget });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Widget: ${data.widget} (${data.widgetClass})`);
+      if (data.slotClass) lines.push(`Slot: ${data.slotClass}`);
+      lines.push(`Properties (${data.propertyCount || 0}):`);
+
+      for (const p of data.properties || []) {
+        const src = p.source === "slot" ? " [slot]" : "";
+        lines.push(`  ${p.name} (${p.type})${src} = ${p.value}`);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  // ---------------------------------------------------------------
+  // add_widget
+  // ---------------------------------------------------------------
+  server.tool(
+    "add_widget",
+    "Add a widget to a Widget Blueprint's designer hierarchy. Common widget classes: TextBlock, Button, Image, VerticalBox, HorizontalBox, Overlay, CanvasPanel, Border, SizeBox, ScaleBox, ScrollBox, Spacer, ProgressBar, Slider, CheckBox. If no parent is specified, adds to the root panel.",
+    {
+      blueprint: z.string().describe("Widget Blueprint name or package path"),
+      widgetClass: z.string().describe("Widget class name (e.g. 'TextBlock', 'Button', 'VerticalBox')"),
+      name: z.string().describe("Name for the new widget (e.g. 'TitleText', 'StartButton')"),
+      parent: z.string().optional().describe("Name of the parent panel widget (optional, defaults to root panel)"),
+    },
+    async ({ blueprint, widgetClass, name, parent }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { blueprint, widgetClass, name };
+      if (parent) body.parent = parent;
+
+      const data = await uePost("/api/add-widget", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Widget added successfully.`);
+      lines.push(`Blueprint: ${data.blueprint}`);
+      lines.push(`Name: ${data.name}`);
+      lines.push(`Class: ${data.widgetClass}`);
+      lines.push(`Parent: ${data.parent}`);
+      if (data.saved !== undefined) lines.push(`Saved: ${data.saved}`);
+
+      lines.push(``);
+      lines.push(`Next steps:`);
+      lines.push(`  list_widget_tree(blueprint="${blueprint}") — verify the widget hierarchy`);
+      lines.push(`  set_widget_property(blueprint="${blueprint}", widget="${name}", ...) — configure widget properties`);
+      lines.push(`  get_widget_properties(blueprint="${blueprint}", widget="${name}") — see all available properties`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  // ---------------------------------------------------------------
+  // remove_widget
+  // ---------------------------------------------------------------
+  server.tool(
+    "remove_widget",
+    "Remove a widget from a Widget Blueprint's designer hierarchy. Cannot remove panel widgets that have children — remove or move the children first.",
+    {
+      blueprint: z.string().describe("Widget Blueprint name or package path"),
+      widget: z.string().describe("Name of the widget to remove"),
+    },
+    async ({ blueprint, widget }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/remove-widget", { blueprint, widget });
+      if (data.error) {
+        let msg = `Error: ${data.error}`;
+        if (data.existingWidgets?.length) {
+          msg += `\nExisting widgets: ${data.existingWidgets.join(", ")}`;
+        }
+        return { content: [{ type: "text" as const, text: msg }] };
+      }
+
+      const lines: string[] = [];
+      lines.push(`Widget removed successfully.`);
+      lines.push(`Blueprint: ${data.blueprint}`);
+      lines.push(`Removed: ${data.widget}`);
+      if (data.saved !== undefined) lines.push(`Saved: ${data.saved}`);
+
+      lines.push(``);
+      lines.push(`Next steps:`);
+      lines.push(`  list_widget_tree(blueprint="${blueprint}") — verify the widget was removed`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  // ---------------------------------------------------------------
+  // set_widget_property
+  // ---------------------------------------------------------------
+  server.tool(
+    "set_widget_property",
+    "Set a property on a widget or its slot (layout) in a Widget Blueprint. Properties are searched on the widget first, then on its slot. For FText properties, bare strings are automatically wrapped in INVTEXT(). Use get_widget_properties to discover available properties.",
+    {
+      blueprint: z.string().describe("Widget Blueprint name or package path"),
+      widget: z.string().describe("Name of the widget to modify"),
+      property: z.string().describe("Property name (e.g. 'Text', 'ColorAndOpacity', 'Visibility')"),
+      value: z.string().describe("Value to set (e.g. 'Hello World' for Text, '(R=1,G=0,B=0,A=1)' for color)"),
+    },
+    async ({ blueprint, widget, property, value }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/set-widget-property", { blueprint, widget, property, value });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Property set successfully.`);
+      lines.push(`Widget: ${data.widget}`);
+      lines.push(`Property: ${data.property} (${data.source})`);
+      lines.push(`Value: ${data.value}`);
+      if (data.saved !== undefined) lines.push(`Saved: ${data.saved}`);
+
+      lines.push(``);
+      lines.push(`Next steps:`);
+      lines.push(`  get_widget_properties(blueprint="${blueprint}", widget="${widget}") — verify the change`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  // ---------------------------------------------------------------
+  // move_widget
+  // ---------------------------------------------------------------
+  server.tool(
+    "move_widget",
+    "Move a widget from its current parent to a different panel widget in the same Widget Blueprint. Includes cycle detection to prevent moving a widget into its own descendant.",
+    {
+      blueprint: z.string().describe("Widget Blueprint name or package path"),
+      widget: z.string().describe("Name of the widget to move"),
+      newParent: z.string().describe("Name of the new parent panel widget"),
+    },
+    async ({ blueprint, widget, newParent }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/move-widget", { blueprint, widget, newParent });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Widget moved successfully.`);
+      lines.push(`Widget: ${data.widget}`);
+      lines.push(`From: ${data.oldParent}`);
+      lines.push(`To: ${data.newParent}`);
+      if (data.saved !== undefined) lines.push(`Saved: ${data.saved}`);
+
+      lines.push(``);
+      lines.push(`Next steps:`);
+      lines.push(`  list_widget_tree(blueprint="${blueprint}") — verify the new hierarchy`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  // ---------------------------------------------------------------
+  // create_widget_blueprint
+  // ---------------------------------------------------------------
+  server.tool(
+    "create_widget_blueprint",
+    "Create a new empty Widget Blueprint (UMG). The new blueprint will have an empty widget tree ready for adding widgets.",
+    {
+      name: z.string().describe("Name for the new Widget Blueprint (e.g. 'WBP_MainMenu')"),
+      packagePath: z.string().optional().describe("Package path (default: '/Game')"),
+    },
+    async ({ name, packagePath }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { name };
+      if (packagePath) body.packagePath = packagePath;
+
+      const data = await uePost("/api/create-widget-blueprint", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Widget Blueprint created successfully.`);
+      lines.push(`Name: ${data.name}`);
+      lines.push(`Path: ${data.fullPath}`);
+      if (data.saved !== undefined) lines.push(`Saved: ${data.saved}`);
+
+      lines.push(``);
+      lines.push(`Next steps:`);
+      lines.push(`  add_widget(blueprint="${name}", widgetClass="CanvasPanel", name="RootCanvas") — add a root panel`);
+      lines.push(`  list_widget_tree(blueprint="${name}") — view the widget hierarchy`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+}

--- a/Tools/test/helpers.ts
+++ b/Tools/test/helpers.ts
@@ -134,6 +134,19 @@ export async function createTestMaterialFunction(opts: {
 }
 
 /**
+ * Create a test Widget Blueprint via the HTTP API.
+ */
+export async function createTestWidgetBlueprint(opts: {
+  name: string;
+  packagePath?: string;
+}): Promise<any> {
+  return uePost("/api/create-widget-blueprint", {
+    name: opts.name,
+    packagePath: opts.packagePath ?? "/Game/Test",
+  });
+}
+
+/**
  * Create a test Animation Blueprint via the HTTP API.
  */
 export async function createTestAnimBlueprint(opts: {

--- a/Tools/test/tools/widgets.test.ts
+++ b/Tools/test/tools/widgets.test.ts
@@ -1,0 +1,374 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { uePost, createTestWidgetBlueprint, deleteTestBlueprint, uniqueName } from "../helpers.js";
+
+describe("Widget Blueprint tools", () => {
+  const wbpName = uniqueName("WBP_WidgetTest");
+  const packagePath = "/Game/Test";
+
+  beforeAll(async () => {
+    const res = await createTestWidgetBlueprint({ name: wbpName });
+    expect(res.error).toBeUndefined();
+    expect(res.success).toBe(true);
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${wbpName}`);
+  });
+
+  // --- create_widget_blueprint tests ---
+
+  it("create_widget_blueprint succeeds", async () => {
+    const name = uniqueName("WBP_CreateTest");
+    const data = await uePost("/api/create-widget-blueprint", {
+      name,
+      packagePath,
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.name).toBe(name);
+    expect(data.class).toBe("WidgetBlueprint");
+
+    // Cleanup
+    await deleteTestBlueprint(`${packagePath}/${name}`);
+  });
+
+  it("create_widget_blueprint rejects missing name", async () => {
+    const data = await uePost("/api/create-widget-blueprint", {});
+    expect(data.error).toBeDefined();
+  });
+
+  // --- list_widget_tree tests ---
+
+  it("list_widget_tree on empty widget blueprint", async () => {
+    const data = await uePost("/api/list-widget-tree", { blueprint: wbpName });
+    expect(data.error).toBeUndefined();
+    expect(data.blueprint).toBe(wbpName);
+    expect(data.widgets).toBeDefined();
+    expect(Array.isArray(data.widgets)).toBe(true);
+  });
+
+  it("list_widget_tree rejects non-widget blueprint", async () => {
+    // Create a regular Actor blueprint
+    const actorBpName = uniqueName("BP_NonWidgetTest");
+    await uePost("/api/create-blueprint", {
+      blueprintName: actorBpName,
+      packagePath,
+      parentClass: "Actor",
+      blueprintType: "Normal",
+    });
+
+    const data = await uePost("/api/list-widget-tree", { blueprint: actorBpName });
+    expect(data.error).toBeDefined();
+    expect(data.error).toContain("not a Widget Blueprint");
+
+    await deleteTestBlueprint(`${packagePath}/${actorBpName}`);
+  });
+
+  it("list_widget_tree rejects missing fields", async () => {
+    const data = await uePost("/api/list-widget-tree", {});
+    expect(data.error).toBeDefined();
+  });
+
+  it("list_widget_tree rejects non-existent blueprint", async () => {
+    const data = await uePost("/api/list-widget-tree", { blueprint: "WBP_Nonexistent_XYZ_999" });
+    expect(data.error).toBeDefined();
+  });
+
+  // --- add_widget tests ---
+
+  it("adds a CanvasPanel as root", async () => {
+    const data = await uePost("/api/add-widget", {
+      blueprint: wbpName,
+      widgetClass: "CanvasPanel",
+      name: "RootCanvas",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.name).toBe("RootCanvas");
+    expect(data.widgetClass).toContain("CanvasPanel");
+    expect(data.saved).toBe(true);
+  });
+
+  it("lists the root CanvasPanel", async () => {
+    const data = await uePost("/api/list-widget-tree", { blueprint: wbpName });
+    expect(data.error).toBeUndefined();
+    expect(data.rootWidget).toBe("RootCanvas");
+    expect(data.count).toBeGreaterThanOrEqual(1);
+    const root = data.widgets.find((w: any) => w.name === "RootCanvas");
+    expect(root).toBeDefined();
+    expect(root.isPanel).toBe(true);
+  });
+
+  it("adds a TextBlock to the CanvasPanel", async () => {
+    const data = await uePost("/api/add-widget", {
+      blueprint: wbpName,
+      widgetClass: "TextBlock",
+      name: "TitleText",
+      parent: "RootCanvas",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.name).toBe("TitleText");
+    expect(data.parent).toBe("RootCanvas");
+  });
+
+  it("adds a VerticalBox to the CanvasPanel", async () => {
+    const data = await uePost("/api/add-widget", {
+      blueprint: wbpName,
+      widgetClass: "VerticalBox",
+      name: "MainVBox",
+      parent: "RootCanvas",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.widgetClass).toContain("VerticalBox");
+  });
+
+  it("adds a Button inside the VerticalBox", async () => {
+    const data = await uePost("/api/add-widget", {
+      blueprint: wbpName,
+      widgetClass: "Button",
+      name: "StartButton",
+      parent: "MainVBox",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.parent).toBe("MainVBox");
+  });
+
+  it("rejects duplicate widget name", async () => {
+    const data = await uePost("/api/add-widget", {
+      blueprint: wbpName,
+      widgetClass: "TextBlock",
+      name: "TitleText",
+    });
+    expect(data.error).toBeDefined();
+    expect(data.error).toContain("already exists");
+  });
+
+  it("rejects adding child to non-panel widget", async () => {
+    const data = await uePost("/api/add-widget", {
+      blueprint: wbpName,
+      widgetClass: "TextBlock",
+      name: "ChildOfText",
+      parent: "TitleText",
+    });
+    expect(data.error).toBeDefined();
+    expect(data.error).toContain("not a panel");
+  });
+
+  it("rejects invalid widget class", async () => {
+    const data = await uePost("/api/add-widget", {
+      blueprint: wbpName,
+      widgetClass: "FakeWidgetClass_XYZ_999",
+      name: "TestFake",
+    });
+    expect(data.error).toBeDefined();
+    expect(data.error).toContain("not found");
+  });
+
+  it("rejects missing required fields for add_widget", async () => {
+    const data = await uePost("/api/add-widget", {});
+    expect(data.error).toBeDefined();
+  });
+
+  // --- get_widget_properties tests ---
+
+  it("gets properties for a TextBlock", async () => {
+    const data = await uePost("/api/get-widget-properties", {
+      blueprint: wbpName,
+      widget: "TitleText",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.widget).toBe("TitleText");
+    expect(data.widgetClass).toContain("TextBlock");
+    expect(data.properties).toBeDefined();
+    expect(Array.isArray(data.properties)).toBe(true);
+    expect(data.propertyCount).toBeGreaterThan(0);
+
+    // Should have both widget and slot properties
+    const widgetProps = data.properties.filter((p: any) => p.source === "widget");
+    const slotProps = data.properties.filter((p: any) => p.source === "slot");
+    expect(widgetProps.length).toBeGreaterThan(0);
+    expect(slotProps.length).toBeGreaterThan(0);
+  });
+
+  it("rejects get_widget_properties for non-existent widget", async () => {
+    const data = await uePost("/api/get-widget-properties", {
+      blueprint: wbpName,
+      widget: "NonExistent_XYZ_999",
+    });
+    expect(data.error).toBeDefined();
+    expect(data.error).toContain("not found");
+  });
+
+  it("rejects get_widget_properties with missing fields", async () => {
+    const data = await uePost("/api/get-widget-properties", {
+      blueprint: wbpName,
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  // --- set_widget_property tests ---
+
+  it("sets Text property on a TextBlock", async () => {
+    const data = await uePost("/api/set-widget-property", {
+      blueprint: wbpName,
+      widget: "TitleText",
+      property: "Text",
+      value: "Hello World",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.property).toBe("Text");
+    expect(data.source).toBe("widget");
+  });
+
+  it("rejects set_widget_property for invalid property", async () => {
+    const data = await uePost("/api/set-widget-property", {
+      blueprint: wbpName,
+      widget: "TitleText",
+      property: "NonExistentProperty_XYZ_999",
+      value: "test",
+    });
+    expect(data.error).toBeDefined();
+    expect(data.error).toContain("not found");
+  });
+
+  it("rejects set_widget_property with missing fields", async () => {
+    const data = await uePost("/api/set-widget-property", {
+      blueprint: wbpName,
+      widget: "TitleText",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  // --- move_widget tests ---
+
+  it("moves a widget to a different parent", async () => {
+    // Move TitleText from RootCanvas to MainVBox
+    const data = await uePost("/api/move-widget", {
+      blueprint: wbpName,
+      widget: "TitleText",
+      newParent: "MainVBox",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.widget).toBe("TitleText");
+    expect(data.oldParent).toBe("RootCanvas");
+    expect(data.newParent).toBe("MainVBox");
+  });
+
+  it("verifies widget was moved", async () => {
+    const data = await uePost("/api/list-widget-tree", { blueprint: wbpName });
+    expect(data.error).toBeUndefined();
+    const titleText = data.widgets.find((w: any) => w.name === "TitleText");
+    expect(titleText).toBeDefined();
+    expect(titleText.parent).toBe("MainVBox");
+  });
+
+  it("rejects move to non-panel target", async () => {
+    const data = await uePost("/api/move-widget", {
+      blueprint: wbpName,
+      widget: "StartButton",
+      newParent: "TitleText",
+    });
+    expect(data.error).toBeDefined();
+    expect(data.error).toContain("not a panel");
+  });
+
+  it("rejects move that would create a cycle", async () => {
+    // Try to move MainVBox (which contains StartButton) into StartButton
+    // StartButton is a PanelWidget (Button is a ContentWidget/PanelWidget)
+    // but MainVBox is an ancestor of StartButton so this should fail
+    const data = await uePost("/api/move-widget", {
+      blueprint: wbpName,
+      widget: "MainVBox",
+      newParent: "StartButton",
+    });
+    expect(data.error).toBeDefined();
+    // Could be cycle detection or non-panel error depending on Button's type
+    expect(data.error).toBeTruthy();
+  });
+
+  it("rejects move with missing fields", async () => {
+    const data = await uePost("/api/move-widget", {
+      blueprint: wbpName,
+      widget: "TitleText",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  // --- remove_widget tests ---
+
+  it("removes a leaf widget (StartButton)", async () => {
+    const data = await uePost("/api/remove-widget", {
+      blueprint: wbpName,
+      widget: "StartButton",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.saved).toBe(true);
+  });
+
+  it("removes TitleText", async () => {
+    const data = await uePost("/api/remove-widget", {
+      blueprint: wbpName,
+      widget: "TitleText",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+  });
+
+  it("verifies widgets are removed", async () => {
+    const data = await uePost("/api/list-widget-tree", { blueprint: wbpName });
+    expect(data.error).toBeUndefined();
+    const btn = data.widgets.find((w: any) => w.name === "StartButton");
+    expect(btn).toBeUndefined();
+    const txt = data.widgets.find((w: any) => w.name === "TitleText");
+    expect(txt).toBeUndefined();
+  });
+
+  it("rejects removing non-existent widget", async () => {
+    const data = await uePost("/api/remove-widget", {
+      blueprint: wbpName,
+      widget: "NonExistent_XYZ_999",
+    });
+    expect(data.error).toBeDefined();
+    expect(data.error).toContain("not found");
+    expect(data.existingWidgets).toBeDefined();
+  });
+
+  it("rejects removing panel with children", async () => {
+    // RootCanvas still has MainVBox as a child
+    const data = await uePost("/api/remove-widget", {
+      blueprint: wbpName,
+      widget: "RootCanvas",
+    });
+    expect(data.error).toBeDefined();
+    expect(data.error).toContain("child");
+  });
+
+  it("rejects remove with missing fields", async () => {
+    const data = await uePost("/api/remove-widget", {
+      blueprint: wbpName,
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("cleans up remaining widgets (MainVBox then RootCanvas)", async () => {
+    // Remove MainVBox (now empty after TitleText and StartButton were removed)
+    const res1 = await uePost("/api/remove-widget", {
+      blueprint: wbpName,
+      widget: "MainVBox",
+    });
+    expect(res1.error).toBeUndefined();
+
+    // Now RootCanvas should be removable
+    const res2 = await uePost("/api/remove-widget", {
+      blueprint: wbpName,
+      widget: "RootCanvas",
+    });
+    expect(res2.error).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds **7 new MCP tools** for creating and modifying Widget Blueprints (UMG): `list_widget_tree`, `get_widget_properties`, `add_widget`, `remove_widget`, `set_widget_property`, `move_widget`, `create_widget_blueprint`
- Full C++ backend implementation in a dedicated `BlueprintMCPHandlers_Widgets.cpp` handler file with `LoadWidgetBlueprintByName` helper, automatic `INVTEXT()` wrapping for FText properties, slot property support (anchors, alignment, padding), and cycle detection for `move_widget`
- TypeScript MCP tool layer (`widgets.ts`) with Zod schemas, human-readable response formatting, and next-step hints
- Integration tests and test helper (`createTestWidgetBlueprint`) for widget blueprints
- Adds `UMG`, `UMGEditor`, and `SlateCore` module dependencies to `BlueprintMCP.Build.cs`

## Test plan

- [ ] Run `npm test` with UE5 editor open to verify widget tool integration tests pass
- [ ] Create a Widget Blueprint via `create_widget_blueprint` tool
- [ ] Add widgets (CanvasPanel, VerticalBox, TextBlock, Button) via `add_widget`
- [ ] Verify `list_widget_tree` returns correct hierarchy
- [ ] Set widget properties (Text, color) via `set_widget_property`
- [ ] Move widgets between panels via `move_widget`
- [ ] Remove a widget via `remove_widget`
- [ ] Open created widget in UE5 editor and confirm visual layout matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)