### PR TITLE
Add level actor inspection and modification tools (8 new MCP tools)

### DIFF
--- a/Source/BlueprintMCP/BlueprintMCP.Build.cs
+++ b/Source/BlueprintMCP/BlueprintMCP.Build.cs
@@ -30,7 +30,10 @@ public class BlueprintMCP : ModuleRules
 			"MaterialEditor",
 			"AnimGraph",
 			"AnimGraphRuntime",
-			"RHI"
+			"RHI",
+			"UMG",
+			"UMGEditor",
+			"SlateCore"
 		});
 	}
 }

--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_Level.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_Level.cpp
@@ -1,0 +1,799 @@
+#include "BlueprintMCPServer.h"
+#include "EngineUtils.h"
+#include "Engine/World.h"
+#include "Engine/Level.h"
+#include "GameFramework/Actor.h"
+#include "Components/PrimitiveComponent.h"
+#include "Editor.h"
+#include "UObject/UnrealType.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+#include "Misc/Paths.h"
+#include "Misc/PackageName.h"
+#include "UObject/SavePackage.h"
+
+// ============================================================
+// FindActorByLabel — find an actor by its editor display label
+// ============================================================
+
+AActor* FBlueprintMCPServer::FindActorByLabel(UWorld* World, const FString& Label)
+{
+	if (!World) return nullptr;
+
+	for (TActorIterator<AActor> It(World); It; ++It)
+	{
+		if ((*It)->GetActorLabel().Equals(Label, ESearchCase::IgnoreCase))
+		{
+			return *It;
+		}
+	}
+	return nullptr;
+}
+
+// ============================================================
+// SaveLevelPackage — save the UWorld's .umap package to disk
+// ============================================================
+
+bool FBlueprintMCPServer::SaveLevelPackage(ULevel* Level)
+{
+	if (!Level || !Level->OwningWorld) return false;
+
+	UWorld* World = Level->OwningWorld;
+	UPackage* Package = World->GetPackage();
+	if (!Package) return false;
+
+	FString PackageFilename = FPackageName::LongPackageNameToFilename(
+		Package->GetName(), FPackageName::GetMapPackageExtension());
+	PackageFilename = FPaths::ConvertRelativePathToFull(PackageFilename);
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: SaveLevelPackage — saving '%s'"), *PackageFilename);
+
+	if (FPlatformFileManager::Get().GetPlatformFile().IsReadOnly(*PackageFilename))
+	{
+		FPlatformFileManager::Get().GetPlatformFile().SetReadOnly(*PackageFilename, false);
+	}
+
+	FSavePackageArgs SaveArgs;
+	SaveArgs.TopLevelFlags = RF_Public | RF_Standalone;
+	SaveArgs.SaveFlags = SAVE_NoError;
+
+	FSavePackageResultStruct Result = UPackage::Save(Package, World, *PackageFilename, SaveArgs);
+	const bool bSuccess = (Result.Result == ESavePackageResult::Success);
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: SaveLevelPackage — %s for '%s'"),
+		bSuccess ? TEXT("SUCCEEDED") : TEXT("FAILED"), *World->GetMapName());
+	return bSuccess;
+}
+
+// ============================================================
+// HandleGetCurrentLevel — return info about the currently open level
+// ============================================================
+
+FString FBlueprintMCPServer::HandleGetCurrentLevel(const TMap<FString, FString>& Params, const FString&)
+{
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("GEditor not available — not running in editor mode"));
+	}
+
+	UWorld* World = GEditor->GetEditorWorldContext().World();
+	if (!World)
+	{
+		return MakeErrorJson(TEXT("No editor world available"));
+	}
+
+	int32 ActorCount = 0;
+	for (TActorIterator<AActor> It(World); It; ++It)
+	{
+		++ActorCount;
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("levelName"), World->GetMapName());
+	Result->SetStringField(TEXT("packageName"), World->GetPackage()->GetName());
+	Result->SetNumberField(TEXT("actorCount"), ActorCount);
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleListActors — list actors in the current level with optional filters
+// ============================================================
+
+FString FBlueprintMCPServer::HandleListActors(const TMap<FString, FString>& Params, const FString&)
+{
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("GEditor not available — not running in editor mode"));
+	}
+
+	UWorld* World = GEditor->GetEditorWorldContext().World();
+	if (!World)
+	{
+		return MakeErrorJson(TEXT("No editor world available"));
+	}
+
+	const FString* ClassFilter = Params.Find(TEXT("classFilter"));
+	const FString* NameFilter  = Params.Find(TEXT("nameFilter"));
+	const FString* FolderFilter = Params.Find(TEXT("folder"));
+
+	TArray<TSharedPtr<FJsonValue>> ActorsArr;
+
+	for (TActorIterator<AActor> It(World); It; ++It)
+	{
+		AActor* Actor = *It;
+		if (!Actor) continue;
+
+		FString Label     = Actor->GetActorLabel();
+		FString ClassName = Actor->GetClass()->GetName();
+		FString FolderPath = Actor->GetFolderPath().ToString();
+
+		// Apply substring filters
+		if (ClassFilter && !ClassFilter->IsEmpty())
+		{
+			if (!ClassName.Contains(*ClassFilter, ESearchCase::IgnoreCase))
+				continue;
+		}
+		if (NameFilter && !NameFilter->IsEmpty())
+		{
+			if (!Label.Contains(*NameFilter, ESearchCase::IgnoreCase))
+				continue;
+		}
+		if (FolderFilter && !FolderFilter->IsEmpty())
+		{
+			if (!FolderPath.StartsWith(*FolderFilter, ESearchCase::IgnoreCase))
+				continue;
+		}
+
+		FVector Loc = Actor->GetActorLocation();
+
+		TSharedRef<FJsonObject> LocObj = MakeShared<FJsonObject>();
+		LocObj->SetNumberField(TEXT("x"), Loc.X);
+		LocObj->SetNumberField(TEXT("y"), Loc.Y);
+		LocObj->SetNumberField(TEXT("z"), Loc.Z);
+
+		TSharedRef<FJsonObject> ActorObj = MakeShared<FJsonObject>();
+		ActorObj->SetStringField(TEXT("label"), Label);
+		ActorObj->SetStringField(TEXT("class"), ClassName);
+		ActorObj->SetStringField(TEXT("folder"), FolderPath);
+		ActorObj->SetObjectField(TEXT("location"), LocObj);
+
+		ActorsArr.Add(MakeShared<FJsonValueObject>(ActorObj));
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("level"), World->GetMapName());
+	Result->SetNumberField(TEXT("count"), ActorsArr.Num());
+	Result->SetArrayField(TEXT("actors"), ActorsArr);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// ExportPropertyFields — export a single property into OutProps.
+// Complex structs (>4 edit-able sub-fields) are expanded into
+// individual entries so no sub-field is silently omitted.
+// Each entry carries isDefault=true when the value matches the CDO.
+// ============================================================
+
+static void ExportPropertyFields(
+	FProperty*                       Prop,
+	void*                            ContainerData,   // actor or component ptr
+	void*                            DefaultData,     // CDO ptr (may be nullptr)
+	TArray<TSharedPtr<FJsonValue>>& OutProps,
+	int32&                           PropCount,
+	const int32                      MaxProps)
+{
+	if (!Prop || PropCount >= MaxProps) return;
+	if (!Prop->HasAnyPropertyFlags(CPF_Edit)) return;
+
+	void* PropAddr    = Prop->ContainerPtrToValuePtr<void>(ContainerData);
+	void* DefaultAddr = DefaultData ? Prop->ContainerPtrToValuePtr<void>(DefaultData) : nullptr;
+
+	// Is this property's value identical to the CDO?
+	const bool bIsDefault = DefaultAddr && Prop->Identical(PropAddr, DefaultAddr, PPF_None);
+
+	// Expand structs that have more than 4 editable sub-fields.
+	// Small value types (FVector, FLinearColor, FRotator etc.) stay as blobs.
+	if (FStructProperty* StructProp = CastField<FStructProperty>(Prop))
+	{
+		int32 EditableSubFields = 0;
+		for (TFieldIterator<FProperty> It(StructProp->Struct); It; ++It)
+		{
+			if ((*It)->HasAnyPropertyFlags(CPF_Edit)) ++EditableSubFields;
+		}
+
+		if (EditableSubFields > 4)
+		{
+			// Use the CDO's struct data as the sub-field default reference.
+			// If unavailable, default-initialize a scratch buffer.
+			TArray<uint8> DefaultBuffer;
+			void* StructDefaultData = DefaultAddr;
+			if (!StructDefaultData)
+			{
+				DefaultBuffer.SetNumZeroed(StructProp->Struct->GetStructureSize());
+				StructProp->Struct->InitializeStruct(DefaultBuffer.GetData());
+				StructDefaultData = DefaultBuffer.GetData();
+			}
+
+			const FString StructFieldName = Prop->GetName();
+
+			for (TFieldIterator<FProperty> SubIt(StructProp->Struct); SubIt; ++SubIt)
+			{
+				FProperty* SubProp = *SubIt;
+				if (!SubProp || !SubProp->HasAnyPropertyFlags(CPF_Edit)) continue;
+				if (PropCount >= MaxProps) break;
+
+				void* SubAddr        = SubProp->ContainerPtrToValuePtr<void>(PropAddr);
+				void* DefaultSubAddr = SubProp->ContainerPtrToValuePtr<void>(StructDefaultData);
+
+				const bool bSubIsDefault = SubProp->Identical(SubAddr, DefaultSubAddr, PPF_None);
+
+				// Always export the actual value (never pass default to ExportTextItem
+				// so no sub-fields are silently skipped)
+				FString SubValue;
+				SubProp->ExportTextItem_Direct(SubValue, SubAddr, nullptr, nullptr, PPF_None);
+
+				TSharedRef<FJsonObject> PropObj = MakeShared<FJsonObject>();
+				PropObj->SetStringField(TEXT("name"),      SubProp->GetName());
+				PropObj->SetStringField(TEXT("type"),      SubProp->GetCPPType());
+				PropObj->SetStringField(TEXT("value"),     SubValue);
+				PropObj->SetBoolField  (TEXT("isDefault"), bSubIsDefault);
+				PropObj->SetStringField(TEXT("struct"),    StructFieldName);
+				OutProps.Add(MakeShared<FJsonValueObject>(PropObj));
+				++PropCount;
+			}
+			return; // struct fully expanded — do not emit the blob entry
+		}
+	}
+
+	// Simple property or small struct — emit as a single entry
+	FString Value;
+	Prop->ExportTextItem_Direct(Value, PropAddr, nullptr, nullptr, PPF_None);
+
+	TSharedRef<FJsonObject> PropObj = MakeShared<FJsonObject>();
+	PropObj->SetStringField(TEXT("name"),      Prop->GetName());
+	PropObj->SetStringField(TEXT("type"),      Prop->GetCPPType());
+	PropObj->SetStringField(TEXT("value"),     Value);
+	PropObj->SetBoolField  (TEXT("isDefault"), bIsDefault);
+	OutProps.Add(MakeShared<FJsonValueObject>(PropObj));
+	++PropCount;
+}
+
+// ============================================================
+// HandleGetActorProperties — get CPF_Edit properties of a named actor
+// ============================================================
+
+FString FBlueprintMCPServer::HandleGetActorProperties(const TMap<FString, FString>& Params, const FString&)
+{
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("GEditor not available — not running in editor mode"));
+	}
+
+	UWorld* World = GEditor->GetEditorWorldContext().World();
+	if (!World)
+	{
+		return MakeErrorJson(TEXT("No editor world available"));
+	}
+
+	const FString* LabelPtr = Params.Find(TEXT("label"));
+	if (!LabelPtr || LabelPtr->IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required parameter: label"));
+	}
+
+	AActor* Actor = FindActorByLabel(World, *LabelPtr);
+	if (!Actor)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Actor with label '%s' not found"), **LabelPtr));
+	}
+
+	const int32 MaxProps = 1000;
+
+	// Gather all components for discovery (always included in response)
+	TArray<UActorComponent*> AllComponents;
+	Actor->GetComponents(AllComponents);
+
+	TArray<TSharedPtr<FJsonValue>> CompArr;
+	for (UActorComponent* Comp : AllComponents)
+	{
+		if (!Comp) continue;
+		TSharedRef<FJsonObject> CompObj = MakeShared<FJsonObject>();
+		CompObj->SetStringField(TEXT("name"), Comp->GetName());
+		CompObj->SetStringField(TEXT("class"), Comp->GetClass()->GetName());
+		CompArr.Add(MakeShared<FJsonValueObject>(CompObj));
+	}
+
+	// If 'component' param is given, list that component's properties instead
+	const FString* ComponentPtr = Params.Find(TEXT("component"));
+	if (ComponentPtr && !ComponentPtr->IsEmpty())
+	{
+		UActorComponent* TargetComp = nullptr;
+		for (UActorComponent* Comp : AllComponents)
+		{
+			if (Comp && Comp->GetName().Equals(*ComponentPtr, ESearchCase::IgnoreCase))
+			{
+				TargetComp = Comp;
+				break;
+			}
+		}
+		if (!TargetComp)
+		{
+			return MakeErrorJson(FString::Printf(
+				TEXT("Component '%s' not found on actor '%s'. Available components: see get_actor_properties without 'component' param."),
+				**ComponentPtr, **LabelPtr));
+		}
+
+		void* CompCDO = TargetComp->GetClass()->GetDefaultObject();
+
+		TArray<TSharedPtr<FJsonValue>> PropsArr;
+		int32 PropCount = 0;
+		for (TFieldIterator<FProperty> PropIt(TargetComp->GetClass()); PropIt; ++PropIt)
+		{
+			ExportPropertyFields(*PropIt, TargetComp, CompCDO, PropsArr, PropCount, MaxProps);
+		}
+
+		TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+		Result->SetStringField(TEXT("label"),     *LabelPtr);
+		Result->SetStringField(TEXT("component"), *ComponentPtr);
+		Result->SetStringField(TEXT("class"),     TargetComp->GetClass()->GetName());
+		Result->SetNumberField(TEXT("count"),     PropsArr.Num());
+		Result->SetArrayField (TEXT("properties"), PropsArr);
+		return JsonToString(Result);
+	}
+
+	// Default: list actor-level properties + component list for discovery
+	void* ActorCDO = Actor->GetClass()->GetDefaultObject();
+
+	TArray<TSharedPtr<FJsonValue>> PropsArr;
+	int32 PropCount = 0;
+	for (TFieldIterator<FProperty> PropIt(Actor->GetClass()); PropIt; ++PropIt)
+	{
+		ExportPropertyFields(*PropIt, Actor, ActorCDO, PropsArr, PropCount, MaxProps);
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("label"),      *LabelPtr);
+	Result->SetStringField(TEXT("class"),      Actor->GetClass()->GetName());
+	Result->SetNumberField(TEXT("count"),      PropsArr.Num());
+	Result->SetArrayField (TEXT("properties"), PropsArr);
+	Result->SetArrayField (TEXT("components"), CompArr);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleSetActorTransform — move/rotate/scale an actor in the level
+// ============================================================
+
+FString FBlueprintMCPServer::HandleSetActorTransform(const TMap<FString, FString>&, const FString& Body)
+{
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("GEditor not available — not running in editor mode"));
+	}
+
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString Label = Json->GetStringField(TEXT("label"));
+	if (Label.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: label"));
+	}
+
+	UWorld* World = GEditor->GetEditorWorldContext().World();
+	if (!World)
+	{
+		return MakeErrorJson(TEXT("No editor world available"));
+	}
+
+	AActor* Actor = FindActorByLabel(World, Label);
+	if (!Actor)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Actor with label '%s' not found"), *Label));
+	}
+
+	Actor->Modify();
+
+	bool bMoved = false;
+
+	if (Json->HasField(TEXT("location")))
+	{
+		TSharedPtr<FJsonObject> LocObj = Json->GetObjectField(TEXT("location"));
+		if (LocObj.IsValid())
+		{
+			FVector NewLocation = Actor->GetActorLocation();
+			if (LocObj->HasField(TEXT("x"))) NewLocation.X = LocObj->GetNumberField(TEXT("x"));
+			if (LocObj->HasField(TEXT("y"))) NewLocation.Y = LocObj->GetNumberField(TEXT("y"));
+			if (LocObj->HasField(TEXT("z"))) NewLocation.Z = LocObj->GetNumberField(TEXT("z"));
+			Actor->SetActorLocation(NewLocation, false, nullptr, ETeleportType::TeleportPhysics);
+			bMoved = true;
+		}
+	}
+
+	if (Json->HasField(TEXT("rotation")))
+	{
+		TSharedPtr<FJsonObject> RotObj = Json->GetObjectField(TEXT("rotation"));
+		if (RotObj.IsValid())
+		{
+			FRotator NewRotation = Actor->GetActorRotation();
+			if (RotObj->HasField(TEXT("pitch"))) NewRotation.Pitch = RotObj->GetNumberField(TEXT("pitch"));
+			if (RotObj->HasField(TEXT("yaw")))   NewRotation.Yaw   = RotObj->GetNumberField(TEXT("yaw"));
+			if (RotObj->HasField(TEXT("roll")))  NewRotation.Roll  = RotObj->GetNumberField(TEXT("roll"));
+			Actor->SetActorRotation(NewRotation, ETeleportType::TeleportPhysics);
+			bMoved = true;
+		}
+	}
+
+	if (Json->HasField(TEXT("scale")))
+	{
+		TSharedPtr<FJsonObject> ScaleObj = Json->GetObjectField(TEXT("scale"));
+		if (ScaleObj.IsValid())
+		{
+			FVector NewScale = Actor->GetActorScale3D();
+			if (ScaleObj->HasField(TEXT("x"))) NewScale.X = ScaleObj->GetNumberField(TEXT("x"));
+			if (ScaleObj->HasField(TEXT("y"))) NewScale.Y = ScaleObj->GetNumberField(TEXT("y"));
+			if (ScaleObj->HasField(TEXT("z"))) NewScale.Z = ScaleObj->GetNumberField(TEXT("z"));
+			Actor->SetActorScale3D(NewScale);
+			bMoved = true;
+		}
+	}
+
+	if (bMoved)
+	{
+		Actor->PostEditMove(true);
+		Actor->MarkPackageDirty();
+		GEditor->RedrawAllViewports(true);
+	}
+
+	FVector Loc   = Actor->GetActorLocation();
+	FRotator Rot  = Actor->GetActorRotation();
+	FVector Scale = Actor->GetActorScale3D();
+
+	TSharedRef<FJsonObject> LocResult = MakeShared<FJsonObject>();
+	LocResult->SetNumberField(TEXT("x"), Loc.X);
+	LocResult->SetNumberField(TEXT("y"), Loc.Y);
+	LocResult->SetNumberField(TEXT("z"), Loc.Z);
+
+	TSharedRef<FJsonObject> RotResult = MakeShared<FJsonObject>();
+	RotResult->SetNumberField(TEXT("pitch"), Rot.Pitch);
+	RotResult->SetNumberField(TEXT("yaw"),   Rot.Yaw);
+	RotResult->SetNumberField(TEXT("roll"),  Rot.Roll);
+
+	TSharedRef<FJsonObject> ScaleResult = MakeShared<FJsonObject>();
+	ScaleResult->SetNumberField(TEXT("x"), Scale.X);
+	ScaleResult->SetNumberField(TEXT("y"), Scale.Y);
+	ScaleResult->SetNumberField(TEXT("z"), Scale.Z);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("label"), Label);
+	Result->SetObjectField(TEXT("location"), LocResult);
+	Result->SetObjectField(TEXT("rotation"), RotResult);
+	Result->SetObjectField(TEXT("scale"), ScaleResult);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleSetActorProperty — set a named property on a level actor via reflection
+// ============================================================
+
+FString FBlueprintMCPServer::HandleSetActorProperty(const TMap<FString, FString>&, const FString& Body)
+{
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("GEditor not available — not running in editor mode"));
+	}
+
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString Label         = Json->GetStringField(TEXT("label"));
+	FString PropertyName  = Json->GetStringField(TEXT("property"));
+	FString PropertyValue = Json->GetStringField(TEXT("value"));
+
+	if (Label.IsEmpty() || PropertyName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: label, property"));
+	}
+
+	UWorld* World = GEditor->GetEditorWorldContext().World();
+	if (!World)
+	{
+		return MakeErrorJson(TEXT("No editor world available"));
+	}
+
+	AActor* Actor = FindActorByLabel(World, Label);
+	if (!Actor)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Actor with label '%s' not found"), *Label));
+	}
+
+	// Support "ComponentName.PropertyName" syntax for component sub-properties
+	FString ComponentName, ActualPropertyName;
+	const bool bIsComponentProp = PropertyName.Split(TEXT("."), &ComponentName, &ActualPropertyName);
+
+	if (bIsComponentProp)
+	{
+		// Find the named component on the actor
+		TArray<UActorComponent*> Components;
+		Actor->GetComponents(Components);
+
+		UActorComponent* TargetComp = nullptr;
+		for (UActorComponent* Comp : Components)
+		{
+			if (Comp && Comp->GetName().Equals(ComponentName, ESearchCase::IgnoreCase))
+			{
+				TargetComp = Comp;
+				break;
+			}
+		}
+		if (!TargetComp)
+		{
+			return MakeErrorJson(FString::Printf(
+				TEXT("Component '%s' not found on actor '%s'. Use get_actor_properties(label) to list available components."),
+				*ComponentName, *Label));
+		}
+
+		FProperty* Prop = FindFProperty<FProperty>(TargetComp->GetClass(), *ActualPropertyName);
+		if (!Prop)
+		{
+			return MakeErrorJson(FString::Printf(
+				TEXT("Property '%s' not found on component '%s' (%s). Use get_actor_properties(label, component) to list component properties."),
+				*ActualPropertyName, *ComponentName, *TargetComp->GetClass()->GetName()));
+		}
+
+		TargetComp->Modify();
+
+		void* PropAddr = Prop->ContainerPtrToValuePtr<void>(TargetComp);
+		const TCHAR* ImportResult = Prop->ImportText_Direct(*PropertyValue, PropAddr, TargetComp, 0);
+		if (!ImportResult)
+		{
+			return MakeErrorJson(FString::Printf(
+				TEXT("Failed to set property '%s' to '%s' — value incompatible with type '%s'"),
+				*ActualPropertyName, *PropertyValue, *Prop->GetCPPType()));
+		}
+
+		FPropertyChangedEvent ChangedEvent(Prop);
+		TargetComp->PostEditChangeProperty(ChangedEvent);
+
+		// Force render state update so the change is visible in the viewport immediately
+		if (UPrimitiveComponent* PrimComp = Cast<UPrimitiveComponent>(TargetComp))
+		{
+			PrimComp->MarkRenderStateDirty();
+		}
+		TargetComp->ReregisterComponent();
+		Actor->MarkPackageDirty();
+		GEditor->RedrawAllViewports(true);
+
+		FString ExportedValue;
+		Prop->ExportTextItem_Direct(ExportedValue, PropAddr, nullptr, TargetComp, PPF_None);
+
+		TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+		Result->SetBoolField(TEXT("success"), true);
+		Result->SetStringField(TEXT("label"), Label);
+		Result->SetStringField(TEXT("component"), ComponentName);
+		Result->SetStringField(TEXT("property"), ActualPropertyName);
+		Result->SetStringField(TEXT("value"), ExportedValue);
+		return JsonToString(Result);
+	}
+
+	// Actor-level property (no dot in property name)
+	FProperty* Prop = FindFProperty<FProperty>(Actor->GetClass(), *PropertyName);
+	if (!Prop)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Property '%s' not found on class '%s'. For component properties use 'ComponentName.PropertyName' (e.g. 'StaticMeshComponent0.StaticMesh')."),
+			*PropertyName, *Actor->GetClass()->GetName()));
+	}
+
+	Actor->Modify();
+
+	void* PropAddr = Prop->ContainerPtrToValuePtr<void>(Actor);
+	const TCHAR* ImportResult = Prop->ImportText_Direct(*PropertyValue, PropAddr, Actor, 0);
+	if (!ImportResult)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Failed to set property '%s' to '%s' — value incompatible with type '%s'"),
+			*PropertyName, *PropertyValue, *Prop->GetCPPType()));
+	}
+
+	FPropertyChangedEvent ChangedEvent(Prop);
+	Actor->PostEditChangeProperty(ChangedEvent);
+	Actor->MarkPackageDirty();
+
+	// Read back the exported value to confirm the write
+	FString ExportedValue;
+	Prop->ExportTextItem_Direct(ExportedValue, PropAddr, nullptr, Actor, PPF_None);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("label"), Label);
+	Result->SetStringField(TEXT("property"), PropertyName);
+	Result->SetStringField(TEXT("value"), ExportedValue);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleSpawnActor — spawn a new actor in the current level
+// ============================================================
+
+FString FBlueprintMCPServer::HandleSpawnActor(const TMap<FString, FString>&, const FString& Body)
+{
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("GEditor not available — not running in editor mode"));
+	}
+
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString ClassName = Json->GetStringField(TEXT("class"));
+	if (ClassName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: class"));
+	}
+
+	UWorld* World = GEditor->GetEditorWorldContext().World();
+	if (!World)
+	{
+		return MakeErrorJson(TEXT("No editor world available"));
+	}
+
+	// Resolve the actor class — try exact name, then without "A" prefix
+	UClass* ActorClass = FindClassByName(ClassName);
+	if (!ActorClass && ClassName.StartsWith(TEXT("A")) && ClassName.Len() > 1)
+	{
+		ActorClass = FindClassByName(ClassName.Mid(1));
+	}
+	if (!ActorClass)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Class '%s' not found. Use the class name without prefix, e.g. 'StaticMeshActor', 'DirectionalLight', 'PointLight'"),
+			*ClassName));
+	}
+
+	if (!ActorClass->IsChildOf(AActor::StaticClass()))
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Class '%s' is not an Actor class"), *ActorClass->GetName()));
+	}
+
+	// Build spawn location
+	FVector Location = FVector::ZeroVector;
+	if (Json->HasField(TEXT("location")))
+	{
+		TSharedPtr<FJsonObject> LocObj = Json->GetObjectField(TEXT("location"));
+		if (LocObj.IsValid())
+		{
+			if (LocObj->HasField(TEXT("x"))) Location.X = LocObj->GetNumberField(TEXT("x"));
+			if (LocObj->HasField(TEXT("y"))) Location.Y = LocObj->GetNumberField(TEXT("y"));
+			if (LocObj->HasField(TEXT("z"))) Location.Z = LocObj->GetNumberField(TEXT("z"));
+		}
+	}
+
+	// Build spawn rotation
+	FRotator Rotation = FRotator::ZeroRotator;
+	if (Json->HasField(TEXT("rotation")))
+	{
+		TSharedPtr<FJsonObject> RotObj = Json->GetObjectField(TEXT("rotation"));
+		if (RotObj.IsValid())
+		{
+			if (RotObj->HasField(TEXT("pitch"))) Rotation.Pitch = RotObj->GetNumberField(TEXT("pitch"));
+			if (RotObj->HasField(TEXT("yaw")))   Rotation.Yaw   = RotObj->GetNumberField(TEXT("yaw"));
+			if (RotObj->HasField(TEXT("roll")))  Rotation.Roll  = RotObj->GetNumberField(TEXT("roll"));
+		}
+	}
+
+	FActorSpawnParameters SpawnParams;
+	SpawnParams.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+
+	AActor* NewActor = World->SpawnActor<AActor>(ActorClass, Location, Rotation, SpawnParams);
+	if (!NewActor)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Failed to spawn actor of class '%s'"), *ActorClass->GetName()));
+	}
+
+	// Set label if provided
+	FString Label;
+	if (Json->HasField(TEXT("label")) && !Json->GetStringField(TEXT("label")).IsEmpty())
+	{
+		Label = Json->GetStringField(TEXT("label"));
+		NewActor->SetActorLabel(Label);
+	}
+	else
+	{
+		Label = NewActor->GetActorLabel();
+	}
+
+	// Set outliner folder if provided
+	if (Json->HasField(TEXT("folder")) && !Json->GetStringField(TEXT("folder")).IsEmpty())
+	{
+		NewActor->SetFolderPath(FName(*Json->GetStringField(TEXT("folder"))));
+	}
+
+	NewActor->MarkPackageDirty();
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Spawned actor '%s' (%s) at (%.1f, %.1f, %.1f)"),
+		*Label, *ActorClass->GetName(), Location.X, Location.Y, Location.Z);
+
+	TSharedRef<FJsonObject> LocResult = MakeShared<FJsonObject>();
+	LocResult->SetNumberField(TEXT("x"), Location.X);
+	LocResult->SetNumberField(TEXT("y"), Location.Y);
+	LocResult->SetNumberField(TEXT("z"), Location.Z);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("label"), Label);
+	Result->SetStringField(TEXT("class"), ActorClass->GetName());
+	Result->SetObjectField(TEXT("location"), LocResult);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleDeleteActor — delete a named actor from the current level
+// ============================================================
+
+FString FBlueprintMCPServer::HandleDeleteActor(const TMap<FString, FString>&, const FString& Body)
+{
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("GEditor not available — not running in editor mode"));
+	}
+
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString Label = Json->GetStringField(TEXT("label"));
+	if (Label.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: label"));
+	}
+
+	UWorld* World = GEditor->GetEditorWorldContext().World();
+	if (!World)
+	{
+		return MakeErrorJson(TEXT("No editor world available"));
+	}
+
+	AActor* Actor = FindActorByLabel(World, Label);
+	if (!Actor)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Actor with label '%s' not found"), *Label));
+	}
+
+	FString ActorClass = Actor->GetClass()->GetName();
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Deleting actor '%s' (%s)"), *Label, *ActorClass);
+
+	Actor->Modify();
+	const bool bDestroyed = World->DestroyActor(Actor, false, true);
+	if (!bDestroyed)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Failed to destroy actor '%s'"), *Label));
+	}
+
+	if (World->GetCurrentLevel())
+	{
+		World->GetCurrentLevel()->MarkPackageDirty();
+	}
+
+	GEditor->RedrawAllViewports(true);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("label"), Label);
+	Result->SetStringField(TEXT("class"), ActorClass);
+	return JsonToString(Result);
+}

