### PR TITLE
Add actor state tools: mobility, visibility, physics

### DIFF
--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_ActorState.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_ActorState.cpp
@@ -1,0 +1,296 @@
+#include "BlueprintMCPServer.h"
+#include "Editor.h"
+#include "Engine/World.h"
+#include "EngineUtils.h"
+#include "GameFramework/Actor.h"
+#include "Components/PrimitiveComponent.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+
+// ============================================================
+// Helper — find an actor by label in the editor world
+// (Shared with BlueprintMCPHandlers_LevelActors.cpp — uses same logic)
+// ============================================================
+
+static AActor* FindActorByLabelState(const FString& Label, FString& OutError)
+{
+	if (!GEditor)
+	{
+		OutError = TEXT("Editor not available (running in commandlet mode?).");
+		return nullptr;
+	}
+
+	UWorld* World = GEditor->GetEditorWorldContext().World();
+	if (!World)
+	{
+		OutError = TEXT("No editor world available.");
+		return nullptr;
+	}
+
+	for (TActorIterator<AActor> It(World); It; ++It)
+	{
+		AActor* Actor = *It;
+		if (Actor && Actor->GetActorLabel() == Label)
+		{
+			return Actor;
+		}
+	}
+
+	// Case-insensitive fallback
+	for (TActorIterator<AActor> It(World); It; ++It)
+	{
+		AActor* Actor = *It;
+		if (Actor && Actor->GetActorLabel().Equals(Label, ESearchCase::IgnoreCase))
+		{
+			return Actor;
+		}
+	}
+
+	OutError = FString::Printf(TEXT("Actor with label '%s' not found in the current level. Use list_actors to see available actors."), *Label);
+	return nullptr;
+}
+
+// ============================================================
+// HandleSetActorMobility — set an actor's mobility
+// ============================================================
+
+FString FBlueprintMCPServer::HandleSetActorMobility(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	FString ActorLabel;
+	if (!Json->TryGetStringField(TEXT("actorLabel"), ActorLabel) || ActorLabel.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'actorLabel'."));
+	}
+
+	FString MobilityStr;
+	if (!Json->TryGetStringField(TEXT("mobility"), MobilityStr) || MobilityStr.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'mobility' (Static, Stationary, or Movable)."));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: set_actor_mobility('%s', '%s')"), *ActorLabel, *MobilityStr);
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("set_actor_mobility requires editor mode."));
+	}
+
+	FString Error;
+	AActor* Actor = FindActorByLabelState(ActorLabel, Error);
+	if (!Actor) return MakeErrorJson(Error);
+
+	// Parse mobility
+	EComponentMobility::Type NewMobility;
+	if (MobilityStr.Equals(TEXT("Static"), ESearchCase::IgnoreCase))
+	{
+		NewMobility = EComponentMobility::Static;
+	}
+	else if (MobilityStr.Equals(TEXT("Stationary"), ESearchCase::IgnoreCase))
+	{
+		NewMobility = EComponentMobility::Stationary;
+	}
+	else if (MobilityStr.Equals(TEXT("Movable"), ESearchCase::IgnoreCase))
+	{
+		NewMobility = EComponentMobility::Movable;
+	}
+	else
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Invalid mobility value '%s'. Must be Static, Stationary, or Movable."), *MobilityStr));
+	}
+
+	USceneComponent* RootComp = Actor->GetRootComponent();
+	if (!RootComp)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Actor '%s' has no root component to set mobility on."), *ActorLabel));
+	}
+
+	EComponentMobility::Type OldMobility = RootComp->Mobility;
+	RootComp->SetMobility(NewMobility);
+	Actor->MarkPackageDirty();
+
+	if (GEditor)
+	{
+		GEditor->RedrawAllViewports(true);
+	}
+
+	auto MobilityToString = [](EComponentMobility::Type M) -> FString {
+		switch (M)
+		{
+		case EComponentMobility::Static:     return TEXT("Static");
+		case EComponentMobility::Stationary: return TEXT("Stationary");
+		case EComponentMobility::Movable:    return TEXT("Movable");
+		default:                             return TEXT("Unknown");
+		}
+	};
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("actorLabel"), ActorLabel);
+	Result->SetStringField(TEXT("previousMobility"), MobilityToString(OldMobility));
+	Result->SetStringField(TEXT("newMobility"), MobilityToString(NewMobility));
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleSetActorVisibility — show/hide an actor
+// ============================================================
+
+FString FBlueprintMCPServer::HandleSetActorVisibility(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	FString ActorLabel;
+	if (!Json->TryGetStringField(TEXT("actorLabel"), ActorLabel) || ActorLabel.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'actorLabel'."));
+	}
+
+	bool bVisible = true;
+	if (!Json->TryGetBoolField(TEXT("visible"), bVisible))
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'visible' (true or false)."));
+	}
+
+	bool bPropagateToChildren = true;
+	Json->TryGetBoolField(TEXT("propagateToChildren"), bPropagateToChildren);
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: set_actor_visibility('%s', visible=%s)"),
+		*ActorLabel, bVisible ? TEXT("true") : TEXT("false"));
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("set_actor_visibility requires editor mode."));
+	}
+
+	FString Error;
+	AActor* Actor = FindActorByLabelState(ActorLabel, Error);
+	if (!Actor) return MakeErrorJson(Error);
+
+	bool bWasHidden = Actor->IsHidden();
+	Actor->SetIsTemporarilyHiddenInEditor(!bVisible);
+	Actor->SetActorHiddenInGame(!bVisible);
+	Actor->MarkPackageDirty();
+
+	if (bPropagateToChildren)
+	{
+		TArray<AActor*> AttachedActors;
+		Actor->GetAttachedActors(AttachedActors);
+		for (AActor* Child : AttachedActors)
+		{
+			if (Child)
+			{
+				Child->SetIsTemporarilyHiddenInEditor(!bVisible);
+				Child->SetActorHiddenInGame(!bVisible);
+				Child->MarkPackageDirty();
+			}
+		}
+	}
+
+	if (GEditor)
+	{
+		GEditor->RedrawAllViewports(true);
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("actorLabel"), ActorLabel);
+	Result->SetBoolField(TEXT("visible"), bVisible);
+	Result->SetBoolField(TEXT("wasHidden"), bWasHidden);
+	Result->SetBoolField(TEXT("propagatedToChildren"), bPropagateToChildren);
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleSetActorPhysics — enable/disable physics simulation
+// ============================================================
+
+FString FBlueprintMCPServer::HandleSetActorPhysics(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	FString ActorLabel;
+	if (!Json->TryGetStringField(TEXT("actorLabel"), ActorLabel) || ActorLabel.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'actorLabel'."));
+	}
+
+	bool bSimulatePhysics = true;
+	if (!Json->TryGetBoolField(TEXT("simulatePhysics"), bSimulatePhysics))
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'simulatePhysics' (true or false)."));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: set_actor_physics('%s', simulate=%s)"),
+		*ActorLabel, bSimulatePhysics ? TEXT("true") : TEXT("false"));
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("set_actor_physics requires editor mode."));
+	}
+
+	FString Error;
+	AActor* Actor = FindActorByLabelState(ActorLabel, Error);
+	if (!Actor) return MakeErrorJson(Error);
+
+	UPrimitiveComponent* PrimComp = Cast<UPrimitiveComponent>(Actor->GetRootComponent());
+	if (!PrimComp)
+	{
+		// Try to find any primitive component on the actor
+		PrimComp = Actor->FindComponentByClass<UPrimitiveComponent>();
+	}
+
+	if (!PrimComp)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Actor '%s' has no primitive component that can simulate physics."), *ActorLabel));
+	}
+
+	bool bWasSimulating = PrimComp->IsSimulatingPhysics();
+
+	// If enabling physics, ensure mobility is Movable
+	if (bSimulatePhysics && PrimComp->Mobility != EComponentMobility::Movable)
+	{
+		PrimComp->SetMobility(EComponentMobility::Movable);
+	}
+
+	PrimComp->SetSimulatePhysics(bSimulatePhysics);
+
+	bool bEnableGravity = true;
+	if (Json->TryGetBoolField(TEXT("enableGravity"), bEnableGravity))
+	{
+		PrimComp->SetEnableGravity(bEnableGravity);
+	}
+
+	Actor->MarkPackageDirty();
+
+	if (GEditor)
+	{
+		GEditor->RedrawAllViewports(true);
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("actorLabel"), ActorLabel);
+	Result->SetBoolField(TEXT("simulatePhysics"), bSimulatePhysics);
+	Result->SetBoolField(TEXT("wasSimulating"), bWasSimulating);
+	Result->SetStringField(TEXT("component"), PrimComp->GetName());
+
+	return JsonToString(Result);
+}

