### PR TITLE
Add exec_command tool for editor console commands

### DIFF
--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -39,6 +39,7 @@
 #include "Misc/Paths.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Guid.h"
+#include "Misc/OutputDeviceHelper.h"
 #include "AssetToolsModule.h"
 #include "IAssetTools.h"
 #include "UObject/UObjectIterator.h"
@@ -788,6 +789,10 @@ bool FBlueprintMCPServer::Start(int32 InPort, bool bEditorMode)
 	Router->BindRoute(FHttpPath(TEXT("/api/set-state-blend-space")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("setStateBlendSpace")));
 
+	// Console command execution
+	Router->BindRoute(FHttpPath(TEXT("/api/exec")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("exec")));
+
 	// Register TMap dispatch handlers
 	RegisterHandlers();
 
@@ -1047,6 +1052,9 @@ void FBlueprintMCPServer::RegisterHandlers()
 	HandlerMap.Add(TEXT("createBlendSpace"),        [this](const TMap<FString, FString>&, const FString& B) { return HandleCreateBlendSpace(B); });
 	HandlerMap.Add(TEXT("setBlendSpaceSamples"),    [this](const TMap<FString, FString>&, const FString& B) { return HandleSetBlendSpaceSamples(B); });
 	HandlerMap.Add(TEXT("setStateBlendSpace"),      [this](const TMap<FString, FString>&, const FString& B) { return HandleSetStateBlendSpace(B); });
+
+	// Console command execution
+	HandlerMap.Add(TEXT("exec"),                    [this](const TMap<FString, FString>&, const FString& B) { return HandleExecCommand(B); });
 }
 
 // ============================================================
@@ -2093,4 +2101,62 @@ TSharedPtr<FJsonObject> FBlueprintMCPServer::SerializeMaterialExpression(UMateri
 	}
 
 	return EJ;
+}
+
+// ============================================================
+// HandleExecCommand — execute an editor console command
+// ============================================================
+
+/**
+ * Custom output device that captures console command output into a string.
+ */
+class FStringOutputDeviceCapture : public FOutputDevice
+{
+public:
+	FString CapturedOutput;
+
+	virtual void Serialize(const TCHAR* V, ELogVerbosity::Type Verbosity, const FName& Category) override
+	{
+		if (!CapturedOutput.IsEmpty())
+		{
+			CapturedOutput += TEXT("\n");
+		}
+		CapturedOutput += V;
+	}
+};
+
+FString FBlueprintMCPServer::HandleExecCommand(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	FString Command;
+	if (!Json->TryGetStringField(TEXT("command"), Command) || Command.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'command'."));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: exec_command(\"%s\")"), *Command);
+
+	// Editor-only: refuse if running in commandlet mode (no GEditor/GWorld for most commands)
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("exec_command is only available in editor mode. Open the UE5 editor to use this tool."));
+	}
+
+	// Capture output from the command
+	FStringOutputDeviceCapture OutputCapture;
+
+	UWorld* World = GEditor ? GEditor->GetEditorWorldContext().World() : nullptr;
+	bool bSuccess = GEngine->Exec(World, *Command, OutputCapture);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), bSuccess);
+	Result->SetStringField(TEXT("command"), Command);
+	Result->SetStringField(TEXT("output"), OutputCapture.CapturedOutput);
+
+	return JsonToString(Result);
 }

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -257,6 +257,9 @@ private:
 	FString HandleDiffMaterialGraph(const FString& Body);
 	FString HandleRestoreMaterialGraph(const FString& Body);
 
+	// ----- Console command execution -----
+	FString HandleExecCommand(const FString& Body);
+
 	// ----- Animation Blueprint handlers -----
 	FString HandleCreateAnimBlueprint(const FString& Body);
 	FString HandleAddAnimState(const FString& Body);

--- a/Tools/src/tools/utility.ts
+++ b/Tools/src/tools/utility.ts
@@ -1,4 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 import { ensureUE, ueGet, uePost, isUEHealthy, gracefulShutdown, state } from "../ue-bridge.js";
 
 export function registerUtilityTools(server: McpServer): void {
@@ -41,6 +42,32 @@ export function registerUtilityTools(server: McpServer): void {
         `Material Instances: ${data.materialInstanceCount}${data.delta?.materialInstances ? ` (${data.delta.materialInstances >= 0 ? "+" : ""}${data.delta.materialInstances})` : ""}`,
         `Material Functions: ${data.materialFunctionCount}${data.delta?.materialFunctions ? ` (${data.delta.materialFunctions >= 0 ? "+" : ""}${data.delta.materialFunctions})` : ""}`,
       ];
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "exec_command",
+    "Execute an editor console command and return its output. Requires editor mode (not commandlet). Useful for: saving assets (\"Asset.SaveAll\"), running automation tests (\"Automation RunTests <filter>\"), triggering Live Coding, etc.",
+    {
+      command: z.string().describe("The console command to execute (e.g. \"Asset.SaveAll\", \"Automation RunTests MyTests\")"),
+    },
+    async ({ command }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/exec", { command });
+      if (data.error) {
+        return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+      }
+
+      const lines = [
+        `Command: ${data.command}`,
+        `Success: ${data.success}`,
+      ];
+      if (data.output) {
+        lines.push(`Output:\n${data.output}`);
+      }
       return { content: [{ type: "text" as const, text: lines.join("\n") }] };
     }
   );


### PR DESCRIPTION
## Summary
- Adds `exec_command` MCP tool that executes editor console commands via `GEngine->Exec()` and returns captured output
- Editor-only (returns error in commandlet mode)
- Enables saving assets (`Asset.SaveAll`), running automation tests (`Automation RunTests ...`), triggering Live Coding, etc.

## Changes
- **C++**: New `HandleExecCommand()` handler with `FStringOutputDeviceCapture` output device, route at `POST /api/exec`
- **TypeScript**: New `exec_command` tool in `utility.ts`

## Test plan
- [ ] Open UE5 editor, verify `exec_command("Asset.SaveAll")` returns `success: true`
- [ ] Verify `exec_command("Automation RunTests ...")` triggers tests and returns output
- [ ] Verify error returned when used in commandlet mode

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)