--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_Level.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_Level.cpp
@@ -5,6 +5,7 @@
 #include "GameFramework/Actor.h"
 #include "Components/PrimitiveComponent.h"
 #include "Editor.h"
+#include "Selection.h"
 #include "UObject/UnrealType.h"
 #include "Serialization/JsonReader.h"
 #include "Serialization/JsonWriter.h"
@@ -93,6 +94,70 @@ FString FBlueprintMCPServer::HandleGetCurrentLevel(const TMap<FString, FString>&
 	Result->SetStringField(TEXT("packageName"), World->GetPackage()->GetName());
 	Result->SetNumberField(TEXT("actorCount"), ActorCount);
 
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleGetSelectedActors — return actors currently selected in the editor
+// ============================================================
+
+FString FBlueprintMCPServer::HandleGetSelectedActors(const TMap<FString, FString>& Params, const FString&)
+{
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("GEditor not available — not running in editor mode"));
+	}
+
+	USelection* Selection = GEditor->GetSelectedActors();
+	if (!Selection)
+	{
+		return MakeErrorJson(TEXT("Could not retrieve editor actor selection"));
+	}
+
+	TArray<AActor*> SelectedActors;
+	Selection->GetSelectedObjects<AActor>(SelectedActors);
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: GetSelectedActors — %d actors selected"), SelectedActors.Num());
+
+	TArray<TSharedPtr<FJsonValue>> ActorsArr;
+
+	for (AActor* Actor : SelectedActors)
+	{
+		if (!Actor) continue;
+
+		FVector  Loc   = Actor->GetActorLocation();
+		FRotator Rot   = Actor->GetActorRotation();
+		FVector  Scale = Actor->GetActorScale3D();
+
+		TSharedRef<FJsonObject> LocObj = MakeShared<FJsonObject>();
+		LocObj->SetNumberField(TEXT("x"), Loc.X);
+		LocObj->SetNumberField(TEXT("y"), Loc.Y);
+		LocObj->SetNumberField(TEXT("z"), Loc.Z);
+
+		TSharedRef<FJsonObject> RotObj = MakeShared<FJsonObject>();
+		RotObj->SetNumberField(TEXT("pitch"), Rot.Pitch);
+		RotObj->SetNumberField(TEXT("yaw"),   Rot.Yaw);
+		RotObj->SetNumberField(TEXT("roll"),  Rot.Roll);
+
+		TSharedRef<FJsonObject> ScaleObj = MakeShared<FJsonObject>();
+		ScaleObj->SetNumberField(TEXT("x"), Scale.X);
+		ScaleObj->SetNumberField(TEXT("y"), Scale.Y);
+		ScaleObj->SetNumberField(TEXT("z"), Scale.Z);
+
+		TSharedRef<FJsonObject> ActorObj = MakeShared<FJsonObject>();
+		ActorObj->SetStringField(TEXT("label"),  Actor->GetActorLabel());
+		ActorObj->SetStringField(TEXT("class"),  Actor->GetClass()->GetName());
+		ActorObj->SetStringField(TEXT("folder"), Actor->GetFolderPath().ToString());
+		ActorObj->SetObjectField(TEXT("location"), LocObj);
+		ActorObj->SetObjectField(TEXT("rotation"), RotObj);
+		ActorObj->SetObjectField(TEXT("scale"),    ScaleObj);
+
+		ActorsArr.Add(MakeShared<FJsonValueObject>(ActorObj));
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetNumberField(TEXT("count"),  ActorsArr.Num());
+	Result->SetArrayField (TEXT("actors"), ActorsArr);
 	return JsonToString(Result);
 }
 