--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -793,13 +793,15 @@ bool FBlueprintMCPServer::Start(int32 InPort, bool bEditorMode)
 	Router->BindRoute(FHttpPath(TEXT("/api/exec")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("exec")));
 
-	// Actor state tools
-	Router->BindRoute(FHttpPath(TEXT("/api/set-actor-mobility")), EHttpServerRequestVerbs::VERB_POST,
-		QueuedHandler(TEXT("setActorMobility")));
-	Router->BindRoute(FHttpPath(TEXT("/api/set-actor-visibility")), EHttpServerRequestVerbs::VERB_POST,
-		QueuedHandler(TEXT("setActorVisibility")));
-	Router->BindRoute(FHttpPath(TEXT("/api/set-actor-physics")), EHttpServerRequestVerbs::VERB_POST,
-		QueuedHandler(TEXT("setActorPhysics")));
+	// Level actor tools
+	Router->BindRoute(FHttpPath(TEXT("/api/attach-actor")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("attachActor")));
+	Router->BindRoute(FHttpPath(TEXT("/api/detach-actor")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("detachActor")));
+	Router->BindRoute(FHttpPath(TEXT("/api/duplicate-actor")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("duplicateActor")));
+	Router->BindRoute(FHttpPath(TEXT("/api/rename-actor")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("renameActor")));
 
 	// Register TMap dispatch handlers
 	RegisterHandlers();
