### PR TITLE
fix: defer asset scan until Asset Registry finishes gathering

### DIFF
--- a/Source/BlueprintMCP/Private/BlueprintMCPEditorSubsystem.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPEditorSubsystem.cpp
@@ -1,5 +1,7 @@
 #include "BlueprintMCPEditorSubsystem.h"
 #include "BlueprintMCPServer.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "AssetRegistry/IAssetRegistry.h"
 
 void UBlueprintMCPEditorSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 {
@@ -15,6 +17,18 @@ void UBlueprintMCPEditorSubsystem::Initialize(FSubsystemCollectionBase& Collecti
 	if (Server->Start(9847, /*bEditorMode=*/true))
 	{
 		UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Editor subsystem started — MCP server on port %d"), Server->GetPort());
+
+		// Asset Registry loads asynchronously during editor startup.
+		// The initial scan in Start() only sees engine assets.
+		// Defer a full rescan until the registry finishes gathering.
+		FAssetRegistryModule& ARM = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+		IAssetRegistry& AR = ARM.Get();
+
+		if (AR.IsGathering())
+		{
+			OnFilesLoadedHandle = AR.OnFilesLoaded().AddUObject(
+				this, &UBlueprintMCPEditorSubsystem::HandleAssetRegistryReady);
+		}
 	}
 	else
 	{
@@ -23,8 +37,31 @@ void UBlueprintMCPEditorSubsystem::Initialize(FSubsystemCollectionBase& Collecti
 	}
 }
 
+void UBlueprintMCPEditorSubsystem::HandleAssetRegistryReady()
+{
+	if (OnFilesLoadedHandle.IsValid())
+	{
+		FAssetRegistryModule& ARM = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+		ARM.Get().OnFilesLoaded().Remove(OnFilesLoadedHandle);
+		OnFilesLoadedHandle.Reset();
+	}
+
+	if (Server && Server->IsRunning())
+	{
+		Server->HandleRescan();
+		UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Deferred rescan complete after Asset Registry finished gathering."));
+	}
+}
+
 void UBlueprintMCPEditorSubsystem::Deinitialize()
 {
+	if (OnFilesLoadedHandle.IsValid() && FModuleManager::Get().IsModuleLoaded("AssetRegistry"))
+	{
+		FAssetRegistryModule& ARM = FModuleManager::GetModuleChecked<FAssetRegistryModule>("AssetRegistry");
+		ARM.Get().OnFilesLoaded().Remove(OnFilesLoadedHandle);
+		OnFilesLoadedHandle.Reset();
+	}
+
 	if (Server)
 	{
 		Server->Stop();

--- a/Source/BlueprintMCP/Public/BlueprintMCPEditorSubsystem.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPEditorSubsystem.h
@@ -30,5 +30,8 @@ public:
 	virtual TStatId GetStatId() const override;
 
 private:
+	void HandleAssetRegistryReady();
+
 	TUniquePtr<FBlueprintMCPServer> Server;
+	FDelegateHandle OnFilesLoadedHandle;
 };

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -78,6 +78,9 @@ public:
 	/** Whether the HTTP server is currently listening. */
 	bool IsRunning() const { return bRunning; }
 
+	/** Re-scan the Asset Registry and refresh cached asset lists. */
+	FString HandleRescan();
+
 	/** Port the server is listening on. */
 	int32 GetPort() const { return Port; }
 
@@ -117,9 +120,6 @@ private:
 	int32 Port = 9847;
 	bool bRunning = false;
 	bool bIsEditor = false;
-
-	// ----- Asset registry rescan -----
-	FString HandleRescan();
 
 	// ----- Request handlers (read-only) -----
 	FString HandleList(const TMap<FString, FString>& Params);


### PR DESCRIPTION
The editor subsystem scans the Asset Registry in Start(), but during editor startup the registry is still loading asynchronously. This causes the initial blueprint/material index to contain only engine assets.

Hook IAssetRegistry::OnFilesLoaded() to automatically rescan once gathering completes. The HTTP server starts immediately so MCP clients can connect without delay.

Also moves HandleRescan() to public so the subsystem can call it.