--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_Widgets.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_Widgets.cpp
@@ -1,0 +1,933 @@
+#include "BlueprintMCPServer.h"
+#include "Engine/Blueprint.h"
+#include "WidgetBlueprint.h"
+#include "Blueprint/WidgetTree.h"
+#include "Components/Widget.h"
+#include "Components/PanelWidget.h"
+#include "Components/PanelSlot.h"
+#include "Components/CanvasPanel.h"
+#include "Components/CanvasPanelSlot.h"
+#include "Components/VerticalBox.h"
+#include "Components/HorizontalBox.h"
+#include "Components/Overlay.h"
+#include "Components/TextBlock.h"
+#include "Components/Image.h"
+#include "Components/Button.h"
+#include "Components/Border.h"
+#include "Components/SizeBox.h"
+#include "Components/ScaleBox.h"
+#include "Components/ScrollBox.h"
+#include "Components/GridPanel.h"
+#include "Components/WrapBox.h"
+#include "Components/WidgetSwitcher.h"
+#include "Components/Spacer.h"
+#include "Components/ProgressBar.h"
+#include "Components/Slider.h"
+#include "Components/CheckBox.h"
+#include "Components/ComboBoxString.h"
+#include "Components/EditableTextBox.h"
+#include "Kismet2/BlueprintEditorUtils.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+#include "UObject/UObjectIterator.h"
+#include "UObject/PropertyIterator.h"
+#include "AssetToolsModule.h"
+#include "IAssetTools.h"
+#include "WidgetBlueprintFactory.h"
+#include "UObject/SavePackage.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "Misc/PackageName.h"
+
+// ============================================================
+// LoadWidgetBlueprintByName — load and cast to UWidgetBlueprint
+// ============================================================
+
+UWidgetBlueprint* FBlueprintMCPServer::LoadWidgetBlueprintByName(const FString& NameOrPath, FString& OutError)
+{
+	UBlueprint* BP = LoadBlueprintByName(NameOrPath, OutError);
+	if (!BP)
+	{
+		return nullptr;
+	}
+
+	UWidgetBlueprint* WidgetBP = Cast<UWidgetBlueprint>(BP);
+	if (!WidgetBP)
+	{
+		OutError = FString::Printf(
+			TEXT("Blueprint '%s' is not a Widget Blueprint (class: %s). "
+				"This tool only works on Widget Blueprints (UMG)."),
+			*NameOrPath, *BP->GetClass()->GetName());
+		return nullptr;
+	}
+
+	return WidgetBP;
+}
+
+// ============================================================
+// Helper: Find a widget by name in the widget tree
+// ============================================================
+
+static UWidget* FindWidgetByName(UWidgetTree* Tree, const FString& WidgetName)
+{
+	TArray<UWidget*> AllWidgets;
+	Tree->GetAllWidgets(AllWidgets);
+
+	// Exact match first
+	for (UWidget* W : AllWidgets)
+	{
+		if (W && W->GetName() == WidgetName)
+		{
+			return W;
+		}
+	}
+
+	// Case-insensitive fallback
+	for (UWidget* W : AllWidgets)
+	{
+		if (W && W->GetName().Equals(WidgetName, ESearchCase::IgnoreCase))
+		{
+			return W;
+		}
+	}
+
+	return nullptr;
+}
+
+// ============================================================
+// Helper: Check if Target is a descendant of Ancestor
+// ============================================================
+
+static bool IsDescendantOf(UWidget* Target, UWidget* Ancestor)
+{
+	if (!Target || !Ancestor)
+	{
+		return false;
+	}
+
+	UPanelWidget* Panel = Cast<UPanelWidget>(Ancestor);
+	if (!Panel)
+	{
+		return false;
+	}
+
+	for (int32 i = 0; i < Panel->GetChildrenCount(); ++i)
+	{
+		UWidget* Child = Panel->GetChildAt(i);
+		if (Child == Target)
+		{
+			return true;
+		}
+		if (IsDescendantOf(Target, Child))
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+// ============================================================
+// Helper: Serialize a widget to JSON (for tree listing)
+// ============================================================
+
+static TSharedRef<FJsonObject> SerializeWidgetInfo(UWidget* Widget, UPanelWidget* ParentPanel)
+{
+	TSharedRef<FJsonObject> Obj = MakeShared<FJsonObject>();
+	Obj->SetStringField(TEXT("name"), Widget->GetName());
+	Obj->SetStringField(TEXT("class"), Widget->GetClass()->GetName());
+
+	if (ParentPanel)
+	{
+		Obj->SetStringField(TEXT("parent"), ParentPanel->GetName());
+	}
+
+	// Slot info
+	UPanelSlot* Slot = Widget->Slot;
+	if (Slot)
+	{
+		Obj->SetStringField(TEXT("slotClass"), Slot->GetClass()->GetName());
+	}
+
+	// Visibility
+	Obj->SetStringField(TEXT("visibility"), StaticEnum<ESlateVisibility>()->GetNameStringByValue((int64)Widget->GetVisibility()));
+
+	// If this widget is a panel, list child count
+	UPanelWidget* AsPanel = Cast<UPanelWidget>(Widget);
+	if (AsPanel)
+	{
+		Obj->SetBoolField(TEXT("isPanel"), true);
+		Obj->SetNumberField(TEXT("childCount"), AsPanel->GetChildrenCount());
+	}
+	else
+	{
+		Obj->SetBoolField(TEXT("isPanel"), false);
+	}
+
+	return Obj;
+}
+
+// ============================================================
+// Helper: Build widget tree recursively
+// ============================================================
+
+static void BuildWidgetTreeRecursive(UWidget* Widget, UPanelWidget* ParentPanel, TArray<TSharedPtr<FJsonValue>>& OutArray, int32 Depth)
+{
+	if (!Widget)
+	{
+		return;
+	}
+
+	TSharedRef<FJsonObject> WidgetObj = SerializeWidgetInfo(Widget, ParentPanel);
+	WidgetObj->SetNumberField(TEXT("depth"), Depth);
+	OutArray.Add(MakeShared<FJsonValueObject>(WidgetObj));
+
+	UPanelWidget* Panel = Cast<UPanelWidget>(Widget);
+	if (Panel)
+	{
+		for (int32 i = 0; i < Panel->GetChildrenCount(); ++i)
+		{
+			BuildWidgetTreeRecursive(Panel->GetChildAt(i), Panel, OutArray, Depth + 1);
+		}
+	}
+}
+
+// ============================================================
+// HandleListWidgetTree
+// ============================================================
+
+FString FBlueprintMCPServer::HandleListWidgetTree(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString BlueprintName = Json->GetStringField(TEXT("blueprint"));
+	if (BlueprintName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: blueprint"));
+	}
+
+	FString LoadError;
+	UWidgetBlueprint* WidgetBP = LoadWidgetBlueprintByName(BlueprintName, LoadError);
+	if (!WidgetBP)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	UWidgetTree* Tree = WidgetBP->WidgetTree;
+	if (!Tree)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Widget Blueprint '%s' has no WidgetTree"),
+			*BlueprintName));
+	}
+
+	TArray<TSharedPtr<FJsonValue>> WidgetsArr;
+
+	UWidget* Root = Tree->RootWidget;
+	if (Root)
+	{
+		BuildWidgetTreeRecursive(Root, nullptr, WidgetsArr, 0);
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("blueprint"), BlueprintName);
+	Result->SetStringField(TEXT("rootWidget"), Root ? Root->GetName() : TEXT("(none)"));
+	Result->SetNumberField(TEXT("count"), WidgetsArr.Num());
+	Result->SetArrayField(TEXT("widgets"), WidgetsArr);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleGetWidgetProperties
+// ============================================================
+
+FString FBlueprintMCPServer::HandleGetWidgetProperties(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString BlueprintName = Json->GetStringField(TEXT("blueprint"));
+	FString WidgetName = Json->GetStringField(TEXT("widget"));
+
+	if (BlueprintName.IsEmpty() || WidgetName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: blueprint, widget"));
+	}
+
+	FString LoadError;
+	UWidgetBlueprint* WidgetBP = LoadWidgetBlueprintByName(BlueprintName, LoadError);
+	if (!WidgetBP)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	UWidgetTree* Tree = WidgetBP->WidgetTree;
+	if (!Tree)
+	{
+		return MakeErrorJson(TEXT("Widget Blueprint has no WidgetTree"));
+	}
+
+	UWidget* Widget = FindWidgetByName(Tree, WidgetName);
+	if (!Widget)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Widget '%s' not found in Widget Blueprint '%s'"),
+			*WidgetName, *BlueprintName));
+	}
+
+	// Collect editable properties from the widget
+	TArray<TSharedPtr<FJsonValue>> PropsArr;
+
+	for (TFieldIterator<FProperty> It(Widget->GetClass()); It; ++It)
+	{
+		FProperty* Prop = *It;
+		if (!Prop || !Prop->HasAnyPropertyFlags(CPF_Edit))
+		{
+			continue;
+		}
+
+		TSharedRef<FJsonObject> PropObj = MakeShared<FJsonObject>();
+		PropObj->SetStringField(TEXT("name"), Prop->GetName());
+		PropObj->SetStringField(TEXT("type"), Prop->GetCPPType());
+		PropObj->SetStringField(TEXT("source"), TEXT("widget"));
+
+		FString ValueStr;
+		const void* ValuePtr = Prop->ContainerPtrToValuePtr<void>(Widget);
+		Prop->ExportTextItem_Direct(ValueStr, ValuePtr, nullptr, nullptr, PPF_None);
+		PropObj->SetStringField(TEXT("value"), ValueStr);
+
+		PropsArr.Add(MakeShared<FJsonValueObject>(PropObj));
+	}
+
+	// Collect slot properties if the widget has a slot
+	UPanelSlot* Slot = Widget->Slot;
+	if (Slot)
+	{
+		for (TFieldIterator<FProperty> It(Slot->GetClass()); It; ++It)
+		{
+			FProperty* Prop = *It;
+			if (!Prop || !Prop->HasAnyPropertyFlags(CPF_Edit))
+			{
+				continue;
+			}
+
+			TSharedRef<FJsonObject> PropObj = MakeShared<FJsonObject>();
+			PropObj->SetStringField(TEXT("name"), Prop->GetName());
+			PropObj->SetStringField(TEXT("type"), Prop->GetCPPType());
+			PropObj->SetStringField(TEXT("source"), TEXT("slot"));
+
+			FString ValueStr;
+			const void* ValuePtr = Prop->ContainerPtrToValuePtr<void>(Slot);
+			Prop->ExportTextItem_Direct(ValueStr, ValuePtr, nullptr, nullptr, PPF_None);
+			PropObj->SetStringField(TEXT("value"), ValueStr);
+
+			PropsArr.Add(MakeShared<FJsonValueObject>(PropObj));
+		}
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("blueprint"), BlueprintName);
+	Result->SetStringField(TEXT("widget"), Widget->GetName());
+	Result->SetStringField(TEXT("widgetClass"), Widget->GetClass()->GetName());
+	if (Slot)
+	{
+		Result->SetStringField(TEXT("slotClass"), Slot->GetClass()->GetName());
+	}
+	Result->SetNumberField(TEXT("propertyCount"), PropsArr.Num());
+	Result->SetArrayField(TEXT("properties"), PropsArr);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleAddWidget
+// ============================================================
+
+FString FBlueprintMCPServer::HandleAddWidget(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString BlueprintName = Json->GetStringField(TEXT("blueprint"));
+	FString WidgetClassName = Json->GetStringField(TEXT("widgetClass"));
+	FString WidgetName = Json->GetStringField(TEXT("name"));
+
+	if (BlueprintName.IsEmpty() || WidgetClassName.IsEmpty() || WidgetName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: blueprint, widgetClass, name"));
+	}
+
+	FString ParentWidgetName;
+	if (Json->HasField(TEXT("parent")))
+	{
+		ParentWidgetName = Json->GetStringField(TEXT("parent"));
+	}
+
+	FString LoadError;
+	UWidgetBlueprint* WidgetBP = LoadWidgetBlueprintByName(BlueprintName, LoadError);
+	if (!WidgetBP)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	UWidgetTree* Tree = WidgetBP->WidgetTree;
+	if (!Tree)
+	{
+		return MakeErrorJson(TEXT("Widget Blueprint has no WidgetTree"));
+	}
+
+	// Check for duplicate widget names
+	if (FindWidgetByName(Tree, WidgetName))
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("A widget named '%s' already exists in Widget Blueprint '%s'"),
+			*WidgetName, *BlueprintName));
+	}
+
+	// Resolve the widget class
+	UClass* WidgetClass = nullptr;
+	TArray<FString> NamesToTry;
+	NamesToTry.Add(WidgetClassName);
+	if (!WidgetClassName.StartsWith(TEXT("U")))
+	{
+		NamesToTry.Add(FString::Printf(TEXT("U%s"), *WidgetClassName));
+	}
+	else
+	{
+		NamesToTry.Add(WidgetClassName.Mid(1));
+	}
+
+	for (TObjectIterator<UClass> It; It; ++It)
+	{
+		if (!It->IsChildOf(UWidget::StaticClass()))
+		{
+			continue;
+		}
+
+		FString ClassName = It->GetName();
+		for (const FString& NameToTry : NamesToTry)
+		{
+			if (ClassName.Equals(NameToTry, ESearchCase::IgnoreCase))
+			{
+				WidgetClass = *It;
+				break;
+			}
+		}
+		if (WidgetClass)
+		{
+			break;
+		}
+	}
+
+	if (!WidgetClass)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Widget class '%s' not found or is not a subclass of UWidget. "
+				"Common classes: TextBlock, Button, Image, VerticalBox, HorizontalBox, "
+				"Overlay, CanvasPanel, Border, SizeBox, ScaleBox, ScrollBox, GridPanel, "
+				"WrapBox, WidgetSwitcher, Spacer, ProgressBar, Slider, CheckBox, "
+				"ComboBoxString, EditableTextBox"),
+			*WidgetClassName));
+	}
+
+	// Find parent panel if specified
+	UPanelWidget* ParentPanel = nullptr;
+	if (!ParentWidgetName.IsEmpty())
+	{
+		UWidget* ParentWidget = FindWidgetByName(Tree, ParentWidgetName);
+		if (!ParentWidget)
+		{
+			return MakeErrorJson(FString::Printf(
+				TEXT("Parent widget '%s' not found in Widget Blueprint '%s'"),
+				*ParentWidgetName, *BlueprintName));
+		}
+
+		ParentPanel = Cast<UPanelWidget>(ParentWidget);
+		if (!ParentPanel)
+		{
+			return MakeErrorJson(FString::Printf(
+				TEXT("Parent widget '%s' (class: %s) is not a panel widget and cannot have children. "
+					"Only panel widgets (CanvasPanel, VerticalBox, HorizontalBox, Overlay, etc.) "
+					"can contain child widgets."),
+				*ParentWidgetName, *ParentWidget->GetClass()->GetName()));
+		}
+	}
+	else
+	{
+		// If no parent specified and root exists, try to add to the root if it's a panel
+		UWidget* Root = Tree->RootWidget;
+		if (Root)
+		{
+			ParentPanel = Cast<UPanelWidget>(Root);
+			if (!ParentPanel)
+			{
+				return MakeErrorJson(FString::Printf(
+					TEXT("The root widget '%s' (class: %s) is not a panel widget. "
+						"Specify a 'parent' panel widget explicitly, or set this widget as root by first removing the existing root."),
+					*Root->GetName(), *Root->GetClass()->GetName()));
+			}
+		}
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Adding widget '%s' (%s) to Widget Blueprint '%s'"),
+		*WidgetName, *WidgetClass->GetName(), *BlueprintName);
+
+	// Create the widget in the tree
+	UWidget* NewWidget = Tree->ConstructWidget<UWidget>(WidgetClass, FName(*WidgetName));
+	if (!NewWidget)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Failed to construct widget '%s' with class '%s'"),
+			*WidgetName, *WidgetClass->GetName()));
+	}
+
+	// Add to parent or set as root
+	if (ParentPanel)
+	{
+		UPanelSlot* Slot = ParentPanel->AddChild(NewWidget);
+		if (!Slot)
+		{
+			return MakeErrorJson(FString::Printf(
+				TEXT("Failed to add widget '%s' as child of '%s'"),
+				*WidgetName, *ParentPanel->GetName()));
+		}
+	}
+	else
+	{
+		// No root widget exists — set this as root
+		Tree->RootWidget = NewWidget;
+	}
+
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WidgetBP);
+	bool bSaved = SaveBlueprintPackage(WidgetBP);
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Added widget '%s' (%s) to '%s' (parent: %s, saved: %s)"),
+		*WidgetName, *WidgetClass->GetName(), *BlueprintName,
+		ParentPanel ? *ParentPanel->GetName() : TEXT("(root)"),
+		bSaved ? TEXT("true") : TEXT("false"));
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("blueprint"), BlueprintName);
+	Result->SetStringField(TEXT("name"), NewWidget->GetName());
+	Result->SetStringField(TEXT("widgetClass"), WidgetClass->GetName());
+	if (ParentPanel)
+	{
+		Result->SetStringField(TEXT("parent"), ParentPanel->GetName());
+	}
+	else
+	{
+		Result->SetStringField(TEXT("parent"), TEXT("(root)"));
+	}
+	Result->SetBoolField(TEXT("saved"), bSaved);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleRemoveWidget
+// ============================================================
+
+FString FBlueprintMCPServer::HandleRemoveWidget(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString BlueprintName = Json->GetStringField(TEXT("blueprint"));
+	FString WidgetName = Json->GetStringField(TEXT("widget"));
+
+	if (BlueprintName.IsEmpty() || WidgetName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: blueprint, widget"));
+	}
+
+	FString LoadError;
+	UWidgetBlueprint* WidgetBP = LoadWidgetBlueprintByName(BlueprintName, LoadError);
+	if (!WidgetBP)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	UWidgetTree* Tree = WidgetBP->WidgetTree;
+	if (!Tree)
+	{
+		return MakeErrorJson(TEXT("Widget Blueprint has no WidgetTree"));
+	}
+
+	UWidget* Widget = FindWidgetByName(Tree, WidgetName);
+	if (!Widget)
+	{
+		// Build list of widget names for error message
+		TArray<UWidget*> AllWidgets;
+		Tree->GetAllWidgets(AllWidgets);
+		TArray<TSharedPtr<FJsonValue>> NameList;
+		for (UWidget* W : AllWidgets)
+		{
+			if (W)
+			{
+				NameList.Add(MakeShared<FJsonValueString>(W->GetName()));
+			}
+		}
+
+		TSharedRef<FJsonObject> ErrorResult = MakeShared<FJsonObject>();
+		ErrorResult->SetStringField(TEXT("error"), FString::Printf(
+			TEXT("Widget '%s' not found in Widget Blueprint '%s'"),
+			*WidgetName, *BlueprintName));
+		ErrorResult->SetArrayField(TEXT("existingWidgets"), NameList);
+		return JsonToString(ErrorResult);
+	}
+
+	// Refuse to remove panels that have children
+	UPanelWidget* AsPanel = Cast<UPanelWidget>(Widget);
+	if (AsPanel && AsPanel->GetChildrenCount() > 0)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Cannot remove widget '%s' because it is a panel with %d child(ren). "
+				"Remove or move the children first."),
+			*WidgetName, AsPanel->GetChildrenCount()));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Removing widget '%s' from Widget Blueprint '%s'"),
+		*WidgetName, *BlueprintName);
+
+	// Remove from parent panel
+	UPanelWidget* ParentPanel = Widget->GetParent();
+	if (ParentPanel)
+	{
+		ParentPanel->RemoveChild(Widget);
+	}
+	else if (Tree->RootWidget == Widget)
+	{
+		Tree->RootWidget = nullptr;
+	}
+
+	// Remove from widget tree
+	Tree->RemoveWidget(Widget);
+
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WidgetBP);
+	bool bSaved = SaveBlueprintPackage(WidgetBP);
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Removed widget '%s' from '%s' (saved: %s)"),
+		*WidgetName, *BlueprintName, bSaved ? TEXT("true") : TEXT("false"));
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("blueprint"), BlueprintName);
+	Result->SetStringField(TEXT("widget"), WidgetName);
+	Result->SetBoolField(TEXT("saved"), bSaved);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleSetWidgetProperty
+// ============================================================
+
+FString FBlueprintMCPServer::HandleSetWidgetProperty(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString BlueprintName = Json->GetStringField(TEXT("blueprint"));
+	FString WidgetName = Json->GetStringField(TEXT("widget"));
+	FString PropertyName = Json->GetStringField(TEXT("property"));
+	FString Value = Json->GetStringField(TEXT("value"));
+
+	if (BlueprintName.IsEmpty() || WidgetName.IsEmpty() || PropertyName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: blueprint, widget, property"));
+	}
+
+	FString LoadError;
+	UWidgetBlueprint* WidgetBP = LoadWidgetBlueprintByName(BlueprintName, LoadError);
+	if (!WidgetBP)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	UWidgetTree* Tree = WidgetBP->WidgetTree;
+	if (!Tree)
+	{
+		return MakeErrorJson(TEXT("Widget Blueprint has no WidgetTree"));
+	}
+
+	UWidget* Widget = FindWidgetByName(Tree, WidgetName);
+	if (!Widget)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Widget '%s' not found in Widget Blueprint '%s'"),
+			*WidgetName, *BlueprintName));
+	}
+
+	// Try to find the property on the widget first
+	FProperty* Prop = Widget->GetClass()->FindPropertyByName(FName(*PropertyName));
+	UObject* TargetObject = Widget;
+	FString Source = TEXT("widget");
+
+	// Fall through to slot if not found on widget
+	if (!Prop && Widget->Slot)
+	{
+		Prop = Widget->Slot->GetClass()->FindPropertyByName(FName(*PropertyName));
+		if (Prop)
+		{
+			TargetObject = Widget->Slot;
+			Source = TEXT("slot");
+		}
+	}
+
+	if (!Prop)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Property '%s' not found on widget '%s' (class: %s) or its slot. "
+				"Use get_widget_properties to see all available properties."),
+			*PropertyName, *WidgetName, *Widget->GetClass()->GetName()));
+	}
+
+	// Auto-wrap bare strings in INVTEXT("...") for FText properties
+	FString ValueToSet = Value;
+	FTextProperty* TextProp = CastField<FTextProperty>(Prop);
+	if (TextProp && !Value.StartsWith(TEXT("INVTEXT(")) && !Value.StartsWith(TEXT("NSLOCTEXT(")))
+	{
+		ValueToSet = FString::Printf(TEXT("INVTEXT(\"%s\")"), *Value);
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Setting property '%s' on widget '%s' to '%s' (source: %s)"),
+		*PropertyName, *WidgetName, *ValueToSet, *Source);
+
+	void* ValuePtr = Prop->ContainerPtrToValuePtr<void>(TargetObject);
+	const TCHAR* ImportResult = Prop->ImportText_Direct(*ValueToSet, ValuePtr, TargetObject, PPF_None);
+
+	if (!ImportResult)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Failed to set property '%s' to value '%s' on widget '%s'. "
+				"The value may be in an incorrect format for type '%s'."),
+			*PropertyName, *Value, *WidgetName, *Prop->GetCPPType()));
+	}
+
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WidgetBP);
+	bool bSaved = SaveBlueprintPackage(WidgetBP);
+
+	// Read back the value
+	FString ActualValue;
+	Prop->ExportTextItem_Direct(ActualValue, ValuePtr, nullptr, nullptr, PPF_None);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("blueprint"), BlueprintName);
+	Result->SetStringField(TEXT("widget"), WidgetName);
+	Result->SetStringField(TEXT("property"), PropertyName);
+	Result->SetStringField(TEXT("value"), ActualValue);
+	Result->SetStringField(TEXT("source"), Source);
+	Result->SetBoolField(TEXT("saved"), bSaved);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleMoveWidget
+// ============================================================
+
+FString FBlueprintMCPServer::HandleMoveWidget(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString BlueprintName = Json->GetStringField(TEXT("blueprint"));
+	FString WidgetName = Json->GetStringField(TEXT("widget"));
+	FString NewParentName = Json->GetStringField(TEXT("newParent"));
+
+	if (BlueprintName.IsEmpty() || WidgetName.IsEmpty() || NewParentName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required fields: blueprint, widget, newParent"));
+	}
+
+	FString LoadError;
+	UWidgetBlueprint* WidgetBP = LoadWidgetBlueprintByName(BlueprintName, LoadError);
+	if (!WidgetBP)
+	{
+		return MakeErrorJson(LoadError);
+	}
+
+	UWidgetTree* Tree = WidgetBP->WidgetTree;
+	if (!Tree)
+	{
+		return MakeErrorJson(TEXT("Widget Blueprint has no WidgetTree"));
+	}
+
+	UWidget* Widget = FindWidgetByName(Tree, WidgetName);
+	if (!Widget)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Widget '%s' not found in Widget Blueprint '%s'"),
+			*WidgetName, *BlueprintName));
+	}
+
+	UWidget* NewParentWidget = FindWidgetByName(Tree, NewParentName);
+	if (!NewParentWidget)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Target parent widget '%s' not found in Widget Blueprint '%s'"),
+			*NewParentName, *BlueprintName));
+	}
+
+	UPanelWidget* NewParentPanel = Cast<UPanelWidget>(NewParentWidget);
+	if (!NewParentPanel)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Target parent '%s' (class: %s) is not a panel widget and cannot have children."),
+			*NewParentName, *NewParentWidget->GetClass()->GetName()));
+	}
+
+	// Cycle detection: refuse to move widget into its own descendant
+	if (IsDescendantOf(NewParentWidget, Widget))
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Cannot move widget '%s' into '%s' because '%s' is a descendant of '%s'. "
+				"This would create a cycle in the widget tree."),
+			*WidgetName, *NewParentName, *NewParentName, *WidgetName));
+	}
+
+	// Cannot move to same parent
+	if (Widget->GetParent() == NewParentPanel)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Widget '%s' is already a child of '%s'"),
+			*WidgetName, *NewParentName));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Moving widget '%s' to new parent '%s' in '%s'"),
+		*WidgetName, *NewParentName, *BlueprintName);
+
+	// Remove from current parent
+	UPanelWidget* OldParent = Widget->GetParent();
+	FString OldParentName = OldParent ? OldParent->GetName() : TEXT("(root)");
+	if (OldParent)
+	{
+		OldParent->RemoveChild(Widget);
+	}
+	else if (Tree->RootWidget == Widget)
+	{
+		Tree->RootWidget = nullptr;
+	}
+
+	// Add to new parent
+	UPanelSlot* NewSlot = NewParentPanel->AddChild(Widget);
+	if (!NewSlot)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Failed to add widget '%s' as child of '%s'"),
+			*WidgetName, *NewParentName));
+	}
+
+	FBlueprintEditorUtils::MarkBlueprintAsStructurallyModified(WidgetBP);
+	bool bSaved = SaveBlueprintPackage(WidgetBP);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("blueprint"), BlueprintName);
+	Result->SetStringField(TEXT("widget"), WidgetName);
+	Result->SetStringField(TEXT("oldParent"), OldParentName);
+	Result->SetStringField(TEXT("newParent"), NewParentName);
+	Result->SetBoolField(TEXT("saved"), bSaved);
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleCreateWidgetBlueprint
+// ============================================================
+
+FString FBlueprintMCPServer::HandleCreateWidgetBlueprint(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body"));
+	}
+
+	FString Name = Json->GetStringField(TEXT("name"));
+	FString PackagePath = Json->GetStringField(TEXT("packagePath"));
+
+	if (Name.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: name"));
+	}
+	if (PackagePath.IsEmpty())
+	{
+		PackagePath = TEXT("/Game");
+	}
+
+	// Check if asset already exists
+	FString FullPath = PackagePath / Name;
+	FAssetData* Existing = FindBlueprintAsset(FullPath);
+	if (!Existing)
+	{
+		Existing = FindBlueprintAsset(Name);
+	}
+	if (Existing)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("An asset named '%s' already exists at '%s'"),
+			*Name, *Existing->PackageName.ToString()));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Creating Widget Blueprint '%s' at '%s'"),
+		*Name, *PackagePath);
+
+	// Create the Widget Blueprint using the factory
+	UWidgetBlueprintFactory* Factory = NewObject<UWidgetBlueprintFactory>();
+
+	IAssetTools& AssetTools = FModuleManager::LoadModuleChecked<FAssetToolsModule>("AssetTools").Get();
+	UObject* NewAsset = AssetTools.CreateAsset(Name, PackagePath, UWidgetBlueprint::StaticClass(), Factory);
+
+	if (!NewAsset)
+	{
+		return MakeErrorJson(FString::Printf(
+			TEXT("Failed to create Widget Blueprint '%s' at '%s'"),
+			*Name, *PackagePath));
+	}
+
+	UWidgetBlueprint* NewWidgetBP = Cast<UWidgetBlueprint>(NewAsset);
+	if (!NewWidgetBP)
+	{
+		return MakeErrorJson(TEXT("Created asset is not a Widget Blueprint"));
+	}
+
+	// Save the package
+	bool bSaved = SaveBlueprintPackage(NewWidgetBP);
+
+	// Add to our cached asset list
+	FAssetRegistryModule& ARM = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+	FAssetData NewAssetData = ARM.Get().GetAssetByObjectPath(FSoftObjectPath(NewWidgetBP));
+	if (NewAssetData.IsValid())
+	{
+		AllBlueprintAssets.Add(NewAssetData);
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Created Widget Blueprint '%s' (saved: %s)"),
+		*Name, bSaved ? TEXT("true") : TEXT("false"));
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("name"), Name);
+	Result->SetStringField(TEXT("packagePath"), PackagePath);
+	Result->SetStringField(TEXT("fullPath"), FullPath);
+	Result->SetStringField(TEXT("class"), TEXT("WidgetBlueprint"));
+	Result->SetBoolField(TEXT("saved"), bSaved);
+	return JsonToString(Result);
+}