@@ -952,9 +954,10 @@ void FBlueprintMCPServer::RegisterHandlers()
 		TEXT("addAnimNode"),
 		TEXT("addStateMachine"),
 		TEXT("setStateAnimation"),
-		TEXT("setActorMobility"),
-		TEXT("setActorVisibility"),
-		TEXT("setActorPhysics"),
+		TEXT("attachActor"),
+		TEXT("detachActor"),
+		TEXT("duplicateActor"),
+		TEXT("renameActor"),
 	};
 
 	// GET handlers (use QueryParams, ignore Body)
@@ -1067,10 +1070,11 @@ void FBlueprintMCPServer::RegisterHandlers()
 	// Console command execution
 	HandlerMap.Add(TEXT("exec"),                    [this](const TMap<FString, FString>&, const FString& B) { return HandleExecCommand(B); });
 
-	// Actor state handlers
-	HandlerMap.Add(TEXT("setActorMobility"), [this](const TMap<FString, FString>&, const FString& B) { return HandleSetActorMobility(B); });
-	HandlerMap.Add(TEXT("setActorVisibility"), [this](const TMap<FString, FString>&, const FString& B) { return HandleSetActorVisibility(B); });
-	HandlerMap.Add(TEXT("setActorPhysics"), [this](const TMap<FString, FString>&, const FString& B) { return HandleSetActorPhysics(B); });
+	// Level actor handlers
+	HandlerMap.Add(TEXT("attachActor"), [this](const TMap<FString, FString>&, const FString& B) { return HandleAttachActor(B); });
+	HandlerMap.Add(TEXT("detachActor"), [this](const TMap<FString, FString>&, const FString& B) { return HandleDetachActor(B); });
+	HandlerMap.Add(TEXT("duplicateActor"), [this](const TMap<FString, FString>&, const FString& B) { return HandleDuplicateActor(B); });
+	HandlerMap.Add(TEXT("renameActor"), [this](const TMap<FString, FString>&, const FString& B) { return HandleRenameActor(B); });
 }
 
 // ============================================================