--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -867,16 +867,22 @@ bool FBlueprintMCPServer::ProcessOneRequest()
 	FString Response;
 	if (FRequestHandler* Handler = HandlerMap.Find(Req->Endpoint))
 	{
-		// Wrap mutation endpoints in an undo transaction so users can Ctrl+Z
+		// Wrap mutation endpoints in an undo transaction so users can Ctrl+Z.
+		// Widget Blueprint mutations are EXCLUDED because BP recompilation creates
+		// REINST_ objects whose WidgetTree references get trapped in the TransBuffer,
+		// preventing the old World from being garbage-collected (fatal "World Leak"
+		// crash in ReferenceChainSearch.cpp). Widget tools use snapshot/restore instead.
 		const bool bIsMutation = MutationEndpoints.Contains(Req->Endpoint);
-		if (bIsMutation && GEditor)
+		const bool bIsWidgetMutation = WidgetMutationEndpoints.Contains(Req->Endpoint);
+		const bool bUseTransaction = bIsMutation && !bIsWidgetMutation && GEditor != nullptr;
+		if (bUseTransaction)
 		{
 			GEditor->BeginTransaction(FText::FromString(FString::Printf(TEXT("BlueprintMCP: %s"), *Req->Endpoint)));
 		}
 
 		Response = (*Handler)(Req->QueryParams, Req->Body);
 
-		if (bIsMutation && GEditor)
+		if (bUseTransaction)
 		{
 			GEditor->EndTransaction();
 		}
@@ -955,6 +961,17 @@ void FBlueprintMCPServer::RegisterHandlers()
 		TEXT("addAnimNode"),
 		TEXT("addStateMachine"),
 		TEXT("setStateAnimation"),
+		TEXT("addWidget"),
+		TEXT("removeWidget"),
+		TEXT("setWidgetProperty"),
+		TEXT("moveWidget"),
+		TEXT("createWidgetBlueprint"),
+	};
+
+	// Widget mutations that must NOT be wrapped in undo transactions.
+	// Recompilation of Widget Blueprints creates REINST_ objects whose
+	// WidgetTree refs in the TransBuffer prevent World GC → fatal crash.
+	WidgetMutationEndpoints = {
 		TEXT("addWidget"),
 		TEXT("removeWidget"),
 		TEXT("setWidgetProperty"),

--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -804,6 +804,24 @@ bool FBlueprintMCPServer::Start(int32 InPort, bool bEditorMode)
 	Router->BindRoute(FHttpPath(TEXT("/api/create-widget-blueprint")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("createWidgetBlueprint")));
 
+	// Level actor tools (read)
+	Router->BindRoute(FHttpPath(TEXT("/api/current-level")), EHttpServerRequestVerbs::VERB_GET,
+		QueuedHandler(TEXT("current-level")));
+	Router->BindRoute(FHttpPath(TEXT("/api/list-actors")), EHttpServerRequestVerbs::VERB_GET,
+		QueuedHandler(TEXT("list-actors")));
+	Router->BindRoute(FHttpPath(TEXT("/api/actor-properties")), EHttpServerRequestVerbs::VERB_GET,
+		QueuedHandler(TEXT("actor-properties")));
+
+	// Level actor tools (write)
+	Router->BindRoute(FHttpPath(TEXT("/api/set-actor-transform")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("set-actor-transform")));
+	Router->BindRoute(FHttpPath(TEXT("/api/set-actor-property")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("set-actor-property")));
+	Router->BindRoute(FHttpPath(TEXT("/api/spawn-actor")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("spawn-actor")));
+	Router->BindRoute(FHttpPath(TEXT("/api/delete-actor")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("delete-actor")));
+
 	// Register TMap dispatch handlers
 	RegisterHandlers();
 
@@ -966,6 +984,11 @@ void FBlueprintMCPServer::RegisterHandlers()
 		TEXT("setWidgetProperty"),
 		TEXT("moveWidget"),
 		TEXT("createWidgetBlueprint"),
+		// Level actor mutations
+		TEXT("set-actor-transform"),
+		TEXT("set-actor-property"),
+		TEXT("spawn-actor"),
+		TEXT("delete-actor"),
 	};
 
 	// Widget mutations that must NOT be wrapped in undo transactions.