--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -793,6 +793,14 @@ bool FBlueprintMCPServer::Start(int32 InPort, bool bEditorMode)
 	Router->BindRoute(FHttpPath(TEXT("/api/exec")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("exec")));
 
+	// Actor state tools
+	Router->BindRoute(FHttpPath(TEXT("/api/set-actor-mobility")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("setActorMobility")));
+	Router->BindRoute(FHttpPath(TEXT("/api/set-actor-visibility")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("setActorVisibility")));
+	Router->BindRoute(FHttpPath(TEXT("/api/set-actor-physics")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("setActorPhysics")));
+
 	// Register TMap dispatch handlers
 	RegisterHandlers();
 
@@ -944,6 +952,9 @@ void FBlueprintMCPServer::RegisterHandlers()
 		TEXT("addAnimNode"),
 		TEXT("addStateMachine"),
 		TEXT("setStateAnimation"),
+		TEXT("setActorMobility"),
+		TEXT("setActorVisibility"),
+		TEXT("setActorPhysics"),
 	};
 
 	// GET handlers (use QueryParams, ignore Body)
@@ -1055,6 +1066,11 @@ void FBlueprintMCPServer::RegisterHandlers()
 
 	// Console command execution
 	HandlerMap.Add(TEXT("exec"),                    [this](const TMap<FString, FString>&, const FString& B) { return HandleExecCommand(B); });
+
+	// Actor state handlers
+	HandlerMap.Add(TEXT("setActorMobility"), [this](const TMap<FString, FString>&, const FString& B) { return HandleSetActorMobility(B); });
+	HandlerMap.Add(TEXT("setActorVisibility"), [this](const TMap<FString, FString>&, const FString& B) { return HandleSetActorVisibility(B); });
+	HandlerMap.Add(TEXT("setActorPhysics"), [this](const TMap<FString, FString>&, const FString& B) { return HandleSetActorPhysics(B); });
 }
 
 // ============================================================

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -260,6 +260,12 @@ private:
 	// ----- Console command execution -----
 	FString HandleExecCommand(const FString& Body);
 
+
+	// ----- Actor state tools -----
+	FString HandleSetActorMobility(const FString& Body);
+	FString HandleSetActorVisibility(const FString& Body);
+	FString HandleSetActorPhysics(const FString& Body);
+
 	// ----- Animation Blueprint handlers -----
 	FString HandleCreateAnimBlueprint(const FString& Body);
 	FString HandleAddAnimState(const FString& Body);

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -261,10 +261,11 @@ private:
 	FString HandleExecCommand(const FString& Body);
 
 
-	// ----- Actor state tools -----
-	FString HandleSetActorMobility(const FString& Body);
-	FString HandleSetActorVisibility(const FString& Body);
-	FString HandleSetActorPhysics(const FString& Body);
+	// ----- Level actor tools -----
+	FString HandleAttachActor(const FString& Body);
+	FString HandleDetachActor(const FString& Body);
+	FString HandleDuplicateActor(const FString& Body);
+	FString HandleRenameActor(const FString& Body);
 
 	// ----- Animation Blueprint handlers -----
 	FString HandleCreateAnimBlueprint(const FString& Body);

--- a/Tools/src/index.ts
+++ b/Tools/src/index.ts
@@ -20,7 +20,7 @@ import { registerUserTypeTools } from "./tools/user-types.js";
 import { registerMaterialReadTools } from "./tools/material-read.js";
 import { registerMaterialMutationTools } from "./tools/material-mutation.js";
 import { registerAnimationTools } from "./tools/animation-mutation.js";