@@ -1094,6 +1117,15 @@ void FBlueprintMCPServer::RegisterHandlers()
 	HandlerMap.Add(TEXT("setWidgetProperty"),       [this](const TMap<FString, FString>&, const FString& B) { return HandleSetWidgetProperty(B); });
 	HandlerMap.Add(TEXT("moveWidget"),              [this](const TMap<FString, FString>&, const FString& B) { return HandleMoveWidget(B); });
 	HandlerMap.Add(TEXT("createWidgetBlueprint"),   [this](const TMap<FString, FString>&, const FString& B) { return HandleCreateWidgetBlueprint(B); });
+
+	// Level actor handlers
+	HandlerMap.Add(TEXT("current-level"),       [this](const TMap<FString, FString>& P, const FString& B) { return HandleGetCurrentLevel(P, B); });
+	HandlerMap.Add(TEXT("list-actors"),         [this](const TMap<FString, FString>& P, const FString& B) { return HandleListActors(P, B); });
+	HandlerMap.Add(TEXT("actor-properties"),    [this](const TMap<FString, FString>& P, const FString& B) { return HandleGetActorProperties(P, B); });
+	HandlerMap.Add(TEXT("set-actor-transform"), [this](const TMap<FString, FString>& P, const FString& B) { return HandleSetActorTransform(P, B); });
+	HandlerMap.Add(TEXT("set-actor-property"),  [this](const TMap<FString, FString>& P, const FString& B) { return HandleSetActorProperty(P, B); });
+	HandlerMap.Add(TEXT("spawn-actor"),         [this](const TMap<FString, FString>& P, const FString& B) { return HandleSpawnActor(P, B); });
+	HandlerMap.Add(TEXT("delete-actor"),        [this](const TMap<FString, FString>& P, const FString& B) { return HandleDeleteActor(P, B); });
 }
 
 // ============================================================

--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -788,6 +788,22 @@ bool FBlueprintMCPServer::Start(int32 InPort, bool bEditorMode)
 	Router->BindRoute(FHttpPath(TEXT("/api/set-state-blend-space")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("setStateBlendSpace")));
 
+	// Widget Blueprint tools
+	Router->BindRoute(FHttpPath(TEXT("/api/list-widget-tree")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("listWidgetTree")));
+	Router->BindRoute(FHttpPath(TEXT("/api/get-widget-properties")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("getWidgetProperties")));
+	Router->BindRoute(FHttpPath(TEXT("/api/add-widget")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("addWidget")));
+	Router->BindRoute(FHttpPath(TEXT("/api/remove-widget")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("removeWidget")));
+	Router->BindRoute(FHttpPath(TEXT("/api/set-widget-property")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("setWidgetProperty")));
+	Router->BindRoute(FHttpPath(TEXT("/api/move-widget")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("moveWidget")));
+	Router->BindRoute(FHttpPath(TEXT("/api/create-widget-blueprint")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("createWidgetBlueprint")));
+
 	// Register TMap dispatch handlers
 	RegisterHandlers();
 
@@ -939,6 +955,11 @@ void FBlueprintMCPServer::RegisterHandlers()
 		TEXT("addAnimNode"),
 		TEXT("addStateMachine"),
 		TEXT("setStateAnimation"),
+		TEXT("addWidget"),
+		TEXT("removeWidget"),
+		TEXT("setWidgetProperty"),
+		TEXT("moveWidget"),
+		TEXT("createWidgetBlueprint"),
 	};
 
 	// GET handlers (use QueryParams, ignore Body)
@@ -1047,6 +1068,15 @@ void FBlueprintMCPServer::RegisterHandlers()
 	HandlerMap.Add(TEXT("createBlendSpace"),        [this](const TMap<FString, FString>&, const FString& B) { return HandleCreateBlendSpace(B); });
 	HandlerMap.Add(TEXT("setBlendSpaceSamples"),    [this](const TMap<FString, FString>&, const FString& B) { return HandleSetBlendSpaceSamples(B); });
 	HandlerMap.Add(TEXT("setStateBlendSpace"),      [this](const TMap<FString, FString>&, const FString& B) { return HandleSetStateBlendSpace(B); });
+
+	// Widget Blueprint handlers
+	HandlerMap.Add(TEXT("listWidgetTree"),          [this](const TMap<FString, FString>&, const FString& B) { return HandleListWidgetTree(B); });
+	HandlerMap.Add(TEXT("getWidgetProperties"),     [this](const TMap<FString, FString>&, const FString& B) { return HandleGetWidgetProperties(B); });
+	HandlerMap.Add(TEXT("addWidget"),               [this](const TMap<FString, FString>&, const FString& B) { return HandleAddWidget(B); });
+	HandlerMap.Add(TEXT("removeWidget"),            [this](const TMap<FString, FString>&, const FString& B) { return HandleRemoveWidget(B); });
+	HandlerMap.Add(TEXT("setWidgetProperty"),       [this](const TMap<FString, FString>&, const FString& B) { return HandleSetWidgetProperty(B); });
+	HandlerMap.Add(TEXT("moveWidget"),              [this](const TMap<FString, FString>&, const FString& B) { return HandleMoveWidget(B); });
+	HandlerMap.Add(TEXT("createWidgetBlueprint"),   [this](const TMap<FString, FString>&, const FString& B) { return HandleCreateWidgetBlueprint(B); });
 }
 
 // ============================================================

--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -811,6 +811,8 @@ bool FBlueprintMCPServer::Start(int32 InPort, bool bEditorMode)
 		QueuedHandler(TEXT("list-actors")));
 	Router->BindRoute(FHttpPath(TEXT("/api/actor-properties")), EHttpServerRequestVerbs::VERB_GET,
 		QueuedHandler(TEXT("actor-properties")));
+	Router->BindRoute(FHttpPath(TEXT("/api/selected-actors")), EHttpServerRequestVerbs::VERB_GET,
+		QueuedHandler(TEXT("selected-actors")));
 
 	// Level actor tools (write)
 	Router->BindRoute(FHttpPath(TEXT("/api/set-actor-transform")), EHttpServerRequestVerbs::VERB_POST,
@@ -1122,6 +1124,7 @@ void FBlueprintMCPServer::RegisterHandlers()
 	HandlerMap.Add(TEXT("current-level"),       [this](const TMap<FString, FString>& P, const FString& B) { return HandleGetCurrentLevel(P, B); });
 	HandlerMap.Add(TEXT("list-actors"),         [this](const TMap<FString, FString>& P, const FString& B) { return HandleListActors(P, B); });
 	HandlerMap.Add(TEXT("actor-properties"),    [this](const TMap<FString, FString>& P, const FString& B) { return HandleGetActorProperties(P, B); });
+	HandlerMap.Add(TEXT("selected-actors"),     [this](const TMap<FString, FString>& P, const FString& B) { return HandleGetSelectedActors(P, B); });
 	HandlerMap.Add(TEXT("set-actor-transform"), [this](const TMap<FString, FString>& P, const FString& B) { return HandleSetActorTransform(P, B); });
 	HandlerMap.Add(TEXT("set-actor-property"),  [this](const TMap<FString, FString>& P, const FString& B) { return HandleSetActorProperty(P, B); });
 	HandlerMap.Add(TEXT("spawn-actor"),         [this](const TMap<FString, FString>& P, const FString& B) { return HandleSpawnActor(P, B); });

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -211,6 +211,7 @@ private:
 
 	// ----- Level actors (read) -----
 	FString HandleGetCurrentLevel(const TMap<FString, FString>& Params, const FString&);
+	FString HandleGetSelectedActors(const TMap<FString, FString>& Params, const FString&);
 	FString HandleListActors(const TMap<FString, FString>& Params, const FString&);
 	FString HandleGetActorProperties(const TMap<FString, FString>& Params, const FString&);
 

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -15,6 +15,9 @@ class UMaterialInstanceConstant;
 class UMaterialFunction;
 class UMaterialExpression;
 class UWidgetBlueprint;
+class AActor;
+class UWorld;
+class ULevel;
 
 // ----- Snapshot data structures -----
 
@@ -206,6 +209,17 @@ private:
 	FString HandleRemoveComponent(const FString& Body);
 	FString HandleListComponents(const FString& Body);
 
+	// ----- Level actors (read) -----
+	FString HandleGetCurrentLevel(const TMap<FString, FString>& Params, const FString&);
+	FString HandleListActors(const TMap<FString, FString>& Params, const FString&);
+	FString HandleGetActorProperties(const TMap<FString, FString>& Params, const FString&);
+
+	// ----- Level actors (write) -----
+	FString HandleSetActorTransform(const TMap<FString, FString>&, const FString& Body);
+	FString HandleSetActorProperty(const TMap<FString, FString>&, const FString& Body);
+	FString HandleSpawnActor(const TMap<FString, FString>&, const FString& Body);
+	FString HandleDeleteActor(const TMap<FString, FString>&, const FString& Body);
+
 	// ----- Widget Blueprint tools -----
 	FString HandleListWidgetTree(const FString& Body);
 	FString HandleGetWidgetProperties(const FString& Body);
@@ -292,6 +306,11 @@ private:
 	FString JsonToString(TSharedRef<FJsonObject> JsonObj);
 
 	// ----- Helpers -----
+	/** Find a placed actor in the world by its editor display label (case-insensitive). */
+	AActor* FindActorByLabel(UWorld* World, const FString& Label);
+	/** Save the UWorld's .umap package to disk. */
+	bool SaveLevelPackage(ULevel* Level);
+
 	FAssetData* FindAnyAsset(const FString& NameOrPath);
 	FAssetData* FindBlueprintAsset(const FString& NameOrPath);
 	FAssetData* FindMapAsset(const FString& NameOrPath);

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -14,6 +14,7 @@ class UMaterial;
 class UMaterialInstanceConstant;
 class UMaterialFunction;
 class UMaterialExpression;
+class UWidgetBlueprint;
 
 // ----- Snapshot data structures -----
 
@@ -204,6 +205,15 @@ private:
 	FString HandleRemoveComponent(const FString& Body);
 	FString HandleListComponents(const FString& Body);
 
+	// ----- Widget Blueprint tools -----
+	FString HandleListWidgetTree(const FString& Body);
+	FString HandleGetWidgetProperties(const FString& Body);
+	FString HandleAddWidget(const FString& Body);
+	FString HandleRemoveWidget(const FString& Body);
+	FString HandleSetWidgetProperty(const FString& Body);
+	FString HandleMoveWidget(const FString& Body);
+	FString HandleCreateWidgetBlueprint(const FString& Body);
+
 	// ----- Property defaults -----
 	FString HandleSetBlueprintDefault(const FString& Body);
 
@@ -290,6 +300,9 @@ private:
 	FString MakeErrorJson(const FString& Message);
 	bool SaveBlueprintPackage(UBlueprint* BP);
 	static FString UrlDecode(const FString& EncodedString);
+
+	// ----- Widget helpers -----
+	UWidgetBlueprint* LoadWidgetBlueprintByName(const FString& NameOrPath, FString& OutError);
 
 	// ----- Material helpers -----
 	/** Ensure that Material->MaterialGraph exists (creates it on demand for commandlet mode). */

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -99,6 +99,7 @@ private:
 	using FRequestHandler = TFunction<FString(const TMap<FString, FString>&, const FString&)>;
 	TMap<FString, FRequestHandler> HandlerMap;
 	TSet<FString> MutationEndpoints;
+	TSet<FString> WidgetMutationEndpoints; // excluded from undo transactions (see ProcessOneRequest)
 	void RegisterHandlers();
 	// ----- Queued request model -----
 	struct FPendingRequest

--- a/Tools/src/index.ts
+++ b/Tools/src/index.ts
@@ -20,6 +20,7 @@ import { registerUserTypeTools } from "./tools/user-types.js";
 import { registerMaterialReadTools } from "./tools/material-read.js";
 import { registerMaterialMutationTools } from "./tools/material-mutation.js";
 import { registerAnimationTools } from "./tools/animation-mutation.js";
+import { registerWidgetTools } from "./tools/widgets.js";
 
 // Resource registrations
 import { registerBlueprintListResource } from "./resources/blueprint-list.js";
@@ -48,6 +49,7 @@ registerUserTypeTools(server);
 registerMaterialReadTools(server);
 registerMaterialMutationTools(server);
 registerAnimationTools(server);
+registerWidgetTools(server);
 
 // Register resources
 registerBlueprintListResource(server);

--- a/Tools/src/index.ts
+++ b/Tools/src/index.ts
@@ -21,6 +21,7 @@ import { registerMaterialReadTools } from "./tools/material-read.js";
 import { registerMaterialMutationTools } from "./tools/material-mutation.js";
 import { registerAnimationTools } from "./tools/animation-mutation.js";
 import { registerWidgetTools } from "./tools/widgets.js";
+import { registerLevelTools } from "./tools/level.js";
 
 // Resource registrations
 import { registerBlueprintListResource } from "./resources/blueprint-list.js";
@@ -50,6 +51,7 @@ registerMaterialReadTools(server);
 registerMaterialMutationTools(server);
 registerAnimationTools(server);
 registerWidgetTools(server);
+registerLevelTools(server);
 
 // Register resources
 registerBlueprintListResource(server);

--- a/Tools/src/tools/level.ts
+++ b/Tools/src/tools/level.ts
@@ -4,6 +4,43 @@ import { ensureUE, ueGet, uePost } from "../ue-bridge.js";
 
 export function registerLevelTools(server: McpServer): void {
   server.tool(
+    "get_selected_actors",
+    "Returns all actors currently selected in the Unreal Editor viewport, including their label, class, folder, location, rotation, and scale. Use this to operate on whatever the user has selected without needing to know actor labels in advance.",
+    {},
+    async () => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await ueGet("/api/selected-actors", {});
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+
+      if (!data.count) {
+        lines.push("No actors selected.");
+        lines.push("");
+        lines.push("Select one or more actors in the viewport, then call this tool again.");
+      } else {
+        lines.push(`Selected actors (${data.count}):`);
+        for (const a of data.actors || []) {
+          const loc = a.location;
+          const rot = a.rotation;
+          lines.push(`  ${a.label} (${a.class})${a.folder ? ` [${a.folder}]` : ""}`);
+          lines.push(`    Location: (${loc.x?.toFixed(1)}, ${loc.y?.toFixed(1)}, ${loc.z?.toFixed(1)}) cm`);
+          lines.push(`    Rotation: pitch=${rot.pitch?.toFixed(1)} yaw=${rot.yaw?.toFixed(1)} roll=${rot.roll?.toFixed(1)}`);
+        }
+        lines.push("");
+        lines.push("Next steps:");
+        for (const a of data.actors || []) {
+          lines.push(`  get_actor_properties(label="${a.label}") — inspect properties`);
+        }
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
     "get_current_level",
     "Get information about the currently open level in the Unreal Editor, including its name, package path, and actor count.",
     {},

--- a/Tools/src/tools/level.ts
+++ b/Tools/src/tools/level.ts
@@ -1,0 +1,280 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ensureUE, ueGet, uePost } from "../ue-bridge.js";
+
+export function registerLevelTools(server: McpServer): void {
+  server.tool(
+    "get_current_level",
+    "Get information about the currently open level in the Unreal Editor, including its name, package path, and actor count.",
+    {},
+    async () => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await ueGet("/api/current-level", {});
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Level: ${data.levelName}`);
+      lines.push(`Package: ${data.packageName}`);
+      lines.push(`Actor count: ${data.actorCount}`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "list_actors",
+    "List actors placed in the currently open level. Supports optional filtering by class name, actor label, or outliner folder. Returns label, class, folder, and location for each actor.",
+    {
+      classFilter: z.string().optional().describe("Substring filter on class name (e.g. 'StaticMesh', 'Light', 'Camera')"),
+      nameFilter:  z.string().optional().describe("Substring filter on actor label (display name in world outliner)"),
+      folder:      z.string().optional().describe("Outliner folder prefix to filter by (e.g. 'Lights', 'Environment/Props')"),
+    },
+    async ({ classFilter, nameFilter, folder }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const params: Record<string, string> = {};
+      if (classFilter) params.classFilter = classFilter;
+      if (nameFilter)  params.nameFilter  = nameFilter;
+      if (folder)      params.folder      = folder;
+
+      const data = await ueGet("/api/list-actors", params);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Level: ${data.level}`);
+      lines.push(`Actors (${data.count || 0}):`);
+
+      for (const a of data.actors || []) {
+        const loc = a.location ? ` @ (${a.location.x?.toFixed(1)}, ${a.location.y?.toFixed(1)}, ${a.location.z?.toFixed(1)})` : "";
+        const folder = a.folder ? ` [${a.folder}]` : "";
+        lines.push(`  ${a.label}: ${a.class}${loc}${folder}`);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "get_actor_properties",
+    "Get all editable (CPF_Edit) properties of a placed actor in the current level, identified by its display label. Returns property name, C++ type, current value, and whether the value is at its class default. Complex struct properties are automatically expanded into individual sub-fields so no values are silently omitted. Pass 'component' to inspect a specific component's properties (e.g. 'StaticMeshComponent0'). Without 'component', also returns a 'components' list for discovery.",
+    {
+      label:     z.string().describe("Actor display label as shown in the world outliner (case-insensitive)"),
+      component: z.string().optional().describe("Component name to inspect (e.g. 'StaticMeshComponent0'). Omit to list actor-level properties and discover available components."),
+    },
+    async ({ label, component }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const params: Record<string, string> = { label };
+      if (component) params.component = component;
+
+      const data = await ueGet("/api/actor-properties", params);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+
+      const formatProps = (props: any[]) => {
+        let lastStruct = "";
+        for (const p of props) {
+          const def = p.isDefault ? " (default)" : "";
+          if (p.struct) {
+            // Struct sub-field: group under struct header
+            if (p.struct !== lastStruct) {
+              lines.push(`  [${p.struct}]`);
+              lastStruct = p.struct;
+            }
+            lines.push(`    ${p.name} [${p.type}] = ${p.value}${def}`);
+          } else {
+            lastStruct = "";
+            lines.push(`  ${p.name} [${p.type}] = ${p.value}${def}`);
+          }
+        }
+      };
+
+      if (component) {
+        lines.push(`Actor: ${data.label} — Component: ${data.component} (${data.class})`);
+        lines.push(`Properties (${data.count || 0}):`);
+        formatProps(data.properties || []);
+        lines.push(``);
+        lines.push(`Tip: set_actor_property(label="${label}", property="${component}.PropertyName", value="...")`);
+      } else {
+        lines.push(`Actor: ${data.label} (${data.class})`);
+        lines.push(`Properties (${data.count || 0}):`);
+        formatProps(data.properties || []);
+        if (data.components && data.components.length > 0) {
+          lines.push(``);
+          lines.push(`Components (${data.components.length}):`);
+          for (const c of data.components) {
+            lines.push(`  ${c.name} (${c.class})`);
+          }
+          lines.push(``);
+          lines.push(`Tip: get_actor_properties(label="${label}", component="<name>") to inspect component properties`);
+          lines.push(`     set_actor_property(label="${label}", property="ComponentName.PropName", value="...") to set them`);
+        }
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "set_actor_transform",
+    "Move, rotate, and/or scale a placed actor in the current level. All fields are optional — only provided fields are applied. Location/scale are in centimeters; rotation is in degrees (pitch/yaw/roll).",
+    {
+      label:    z.string().describe("Actor display label (case-insensitive)"),
+      location: z.object({
+        x: z.number().optional(),
+        y: z.number().optional(),
+        z: z.number().optional(),
+      }).optional().describe("New world location in cm (partial updates supported)"),
+      rotation: z.object({
+        pitch: z.number().optional(),
+        yaw:   z.number().optional(),
+        roll:  z.number().optional(),
+      }).optional().describe("New world rotation in degrees (partial updates supported)"),
+      scale: z.object({
+        x: z.number().optional(),
+        y: z.number().optional(),
+        z: z.number().optional(),
+      }).optional().describe("New world scale (partial updates supported)"),
+    },
+    async ({ label, location, rotation, scale }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { label };
+      if (location) body.location = location;
+      if (rotation) body.rotation = rotation;
+      if (scale)    body.scale    = scale;
+
+      const data = await uePost("/api/set-actor-transform", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const loc = data.location;
+      const rot = data.rotation;
+      const scl = data.scale;
+
+      const lines: string[] = [];
+      lines.push(`Transform updated: ${data.label}`);
+      if (loc) lines.push(`  Location: (${loc.x?.toFixed(2)}, ${loc.y?.toFixed(2)}, ${loc.z?.toFixed(2)}) cm`);
+      if (rot) lines.push(`  Rotation: pitch=${rot.pitch?.toFixed(2)} yaw=${rot.yaw?.toFixed(2)} roll=${rot.roll?.toFixed(2)}`);
+      if (scl) lines.push(`  Scale:    (${scl.x?.toFixed(3)}, ${scl.y?.toFixed(3)}, ${scl.z?.toFixed(3)})`);
+
+      lines.push(``);
+      lines.push(`Next steps:`);
+      lines.push(`  list_actors(nameFilter="${label}") — verify the new position`);
+      lines.push(`  get_actor_properties(label="${label}") — inspect other properties`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "set_actor_property",
+    "Set a named property on a placed actor using UE5 reflection. Supports actor-level properties ('bHidden', 'Mobility') and component sub-properties using dot notation ('StaticMeshComponent0.StaticMesh'). Values use UE import-text format (e.g. '1.0', 'true', '/Engine/BasicShapes/Cube.Cube').",
+    {
+      label:    z.string().describe("Actor display label (case-insensitive)"),
+      property: z.string().describe("C++ property name on the actor ('bHidden') or component sub-property ('StaticMeshComponent0.StaticMesh')"),
+      value:    z.string().describe("Value in UE text-import format (e.g. '1.0', 'true', '/Engine/BasicShapes/Cube.Cube', '(R=1,G=0,B=0,A=1)')"),
+    },
+    async ({ label, property, value }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/set-actor-property", { label, property, value });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Property set successfully.`);
+      lines.push(`Actor:    ${data.label}`);
+      if (data.component) lines.push(`Component: ${data.component}`);
+      lines.push(`Property: ${data.property}`);
+      lines.push(`Value:    ${data.value}`);
+
+      lines.push(``);
+      lines.push(`Next steps:`);
+      lines.push(`  get_actor_properties(label="${label}") — verify all properties`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "spawn_actor",
+    "Spawn a new actor in the currently open level. The class can be a C++ class name (e.g. 'StaticMeshActor', 'PointLight', 'DirectionalLight') or a Blueprint class name (e.g. 'BP_MyActor'). Location defaults to world origin if not specified.",
+    {
+      class:    z.string().describe("Actor class name — C++ (e.g. 'StaticMeshActor') or Blueprint (e.g. 'BP_MyActor')"),
+      label:    z.string().optional().describe("Display label for the new actor in the world outliner"),
+      location: z.object({
+        x: z.number().optional().default(0),
+        y: z.number().optional().default(0),
+        z: z.number().optional().default(0),
+      }).optional().describe("Spawn location in world space (cm)"),
+      rotation: z.object({
+        pitch: z.number().optional().default(0),
+        yaw:   z.number().optional().default(0),
+        roll:  z.number().optional().default(0),
+      }).optional().describe("Spawn rotation in degrees"),
+      folder: z.string().optional().describe("Outliner folder path to place the actor in (e.g. 'Enemies/Ground')"),
+    },
+    async ({ class: actorClass, label, location, rotation, folder }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { class: actorClass };
+      if (label)    body.label    = label;
+      if (location) body.location = location;
+      if (rotation) body.rotation = rotation;
+      if (folder)   body.folder   = folder;
+
+      const data = await uePost("/api/spawn-actor", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const loc = data.location;
+
+      const lines: string[] = [];
+      lines.push(`Actor spawned successfully.`);
+      lines.push(`Label: ${data.label}`);
+      lines.push(`Class: ${data.class}`);
+      if (loc) lines.push(`Location: (${loc.x?.toFixed(1)}, ${loc.y?.toFixed(1)}, ${loc.z?.toFixed(1)}) cm`);
+
+      lines.push(``);
+      lines.push(`Next steps:`);
+      lines.push(`  set_actor_property(label="${data.label}", ...) — configure the actor`);
+      lines.push(`  set_actor_transform(label="${data.label}", ...) — reposition the actor`);
+      lines.push(`  delete_actor(label="${data.label}") — remove it if no longer needed`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "delete_actor",
+    "Delete a placed actor from the current level by its display label. This operation is undoable (Ctrl+Z in the editor). The actor must exist in the level.",
+    {
+      label: z.string().describe("Actor display label to delete (case-insensitive)"),
+    },
+    async ({ label }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/delete-actor", { label });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Actor deleted successfully.`);
+      lines.push(`Label: ${data.label}`);
+      lines.push(`Class: ${data.class}`);
+
+      lines.push(``);
+      lines.push(`Next steps:`);
+      lines.push(`  list_actors() — verify the actor was removed`);
+      lines.push(`  (Ctrl+Z in the editor to undo)`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+}

--- a/Tools/src/tools/widgets.ts
+++ b/Tools/src/tools/widgets.ts
@@ -1,0 +1,248 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ensureUE, uePost } from "../ue-bridge.js";
+
+export function registerWidgetTools(server: McpServer): void {
+  // ---------------------------------------------------------------
+  // list_widget_tree
+  // ---------------------------------------------------------------
+  server.tool(
+    "list_widget_tree",
+    "List the full widget hierarchy of a Widget Blueprint (UMG). Shows widget names, classes, parents, slots, and panel/child relationships. Only works on Widget Blueprints.",
+    {
+      blueprint: z.string().describe("Widget Blueprint name or package path (e.g. 'WBP_PlayerHud')"),
+    },
+    async ({ blueprint }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/list-widget-tree", { blueprint });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Widget Blueprint: ${data.blueprint}`);
+      lines.push(`Root: ${data.rootWidget}`);
+      lines.push(`Widgets (${data.count || 0}):`);
+
+      for (const w of data.widgets || []) {
+        const indent = "  ".repeat((w.depth || 0) + 1);
+        const parent = w.parent ? ` (parent: ${w.parent})` : " [Root]";
+        const panel = w.isPanel ? ` [Panel, ${w.childCount} children]` : "";
+        const slot = w.slotClass ? ` slot:${w.slotClass}` : "";
+        lines.push(`${indent}${w.name}: ${w.class}${parent}${panel}${slot}`);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  // ---------------------------------------------------------------
+  // get_widget_properties
+  // ---------------------------------------------------------------
+  server.tool(
+    "get_widget_properties",
+    "Get all editable properties of a specific widget in a Widget Blueprint, including slot properties (anchors, alignment, padding, etc.). Use this to inspect current values before calling set_widget_property.",
+    {
+      blueprint: z.string().describe("Widget Blueprint name or package path"),
+      widget: z.string().describe("Name of the widget to inspect"),
+    },
+    async ({ blueprint, widget }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/get-widget-properties", { blueprint, widget });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Widget: ${data.widget} (${data.widgetClass})`);
+      if (data.slotClass) lines.push(`Slot: ${data.slotClass}`);
+      lines.push(`Properties (${data.propertyCount || 0}):`);
+
+      for (const p of data.properties || []) {
+        const src = p.source === "slot" ? " [slot]" : "";
+        lines.push(`  ${p.name} (${p.type})${src} = ${p.value}`);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  // ---------------------------------------------------------------
+  // add_widget
+  // ---------------------------------------------------------------
+  server.tool(
+    "add_widget",
+    "Add a widget to a Widget Blueprint's designer hierarchy. Common widget classes: TextBlock, Button, Image, VerticalBox, HorizontalBox, Overlay, CanvasPanel, Border, SizeBox, ScaleBox, ScrollBox, Spacer, ProgressBar, Slider, CheckBox. If no parent is specified, adds to the root panel.",
+    {
+      blueprint: z.string().describe("Widget Blueprint name or package path"),
+      widgetClass: z.string().describe("Widget class name (e.g. 'TextBlock', 'Button', 'VerticalBox')"),
+      name: z.string().describe("Name for the new widget (e.g. 'TitleText', 'StartButton')"),
+      parent: z.string().optional().describe("Name of the parent panel widget (optional, defaults to root panel)"),
+    },
+    async ({ blueprint, widgetClass, name, parent }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { blueprint, widgetClass, name };
+      if (parent) body.parent = parent;
+
+      const data = await uePost("/api/add-widget", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Widget added successfully.`);
+      lines.push(`Blueprint: ${data.blueprint}`);
+      lines.push(`Name: ${data.name}`);
+      lines.push(`Class: ${data.widgetClass}`);
+      lines.push(`Parent: ${data.parent}`);
+      if (data.saved !== undefined) lines.push(`Saved: ${data.saved}`);
+
+      lines.push(``);
+      lines.push(`Next steps:`);
+      lines.push(`  list_widget_tree(blueprint="${blueprint}") — verify the widget hierarchy`);
+      lines.push(`  set_widget_property(blueprint="${blueprint}", widget="${name}", ...) — configure widget properties`);
+      lines.push(`  get_widget_properties(blueprint="${blueprint}", widget="${name}") — see all available properties`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  // ---------------------------------------------------------------
+  // remove_widget
+  // ---------------------------------------------------------------
+  server.tool(
+    "remove_widget",
+    "Remove a widget from a Widget Blueprint's designer hierarchy. Cannot remove panel widgets that have children — remove or move the children first.",
+    {
+      blueprint: z.string().describe("Widget Blueprint name or package path"),
+      widget: z.string().describe("Name of the widget to remove"),
+    },
+    async ({ blueprint, widget }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/remove-widget", { blueprint, widget });
+      if (data.error) {
+        let msg = `Error: ${data.error}`;
+        if (data.existingWidgets?.length) {
+          msg += `\nExisting widgets: ${data.existingWidgets.join(", ")}`;
+        }
+        return { content: [{ type: "text" as const, text: msg }] };
+      }
+
+      const lines: string[] = [];
+      lines.push(`Widget removed successfully.`);
+      lines.push(`Blueprint: ${data.blueprint}`);
+      lines.push(`Removed: ${data.widget}`);
+      if (data.saved !== undefined) lines.push(`Saved: ${data.saved}`);
+
+      lines.push(``);
+      lines.push(`Next steps:`);
+      lines.push(`  list_widget_tree(blueprint="${blueprint}") — verify the widget was removed`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  // ---------------------------------------------------------------
+  // set_widget_property
+  // ---------------------------------------------------------------
+  server.tool(
+    "set_widget_property",
+    "Set a property on a widget or its slot (layout) in a Widget Blueprint. Properties are searched on the widget first, then on its slot. For FText properties, bare strings are automatically wrapped in INVTEXT(). Use get_widget_properties to discover available properties.",
+    {
+      blueprint: z.string().describe("Widget Blueprint name or package path"),
+      widget: z.string().describe("Name of the widget to modify"),
+      property: z.string().describe("Property name (e.g. 'Text', 'ColorAndOpacity', 'Visibility')"),
+      value: z.string().describe("Value to set (e.g. 'Hello World' for Text, '(R=1,G=0,B=0,A=1)' for color)"),
+    },
+    async ({ blueprint, widget, property, value }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/set-widget-property", { blueprint, widget, property, value });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Property set successfully.`);
+      lines.push(`Widget: ${data.widget}`);
+      lines.push(`Property: ${data.property} (${data.source})`);
+      lines.push(`Value: ${data.value}`);
+      if (data.saved !== undefined) lines.push(`Saved: ${data.saved}`);
+
+      lines.push(``);
+      lines.push(`Next steps:`);
+      lines.push(`  get_widget_properties(blueprint="${blueprint}", widget="${widget}") — verify the change`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  // ---------------------------------------------------------------
+  // move_widget
+  // ---------------------------------------------------------------
+  server.tool(
+    "move_widget",
+    "Move a widget from its current parent to a different panel widget in the same Widget Blueprint. Includes cycle detection to prevent moving a widget into its own descendant.",
+    {
+      blueprint: z.string().describe("Widget Blueprint name or package path"),
+      widget: z.string().describe("Name of the widget to move"),
+      newParent: z.string().describe("Name of the new parent panel widget"),
+    },
+    async ({ blueprint, widget, newParent }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/move-widget", { blueprint, widget, newParent });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Widget moved successfully.`);
+      lines.push(`Widget: ${data.widget}`);
+      lines.push(`From: ${data.oldParent}`);
+      lines.push(`To: ${data.newParent}`);
+      if (data.saved !== undefined) lines.push(`Saved: ${data.saved}`);
+
+      lines.push(``);
+      lines.push(`Next steps:`);
+      lines.push(`  list_widget_tree(blueprint="${blueprint}") — verify the new hierarchy`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  // ---------------------------------------------------------------
+  // create_widget_blueprint
+  // ---------------------------------------------------------------
+  server.tool(
+    "create_widget_blueprint",
+    "Create a new empty Widget Blueprint (UMG). The new blueprint will have an empty widget tree ready for adding widgets.",
+    {
+      name: z.string().describe("Name for the new Widget Blueprint (e.g. 'WBP_MainMenu')"),
+      packagePath: z.string().optional().describe("Package path (default: '/Game')"),
+    },
+    async ({ name, packagePath }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { name };
+      if (packagePath) body.packagePath = packagePath;
+
+      const data = await uePost("/api/create-widget-blueprint", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Widget Blueprint created successfully.`);
+      lines.push(`Name: ${data.name}`);
+      lines.push(`Path: ${data.fullPath}`);
+      if (data.saved !== undefined) lines.push(`Saved: ${data.saved}`);
+
+      lines.push(``);
+      lines.push(`Next steps:`);
+      lines.push(`  add_widget(blueprint="${name}", widgetClass="CanvasPanel", name="RootCanvas") — add a root panel`);
+      lines.push(`  list_widget_tree(blueprint="${name}") — view the widget hierarchy`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+}

--- a/Tools/test/helpers.ts
+++ b/Tools/test/helpers.ts
@@ -134,6 +134,19 @@ export async function createTestMaterialFunction(opts: {
 }
 
 /**
+ * Create a test Widget Blueprint via the HTTP API.
+ */
+export async function createTestWidgetBlueprint(opts: {
+  name: string;
+  packagePath?: string;
+}): Promise<any> {
+  return uePost("/api/create-widget-blueprint", {
+    name: opts.name,
+    packagePath: opts.packagePath ?? "/Game/Test",
+  });
+}
+
+/**
  * Create a test Animation Blueprint via the HTTP API.
  */
 export async function createTestAnimBlueprint(opts: {

--- a/Tools/test/tools/widgets.test.ts
+++ b/Tools/test/tools/widgets.test.ts
@@ -1,0 +1,374 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { uePost, createTestWidgetBlueprint, deleteTestBlueprint, uniqueName } from "../helpers.js";
+
+describe("Widget Blueprint tools", () => {
+  const wbpName = uniqueName("WBP_WidgetTest");
+  const packagePath = "/Game/Test";
+
+  beforeAll(async () => {
+    const res = await createTestWidgetBlueprint({ name: wbpName });
+    expect(res.error).toBeUndefined();
+    expect(res.success).toBe(true);
+  });
+
+  afterAll(async () => {
+    await deleteTestBlueprint(`${packagePath}/${wbpName}`);
+  });
+
+  // --- create_widget_blueprint tests ---
+
+  it("create_widget_blueprint succeeds", async () => {
+    const name = uniqueName("WBP_CreateTest");
+    const data = await uePost("/api/create-widget-blueprint", {
+      name,
+      packagePath,
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.name).toBe(name);
+    expect(data.class).toBe("WidgetBlueprint");
+
+    // Cleanup
+    await deleteTestBlueprint(`${packagePath}/${name}`);
+  });
+
+  it("create_widget_blueprint rejects missing name", async () => {
+    const data = await uePost("/api/create-widget-blueprint", {});
+    expect(data.error).toBeDefined();
+  });
+
+  // --- list_widget_tree tests ---
+
+  it("list_widget_tree on empty widget blueprint", async () => {
+    const data = await uePost("/api/list-widget-tree", { blueprint: wbpName });
+    expect(data.error).toBeUndefined();
+    expect(data.blueprint).toBe(wbpName);
+    expect(data.widgets).toBeDefined();
+    expect(Array.isArray(data.widgets)).toBe(true);
+  });
+
+  it("list_widget_tree rejects non-widget blueprint", async () => {
+    // Create a regular Actor blueprint
+    const actorBpName = uniqueName("BP_NonWidgetTest");
+    await uePost("/api/create-blueprint", {
+      blueprintName: actorBpName,
+      packagePath,
+      parentClass: "Actor",
+      blueprintType: "Normal",
+    });
+
+    const data = await uePost("/api/list-widget-tree", { blueprint: actorBpName });
+    expect(data.error).toBeDefined();
+    expect(data.error).toContain("not a Widget Blueprint");
+
+    await deleteTestBlueprint(`${packagePath}/${actorBpName}`);
+  });
+
+  it("list_widget_tree rejects missing fields", async () => {
+    const data = await uePost("/api/list-widget-tree", {});
+    expect(data.error).toBeDefined();
+  });
+
+  it("list_widget_tree rejects non-existent blueprint", async () => {
+    const data = await uePost("/api/list-widget-tree", { blueprint: "WBP_Nonexistent_XYZ_999" });
+    expect(data.error).toBeDefined();
+  });
+
+  // --- add_widget tests ---
+
+  it("adds a CanvasPanel as root", async () => {
+    const data = await uePost("/api/add-widget", {
+      blueprint: wbpName,
+      widgetClass: "CanvasPanel",
+      name: "RootCanvas",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.name).toBe("RootCanvas");
+    expect(data.widgetClass).toContain("CanvasPanel");
+    expect(data.saved).toBe(true);
+  });
+
+  it("lists the root CanvasPanel", async () => {
+    const data = await uePost("/api/list-widget-tree", { blueprint: wbpName });
+    expect(data.error).toBeUndefined();
+    expect(data.rootWidget).toBe("RootCanvas");
+    expect(data.count).toBeGreaterThanOrEqual(1);
+    const root = data.widgets.find((w: any) => w.name === "RootCanvas");
+    expect(root).toBeDefined();
+    expect(root.isPanel).toBe(true);
+  });
+
+  it("adds a TextBlock to the CanvasPanel", async () => {
+    const data = await uePost("/api/add-widget", {
+      blueprint: wbpName,
+      widgetClass: "TextBlock",
+      name: "TitleText",
+      parent: "RootCanvas",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.name).toBe("TitleText");
+    expect(data.parent).toBe("RootCanvas");
+  });
+
+  it("adds a VerticalBox to the CanvasPanel", async () => {
+    const data = await uePost("/api/add-widget", {
+      blueprint: wbpName,
+      widgetClass: "VerticalBox",
+      name: "MainVBox",
+      parent: "RootCanvas",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.widgetClass).toContain("VerticalBox");
+  });
+
+  it("adds a Button inside the VerticalBox", async () => {
+    const data = await uePost("/api/add-widget", {
+      blueprint: wbpName,
+      widgetClass: "Button",
+      name: "StartButton",
+      parent: "MainVBox",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.parent).toBe("MainVBox");
+  });
+
+  it("rejects duplicate widget name", async () => {
+    const data = await uePost("/api/add-widget", {
+      blueprint: wbpName,
+      widgetClass: "TextBlock",
+      name: "TitleText",
+    });
+    expect(data.error).toBeDefined();
+    expect(data.error).toContain("already exists");
+  });
+
+  it("rejects adding child to non-panel widget", async () => {
+    const data = await uePost("/api/add-widget", {
+      blueprint: wbpName,
+      widgetClass: "TextBlock",
+      name: "ChildOfText",
+      parent: "TitleText",
+    });
+    expect(data.error).toBeDefined();
+    expect(data.error).toContain("not a panel");
+  });
+
+  it("rejects invalid widget class", async () => {
+    const data = await uePost("/api/add-widget", {
+      blueprint: wbpName,
+      widgetClass: "FakeWidgetClass_XYZ_999",
+      name: "TestFake",
+    });
+    expect(data.error).toBeDefined();
+    expect(data.error).toContain("not found");
+  });
+
+  it("rejects missing required fields for add_widget", async () => {
+    const data = await uePost("/api/add-widget", {});
+    expect(data.error).toBeDefined();
+  });
+
+  // --- get_widget_properties tests ---
+
+  it("gets properties for a TextBlock", async () => {
+    const data = await uePost("/api/get-widget-properties", {
+      blueprint: wbpName,
+      widget: "TitleText",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.widget).toBe("TitleText");
+    expect(data.widgetClass).toContain("TextBlock");
+    expect(data.properties).toBeDefined();
+    expect(Array.isArray(data.properties)).toBe(true);
+    expect(data.propertyCount).toBeGreaterThan(0);
+
+    // Should have both widget and slot properties
+    const widgetProps = data.properties.filter((p: any) => p.source === "widget");
+    const slotProps = data.properties.filter((p: any) => p.source === "slot");
+    expect(widgetProps.length).toBeGreaterThan(0);
+    expect(slotProps.length).toBeGreaterThan(0);
+  });
+
+  it("rejects get_widget_properties for non-existent widget", async () => {
+    const data = await uePost("/api/get-widget-properties", {
+      blueprint: wbpName,
+      widget: "NonExistent_XYZ_999",
+    });
+    expect(data.error).toBeDefined();
+    expect(data.error).toContain("not found");
+  });
+
+  it("rejects get_widget_properties with missing fields", async () => {
+    const data = await uePost("/api/get-widget-properties", {
+      blueprint: wbpName,
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  // --- set_widget_property tests ---
+
+  it("sets Text property on a TextBlock", async () => {
+    const data = await uePost("/api/set-widget-property", {
+      blueprint: wbpName,
+      widget: "TitleText",
+      property: "Text",
+      value: "Hello World",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.property).toBe("Text");
+    expect(data.source).toBe("widget");
+  });
+
+  it("rejects set_widget_property for invalid property", async () => {
+    const data = await uePost("/api/set-widget-property", {
+      blueprint: wbpName,
+      widget: "TitleText",
+      property: "NonExistentProperty_XYZ_999",
+      value: "test",
+    });
+    expect(data.error).toBeDefined();
+    expect(data.error).toContain("not found");
+  });
+
+  it("rejects set_widget_property with missing fields", async () => {
+    const data = await uePost("/api/set-widget-property", {
+      blueprint: wbpName,
+      widget: "TitleText",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  // --- move_widget tests ---
+
+  it("moves a widget to a different parent", async () => {
+    // Move TitleText from RootCanvas to MainVBox
+    const data = await uePost("/api/move-widget", {
+      blueprint: wbpName,
+      widget: "TitleText",
+      newParent: "MainVBox",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.widget).toBe("TitleText");
+    expect(data.oldParent).toBe("RootCanvas");
+    expect(data.newParent).toBe("MainVBox");
+  });
+
+  it("verifies widget was moved", async () => {
+    const data = await uePost("/api/list-widget-tree", { blueprint: wbpName });
+    expect(data.error).toBeUndefined();
+    const titleText = data.widgets.find((w: any) => w.name === "TitleText");
+    expect(titleText).toBeDefined();
+    expect(titleText.parent).toBe("MainVBox");
+  });
+
+  it("rejects move to non-panel target", async () => {
+    const data = await uePost("/api/move-widget", {
+      blueprint: wbpName,
+      widget: "StartButton",
+      newParent: "TitleText",
+    });
+    expect(data.error).toBeDefined();
+    expect(data.error).toContain("not a panel");
+  });
+
+  it("rejects move that would create a cycle", async () => {
+    // Try to move MainVBox (which contains StartButton) into StartButton
+    // StartButton is a PanelWidget (Button is a ContentWidget/PanelWidget)
+    // but MainVBox is an ancestor of StartButton so this should fail
+    const data = await uePost("/api/move-widget", {
+      blueprint: wbpName,
+      widget: "MainVBox",
+      newParent: "StartButton",
+    });
+    expect(data.error).toBeDefined();
+    // Could be cycle detection or non-panel error depending on Button's type
+    expect(data.error).toBeTruthy();
+  });
+
+  it("rejects move with missing fields", async () => {
+    const data = await uePost("/api/move-widget", {
+      blueprint: wbpName,
+      widget: "TitleText",
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  // --- remove_widget tests ---
+
+  it("removes a leaf widget (StartButton)", async () => {
+    const data = await uePost("/api/remove-widget", {
+      blueprint: wbpName,
+      widget: "StartButton",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+    expect(data.saved).toBe(true);
+  });
+
+  it("removes TitleText", async () => {
+    const data = await uePost("/api/remove-widget", {
+      blueprint: wbpName,
+      widget: "TitleText",
+    });
+    expect(data.error).toBeUndefined();
+    expect(data.success).toBe(true);
+  });
+
+  it("verifies widgets are removed", async () => {
+    const data = await uePost("/api/list-widget-tree", { blueprint: wbpName });
+    expect(data.error).toBeUndefined();
+    const btn = data.widgets.find((w: any) => w.name === "StartButton");
+    expect(btn).toBeUndefined();
+    const txt = data.widgets.find((w: any) => w.name === "TitleText");
+    expect(txt).toBeUndefined();
+  });
+
+  it("rejects removing non-existent widget", async () => {
+    const data = await uePost("/api/remove-widget", {
+      blueprint: wbpName,
+      widget: "NonExistent_XYZ_999",
+    });
+    expect(data.error).toBeDefined();
+    expect(data.error).toContain("not found");
+    expect(data.existingWidgets).toBeDefined();
+  });
+
+  it("rejects removing panel with children", async () => {
+    // RootCanvas still has MainVBox as a child
+    const data = await uePost("/api/remove-widget", {
+      blueprint: wbpName,
+      widget: "RootCanvas",
+    });
+    expect(data.error).toBeDefined();
+    expect(data.error).toContain("child");
+  });
+
+  it("rejects remove with missing fields", async () => {
+    const data = await uePost("/api/remove-widget", {
+      blueprint: wbpName,
+    });
+    expect(data.error).toBeDefined();
+  });
+
+  it("cleans up remaining widgets (MainVBox then RootCanvas)", async () => {
+    // Remove MainVBox (now empty after TitleText and StartButton were removed)
+    const res1 = await uePost("/api/remove-widget", {
+      blueprint: wbpName,
+      widget: "MainVBox",
+    });
+    expect(res1.error).toBeUndefined();
+
+    // Now RootCanvas should be removable
+    const res2 = await uePost("/api/remove-widget", {
+      blueprint: wbpName,
+      widget: "RootCanvas",
+    });
+    expect(res2.error).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new **Level** tool group for inspecting and modifying actors placed in the currently open Unreal Editor level. Previously the MCP only operated on Blueprint/Material assets — this adds full CRUD awareness of the world outliner.

### New MCP tools (8)

| Tool | Type | Description |
|------|------|-------------|
| `get_selected_actors` | GET | Returns actors currently selected in the editor viewport with label, class, folder, location, rotation, scale |
| `get_current_level` | GET | Returns level name, package path, and actor count |
| `list_actors` | GET | Lists placed actors with optional `classFilter`, `nameFilter`, `folder` filters |
| `get_actor_properties` | GET | Returns all editable (CPF_Edit) properties; pass `component` to inspect a specific component |
| `set_actor_transform` | POST | Move/rotate/scale an actor; all fields optional (partial updates) |
| `set_actor_property` | POST | Set actor or component property via reflection; supports `ComponentName.PropertyName` dot notation |
| `spawn_actor` | POST | Spawn a C++ or Blueprint class actor at a given location |
| `delete_actor` | POST | Delete an actor by label (undoable via Ctrl+Z) |

### Key implementation details

**Property inspection:**
- Complex structs with >4 editable sub-fields are expanded into individual entries (fixes silent omission of e.g. `FPostProcessSettings` sub-fields)
- Every property includes an `isDefault` flag from CDO comparison via `FProperty::Identical()`
- `get_actor_properties` accepts an optional `component` parameter to inspect a specific component's properties; without it, returns actor-level properties and a component list for discovery

**Component sub-property editing:**
- `set_actor_property` supports `ComponentName.PropertyName` dot notation to target component properties
- Calls `MarkRenderStateDirty()` + `ReregisterComponent()` after mesh/material property changes so updates are visible immediately without clicking in the viewport
- `GEditor->RedrawAllViewports(true)` called after all mutations

**Selection:**
- `get_selected_actors` uses `USelection::GetSelectedObjects<AActor>()` for reliable results

## Test plan

- [x] `get_current_level` returns level name and actor count
- [x] `list_actors` returns all actors; filters by class/name/folder work
- [x] `get_actor_properties` returns all properties with `isDefault` flags; struct sub-fields (e.g. PostProcessVolume's FPostProcessSettings) are expanded correctly
- [x] `get_actor_properties(component=...)` returns component-level properties
- [x] `set_actor_transform` moves/rotates/scales an actor; visible immediately
- [x] `set_actor_property` sets actor and component properties via reflection (`ComponentName.StaticMesh` correctly targets the mesh component)
- [x] `spawn_actor` spawns StaticMeshActor at a location; visible immediately
- [x] `delete_actor` removes the actor; undoable in editor
- [x] `get_selected_actors` returns currently selected actors with location/rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)