-import { registerActorStateTools } from "./tools/actor-state.js";
+import { registerLevelActorTools } from "./tools/level-actors.js";
 
 // Resource registrations
 import { registerBlueprintListResource } from "./resources/blueprint-list.js";
@@ -49,7 +49,7 @@ registerUserTypeTools(server);
 registerMaterialReadTools(server);
 registerMaterialMutationTools(server);
 registerAnimationTools(server);
-registerActorStateTools(server);
+registerLevelActorTools(server);
 
 // Register resources
 registerBlueprintListResource(server);

--- a/Tools/src/index.ts
+++ b/Tools/src/index.ts
@@ -20,6 +20,7 @@ import { registerUserTypeTools } from "./tools/user-types.js";
 import { registerMaterialReadTools } from "./tools/material-read.js";
 import { registerMaterialMutationTools } from "./tools/material-mutation.js";
 import { registerAnimationTools } from "./tools/animation-mutation.js";
+import { registerActorStateTools } from "./tools/actor-state.js";
 
 // Resource registrations
 import { registerBlueprintListResource } from "./resources/blueprint-list.js";
@@ -48,6 +49,7 @@ registerUserTypeTools(server);
 registerMaterialReadTools(server);
 registerMaterialMutationTools(server);
 registerAnimationTools(server);
+registerActorStateTools(server);
 
 // Register resources
 registerBlueprintListResource(server);

--- a/Tools/src/tools/actor-state.ts
+++ b/Tools/src/tools/actor-state.ts
@@ -1,0 +1,97 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ensureUE, uePost } from "../ue-bridge.js";
+
+export function registerActorStateTools(server: McpServer): void {
+  server.tool(
+    "set_actor_mobility",
+    "Set an actor's mobility type (Static, Stationary, or Movable). This affects whether the actor can move at runtime and what lighting features are available. Requires editor mode.",
+    {
+      actorLabel: z.string().describe("Label of the actor in the World Outliner"),
+      mobility: z.enum(["Static", "Stationary", "Movable"])
+        .describe("Mobility type: Static (best perf, no movement), Stationary (some movement), Movable (full movement)"),
+    },
+    async ({ actorLabel, mobility }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/set-actor-mobility", { actorLabel, mobility });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        `Set mobility of '${data.actorLabel}'`,
+        `Previous: ${data.previousMobility}`,
+        `New: ${data.newMobility}`,
+        `\nNext steps:`,
+        `  1. Use list_actors to verify the change`,
+        `  2. Static actors cannot move at runtime — use Movable if the actor needs to move`,
+      ];
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "set_actor_visibility",
+    "Show or hide an actor in the level. Sets both editor visibility and in-game visibility. Optionally propagates to attached child actors. Requires editor mode.",
+    {
+      actorLabel: z.string().describe("Label of the actor in the World Outliner"),
+      visible: z.boolean().describe("true to show the actor, false to hide it"),
+      propagateToChildren: z.boolean().optional()
+        .describe("Whether to also show/hide attached child actors (default: true)"),
+    },
+    async ({ actorLabel, visible, propagateToChildren }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { actorLabel, visible };
+      if (propagateToChildren !== undefined) body.propagateToChildren = propagateToChildren;
+
+      const data = await uePost("/api/set-actor-visibility", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        `${data.visible ? "Shown" : "Hidden"} actor '${data.actorLabel}'`,
+        `Was hidden: ${data.wasHidden}`,
+        `Propagated to children: ${data.propagatedToChildren}`,
+        `\nNext steps:`,
+        `  1. Use list_actors to see all actors and their visibility state`,
+        `  2. Use set_actor_visibility again to toggle back`,
+      ];
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "set_actor_physics",
+    "Enable or disable physics simulation on an actor's primitive component. Automatically sets mobility to Movable when enabling physics. Requires editor mode.",
+    {
+      actorLabel: z.string().describe("Label of the actor in the World Outliner"),
+      simulatePhysics: z.boolean().describe("true to enable physics simulation, false to disable"),
+      enableGravity: z.boolean().optional()
+        .describe("Whether gravity affects this actor (default: true)"),
+    },
+    async ({ actorLabel, simulatePhysics, enableGravity }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { actorLabel, simulatePhysics };
+      if (enableGravity !== undefined) body.enableGravity = enableGravity;
+
+      const data = await uePost("/api/set-actor-physics", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        `${data.simulatePhysics ? "Enabled" : "Disabled"} physics on '${data.actorLabel}'`,
+        `Was simulating: ${data.wasSimulating}`,
+        `Component: ${data.component}`,
+        `\nNext steps:`,
+        `  1. Use set_actor_mobility to change mobility if needed`,
+        `  2. Physics requires a collision-enabled primitive component (StaticMesh, etc.)`,
+      ];
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+}

--- a/Tools/test/tools/actor-state.test.ts
+++ b/Tools/test/tools/actor-state.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { uePost } from "../helpers.js";
+
+describe("actor state tools", () => {
+  describe("set_actor_mobility", () => {
+    it("returns error for missing actorLabel field", async () => {
+      const data = await uePost("/api/set-actor-mobility", { mobility: "Static" });
+      expect(data.error).toBeDefined();
+      expect(data.error).toContain("actorLabel");
+    });
+
+    it("returns error for missing mobility field", async () => {
+      const data = await uePost("/api/set-actor-mobility", { actorLabel: "SomeActor" });
+      expect(data.error).toBeDefined();
+      expect(data.error).toContain("mobility");
+    });
+
+    it("returns error for invalid mobility value", async () => {
+      const data = await uePost("/api/set-actor-mobility", {
+        actorLabel: "SomeActor",
+        mobility: "InvalidValue",
+      });
+      expect(data.error).toBeDefined();
+    });
+
+    it("returns error for non-existent actor", async () => {
+      const data = await uePost("/api/set-actor-mobility", {
+        actorLabel: "NonExistent_Actor_XYZ_999",
+        mobility: "Movable",
+      });
+      expect(data.error).toBeDefined();
+    });
+
+    it("rejects empty JSON body", async () => {
+      const data = await uePost("/api/set-actor-mobility", {});
+      expect(data.error).toBeDefined();
+    });
+  });
+
+  describe("set_actor_visibility", () => {
+    it("returns error for missing actorLabel field", async () => {
+      const data = await uePost("/api/set-actor-visibility", { visible: true });
+      expect(data.error).toBeDefined();
+      expect(data.error).toContain("actorLabel");
+    });
+
+    it("returns error for missing visible field", async () => {
+      const data = await uePost("/api/set-actor-visibility", { actorLabel: "SomeActor" });
+      expect(data.error).toBeDefined();
+      expect(data.error).toContain("visible");
+    });
+
+    it("returns error for non-existent actor", async () => {
+      const data = await uePost("/api/set-actor-visibility", {
+        actorLabel: "NonExistent_Actor_XYZ_999",
+        visible: false,
+      });
+      expect(data.error).toBeDefined();
+    });
+
+    it("rejects empty JSON body", async () => {
+      const data = await uePost("/api/set-actor-visibility", {});
+      expect(data.error).toBeDefined();
+    });
+  });
+
+  describe("set_actor_physics", () => {
+    it("returns error for missing actorLabel field", async () => {
+      const data = await uePost("/api/set-actor-physics", { simulatePhysics: true });
+      expect(data.error).toBeDefined();
+      expect(data.error).toContain("actorLabel");
+    });
+
+    it("returns error for missing simulatePhysics field", async () => {
+      const data = await uePost("/api/set-actor-physics", { actorLabel: "SomeActor" });
+      expect(data.error).toBeDefined();
+      expect(data.error).toContain("simulatePhysics");
+    });
+
+    it("returns error for non-existent actor", async () => {
+      const data = await uePost("/api/set-actor-physics", {
+        actorLabel: "NonExistent_Actor_XYZ_999",
+        simulatePhysics: true,
+      });
+      expect(data.error).toBeDefined();
+    });
+
+    it("rejects empty JSON body", async () => {
+      const data = await uePost("/api/set-actor-physics", {});
+      expect(data.error).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds three new MCP tools for modifying actor state properties in the current level.

| Tool | Description |
|------|-------------|
| `set_actor_mobility` | Set an actor's mobility type (Static, Stationary, or Movable) |
| `set_actor_visibility` | Show/hide an actor in editor and game, with optional child propagation |
| `set_actor_physics` | Enable/disable physics simulation on an actor's primitive component |

## New files

| File | Purpose |
|------|--------|
| `Source/BlueprintMCP/Private/BlueprintMCPHandlers_ActorState.cpp` | C++ handler implementations |
| `Tools/src/tools/actor-state.ts` | TypeScript MCP tool definitions |
| `Tools/test/tools/actor-state.test.ts` | Integration tests |

## Integration changes needed

The following changes to existing files are required to wire up the new handlers:

### `BlueprintMCPServer.h` — add handler declarations:
```cpp
// ----- Actor state tools -----
FString HandleSetActorMobility(const FString& Body);
FString HandleSetActorVisibility(const FString& Body);
FString HandleSetActorPhysics(const FString& Body);
```

### `BlueprintMCPServer.cpp` — add to `RegisterHandlers()`:

Add to `MutationEndpoints`:
```cpp
TEXT("setActorMobility"),
TEXT("setActorVisibility"),
TEXT("setActorPhysics"),
```

Add route bindings (before `RegisterHandlers()` call):
```cpp
// Actor state tools
Router->BindRoute(FHttpPath(TEXT("/api/set-actor-mobility")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("setActorMobility")));
Router->BindRoute(FHttpPath(TEXT("/api/set-actor-visibility")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("setActorVisibility")));
Router->BindRoute(FHttpPath(TEXT("/api/set-actor-physics")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("setActorPhysics")));
```

Add handler map entries:
```cpp
HandlerMap.Add(TEXT("setActorMobility"),   [this](const TMap<FString, FString>&, const FString& B) { return HandleSetActorMobility(B); });
HandlerMap.Add(TEXT("setActorVisibility"), [this](const TMap<FString, FString>&, const FString& B) { return HandleSetActorVisibility(B); });
HandlerMap.Add(TEXT("setActorPhysics"),    [this](const TMap<FString, FString>&, const FString& B) { return HandleSetActorPhysics(B); });
```

### `Tools/src/index.ts` — register the new tools:
```typescript
import { registerActorStateTools } from "./tools/actor-state.js";
// ... then in the registration block:
registerActorStateTools(server);
```

## Key implementation details

- **Mobility**: Changes the root component's mobility; validates against Static/Stationary/Movable enum
- **Visibility**: Sets both `SetIsTemporarilyHiddenInEditor` and `SetActorHiddenInGame`; optionally propagates to attached children
- **Physics**: Auto-promotes mobility to Movable when enabling physics; searches for PrimitiveComponent on root first, then any child; supports optional gravity toggle
- All handlers follow the existing `FindActorByLabel` pattern with case-insensitive fallback
- All mutations mark the package dirty and redraw viewports

## Test plan

- [ ] `set_actor_mobility` — set a StaticMeshActor to Movable, verify root component mobility changed
- [ ] `set_actor_mobility` — reject invalid mobility values
- [ ] `set_actor_visibility` — hide an actor, verify it disappears from viewport
- [ ] `set_actor_visibility` — propagate to children, verify child actors also hidden
- [ ] `set_actor_physics` — enable physics on a StaticMeshActor, verify mobility auto-set to Movable
- [ ] `set_actor_physics` — disable gravity while enabling physics
- [ ] All tools return proper errors for non-existent actors and missing fields
- [ ] `npm run build` succeeds
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)