### PR TITLE
Add spatial tools: raycast (line trace)

### DIFF
--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_Spatial.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_Spatial.cpp
@@ -1,0 +1,215 @@
+#include "BlueprintMCPServer.h"
+#include "Editor.h"
+#include "Engine/World.h"
+#include "EngineUtils.h"
+#include "GameFramework/Actor.h"
+#include "CollisionQueryParams.h"
+#include "Engine/EngineTypes.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+
+// ============================================================
+// HandleRaycast — perform a line trace from point A to point B
+// ============================================================
+
+FString FBlueprintMCPServer::HandleRaycast(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	// Parse start point
+	const TSharedPtr<FJsonObject>* StartObj = nullptr;
+	if (!Json->TryGetObjectField(TEXT("start"), StartObj))
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'start' (object with x, y, z)."));
+	}
+
+	double StartX = 0, StartY = 0, StartZ = 0;
+	(*StartObj)->TryGetNumberField(TEXT("x"), StartX);
+	(*StartObj)->TryGetNumberField(TEXT("y"), StartY);
+	(*StartObj)->TryGetNumberField(TEXT("z"), StartZ);
+
+	// Parse end point
+	const TSharedPtr<FJsonObject>* EndObj = nullptr;
+	if (!Json->TryGetObjectField(TEXT("end"), EndObj))
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'end' (object with x, y, z)."));
+	}
+
+	double EndX = 0, EndY = 0, EndZ = 0;
+	(*EndObj)->TryGetNumberField(TEXT("x"), EndX);
+	(*EndObj)->TryGetNumberField(TEXT("y"), EndY);
+	(*EndObj)->TryGetNumberField(TEXT("z"), EndZ);
+
+	FVector Start(StartX, StartY, StartZ);
+	FVector End(EndX, EndY, EndZ);
+
+	// Optional: trace channel
+	FString ChannelStr;
+	Json->TryGetStringField(TEXT("channel"), ChannelStr);
+
+	// Optional: trace complex geometry
+	bool bTraceComplex = false;
+	Json->TryGetBoolField(TEXT("traceComplex"), bTraceComplex);
+
+	// Optional: multi-hit
+	bool bMulti = false;
+	Json->TryGetBoolField(TEXT("multi"), bMulti);
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: raycast(start=(%.1f,%.1f,%.1f), end=(%.1f,%.1f,%.1f), multi=%s)"),
+		Start.X, Start.Y, Start.Z, End.X, End.Y, End.Z, bMulti ? TEXT("true") : TEXT("false"));
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("raycast requires editor mode."));
+	}
+
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("Editor not available."));
+	}
+
+	UWorld* World = GEditor->GetEditorWorldContext().World();
+	if (!World)
+	{
+		return MakeErrorJson(TEXT("No editor world available."));
+	}
+
+	// Determine trace channel
+	ECollisionChannel TraceChannel = ECC_Visibility;
+	if (ChannelStr.Equals(TEXT("Camera"), ESearchCase::IgnoreCase))
+	{
+		TraceChannel = ECC_Camera;
+	}
+	else if (ChannelStr.Equals(TEXT("WorldStatic"), ESearchCase::IgnoreCase))
+	{
+		TraceChannel = ECC_WorldStatic;
+	}
+	else if (ChannelStr.Equals(TEXT("WorldDynamic"), ESearchCase::IgnoreCase))
+	{
+		TraceChannel = ECC_WorldDynamic;
+	}
+	else if (ChannelStr.Equals(TEXT("Pawn"), ESearchCase::IgnoreCase))
+	{
+		TraceChannel = ECC_Pawn;
+	}
+	else if (ChannelStr.Equals(TEXT("PhysicsBody"), ESearchCase::IgnoreCase))
+	{
+		TraceChannel = ECC_PhysicsBody;
+	}
+
+	FCollisionQueryParams QueryParams;
+	QueryParams.bTraceComplex = bTraceComplex;
+	QueryParams.bReturnPhysicalMaterial = true;
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+
+	if (bMulti)
+	{
+		TArray<FHitResult> Hits;
+		bool bHit = World->LineTraceMultiByChannel(Hits, Start, End, TraceChannel, QueryParams);
+
+		Result->SetBoolField(TEXT("hit"), bHit);
+		Result->SetNumberField(TEXT("hitCount"), Hits.Num());
+
+		TArray<TSharedPtr<FJsonValue>> HitArray;
+		for (const FHitResult& Hit : Hits)
+		{
+			TSharedRef<FJsonObject> HitObj = MakeShared<FJsonObject>();
+
+			TSharedRef<FJsonObject> ImpactPoint = MakeShared<FJsonObject>();
+			ImpactPoint->SetNumberField(TEXT("x"), Hit.ImpactPoint.X);
+			ImpactPoint->SetNumberField(TEXT("y"), Hit.ImpactPoint.Y);
+			ImpactPoint->SetNumberField(TEXT("z"), Hit.ImpactPoint.Z);
+			HitObj->SetObjectField(TEXT("impactPoint"), ImpactPoint);
+
+			TSharedRef<FJsonObject> ImpactNormal = MakeShared<FJsonObject>();
+			ImpactNormal->SetNumberField(TEXT("x"), Hit.ImpactNormal.X);
+			ImpactNormal->SetNumberField(TEXT("y"), Hit.ImpactNormal.Y);
+			ImpactNormal->SetNumberField(TEXT("z"), Hit.ImpactNormal.Z);
+			HitObj->SetObjectField(TEXT("impactNormal"), ImpactNormal);
+
+			HitObj->SetNumberField(TEXT("distance"), Hit.Distance);
+
+			AActor* HitActor = Hit.GetActor();
+			if (HitActor)
+			{
+				HitObj->SetStringField(TEXT("actorLabel"), HitActor->GetActorLabel());
+				HitObj->SetStringField(TEXT("actorClass"), HitActor->GetClass()->GetName());
+			}
+
+			if (Hit.GetComponent())
+			{
+				HitObj->SetStringField(TEXT("componentName"), Hit.GetComponent()->GetName());
+			}
+
+			if (Hit.PhysMaterial.IsValid())
+			{
+				HitObj->SetStringField(TEXT("physicalMaterial"), Hit.PhysMaterial->GetName());
+			}
+
+			HitArray.Add(MakeShared<FJsonValueObject>(HitObj));
+		}
+		Result->SetArrayField(TEXT("hits"), HitArray);
+	}
+	else
+	{
+		FHitResult Hit;
+		bool bHit = World->LineTraceSingleByChannel(Hit, Start, End, TraceChannel, QueryParams);
+
+		Result->SetBoolField(TEXT("hit"), bHit);
+
+		if (bHit)
+		{
+			TSharedRef<FJsonObject> ImpactPoint = MakeShared<FJsonObject>();
+			ImpactPoint->SetNumberField(TEXT("x"), Hit.ImpactPoint.X);
+			ImpactPoint->SetNumberField(TEXT("y"), Hit.ImpactPoint.Y);
+			ImpactPoint->SetNumberField(TEXT("z"), Hit.ImpactPoint.Z);
+			Result->SetObjectField(TEXT("impactPoint"), ImpactPoint);
+
+			TSharedRef<FJsonObject> ImpactNormal = MakeShared<FJsonObject>();
+			ImpactNormal->SetNumberField(TEXT("x"), Hit.ImpactNormal.X);
+			ImpactNormal->SetNumberField(TEXT("y"), Hit.ImpactNormal.Y);
+			ImpactNormal->SetNumberField(TEXT("z"), Hit.ImpactNormal.Z);
+			Result->SetObjectField(TEXT("impactNormal"), ImpactNormal);
+
+			Result->SetNumberField(TEXT("distance"), Hit.Distance);
+
+			AActor* HitActor = Hit.GetActor();
+			if (HitActor)
+			{
+				Result->SetStringField(TEXT("actorLabel"), HitActor->GetActorLabel());
+				Result->SetStringField(TEXT("actorClass"), HitActor->GetClass()->GetName());
+			}
+
+			if (Hit.GetComponent())
+			{
+				Result->SetStringField(TEXT("componentName"), Hit.GetComponent()->GetName());
+			}
+
+			if (Hit.PhysMaterial.IsValid())
+			{
+				Result->SetStringField(TEXT("physicalMaterial"), Hit.PhysMaterial->GetName());
+			}
+		}
+	}
+
+	TSharedRef<FJsonObject> StartJson = MakeShared<FJsonObject>();
+	StartJson->SetNumberField(TEXT("x"), Start.X);
+	StartJson->SetNumberField(TEXT("y"), Start.Y);
+	StartJson->SetNumberField(TEXT("z"), Start.Z);
+	Result->SetObjectField(TEXT("traceStart"), StartJson);
+
+	TSharedRef<FJsonObject> EndJson = MakeShared<FJsonObject>();
+	EndJson->SetNumberField(TEXT("x"), End.X);
+	EndJson->SetNumberField(TEXT("y"), End.Y);
+	EndJson->SetNumberField(TEXT("z"), End.Z);
+	Result->SetObjectField(TEXT("traceEnd"), EndJson);
+
+	return JsonToString(Result);
+}

--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -793,6 +793,10 @@ bool FBlueprintMCPServer::Start(int32 InPort, bool bEditorMode)
 	Router->BindRoute(FHttpPath(TEXT("/api/exec")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("exec")));
 
+	// Spatial tools
+	Router->BindRoute(FHttpPath(TEXT("/api/raycast")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("raycast")));
+
 	// Register TMap dispatch handlers
 	RegisterHandlers();
 
@@ -1055,6 +1059,9 @@ void FBlueprintMCPServer::RegisterHandlers()
 
 	// Console command execution
 	HandlerMap.Add(TEXT("exec"),                    [this](const TMap<FString, FString>&, const FString& B) { return HandleExecCommand(B); });
+
+	// Spatial handlers
+	HandlerMap.Add(TEXT("raycast"), [this](const TMap<FString, FString>&, const FString& B) { return HandleRaycast(B); });
 }
 
 // ============================================================

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -260,6 +260,10 @@ private:
 	// ----- Console command execution -----
 	FString HandleExecCommand(const FString& Body);
 
+
+	// ----- Spatial tools -----
+	FString HandleRaycast(const FString& Body);
+
 	// ----- Animation Blueprint handlers -----
 	FString HandleCreateAnimBlueprint(const FString& Body);
 	FString HandleAddAnimState(const FString& Body);

--- a/Tools/src/index.ts
+++ b/Tools/src/index.ts
@@ -20,6 +20,7 @@ import { registerUserTypeTools } from "./tools/user-types.js";
 import { registerMaterialReadTools } from "./tools/material-read.js";
 import { registerMaterialMutationTools } from "./tools/material-mutation.js";
 import { registerAnimationTools } from "./tools/animation-mutation.js";
+import { registerSpatialTools } from "./tools/spatial.js";
 
 // Resource registrations
 import { registerBlueprintListResource } from "./resources/blueprint-list.js";
@@ -48,6 +49,7 @@ registerUserTypeTools(server);
 registerMaterialReadTools(server);
 registerMaterialMutationTools(server);
 registerAnimationTools(server);
+registerSpatialTools(server);
 
 // Register resources
 registerBlueprintListResource(server);

--- a/Tools/src/tools/spatial.ts
+++ b/Tools/src/tools/spatial.ts
@@ -1,0 +1,72 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ensureUE, uePost } from "../ue-bridge.js";
+
+const Vec3Schema = z.object({
+  x: z.number().describe("X coordinate"),
+  y: z.number().describe("Y coordinate"),
+  z: z.number().describe("Z coordinate"),
+});
+
+export function registerSpatialTools(server: McpServer): void {
+  server.tool(
+    "raycast",
+    "Perform a line trace (raycast) from point A to point B in the editor world. Returns hit information including the actor, component, impact point, and surface normal. Supports single and multi-hit modes. Requires editor mode.",
+    {
+      start: Vec3Schema.describe("Start point of the ray (world coordinates)"),
+      end: Vec3Schema.describe("End point of the ray (world coordinates)"),
+      channel: z.enum(["Visibility", "Camera", "WorldStatic", "WorldDynamic", "Pawn", "PhysicsBody"]).optional()
+        .describe("Collision channel to trace against (default: Visibility)"),
+      traceComplex: z.boolean().optional()
+        .describe("Whether to trace against complex collision geometry (default: false)"),
+      multi: z.boolean().optional()
+        .describe("Whether to return all hits along the ray, not just the first (default: false)"),
+    },
+    async ({ start, end, channel, traceComplex, multi }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { start, end };
+      if (channel) body.channel = channel;
+      if (traceComplex !== undefined) body.traceComplex = traceComplex;
+      if (multi !== undefined) body.multi = multi;
+
+      const data = await uePost("/api/raycast", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Raycast from (${data.traceStart.x}, ${data.traceStart.y}, ${data.traceStart.z}) to (${data.traceEnd.x}, ${data.traceEnd.y}, ${data.traceEnd.z})`);
+
+      if (!data.hit) {
+        lines.push("Result: No hit");
+      } else if (data.hits) {
+        // Multi-hit mode
+        lines.push(`Result: ${data.hitCount} hit(s)`);
+        for (const hit of data.hits) {
+          lines.push(`  ---`);
+          if (hit.actorLabel) lines.push(`  Actor: ${hit.actorLabel} (${hit.actorClass})`);
+          if (hit.componentName) lines.push(`  Component: ${hit.componentName}`);
+          lines.push(`  Impact: (${hit.impactPoint.x.toFixed(1)}, ${hit.impactPoint.y.toFixed(1)}, ${hit.impactPoint.z.toFixed(1)})`);
+          lines.push(`  Normal: (${hit.impactNormal.x.toFixed(2)}, ${hit.impactNormal.y.toFixed(2)}, ${hit.impactNormal.z.toFixed(2)})`);
+          lines.push(`  Distance: ${hit.distance.toFixed(1)}`);
+          if (hit.physicalMaterial) lines.push(`  Material: ${hit.physicalMaterial}`);
+        }
+      } else {
+        // Single hit
+        lines.push("Result: Hit!");
+        if (data.actorLabel) lines.push(`Actor: ${data.actorLabel} (${data.actorClass})`);
+        if (data.componentName) lines.push(`Component: ${data.componentName}`);
+        lines.push(`Impact: (${data.impactPoint.x.toFixed(1)}, ${data.impactPoint.y.toFixed(1)}, ${data.impactPoint.z.toFixed(1)})`);
+        lines.push(`Normal: (${data.impactNormal.x.toFixed(2)}, ${data.impactNormal.y.toFixed(2)}, ${data.impactNormal.z.toFixed(2)})`);
+        lines.push(`Distance: ${data.distance.toFixed(1)}`);
+        if (data.physicalMaterial) lines.push(`Material: ${data.physicalMaterial}`);
+      }
+
+      lines.push(`\nNext steps:`);
+      lines.push(`  1. Use the impact point coordinates for spawning actors or setting transforms`);
+      lines.push(`  2. Use multi mode to find all actors along a path`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+}

--- a/Tools/test/tools/spatial.test.ts
+++ b/Tools/test/tools/spatial.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { uePost } from "../helpers.js";
+
+describe("spatial tools", () => {
+  describe("raycast", () => {
+    it("returns error for missing start field", async () => {
+      const data = await uePost("/api/raycast", {
+        end: { x: 100, y: 0, z: 0 },
+      });
+      expect(data.error).toBeDefined();
+      expect(data.error).toContain("start");
+    });
+
+    it("returns error for missing end field", async () => {
+      const data = await uePost("/api/raycast", {
+        start: { x: 0, y: 0, z: 0 },
+      });
+      expect(data.error).toBeDefined();
+      expect(data.error).toContain("end");
+    });
+
+    it("rejects empty JSON body", async () => {
+      const data = await uePost("/api/raycast", {});
+      expect(data.error).toBeDefined();
+    });
+
+    it("returns hit=false for a trace into empty space", async () => {
+      // Trace high above the level where nothing should exist
+      const data = await uePost("/api/raycast", {
+        start: { x: 0, y: 0, z: 999999 },
+        end: { x: 0, y: 0, z: 999998 },
+      });
+      // Should succeed (no error) but hit=false
+      expect(data.error).toBeUndefined();
+      expect(data.hit).toBe(false);
+    });
+
+    it("supports multi-hit mode without errors", async () => {
+      const data = await uePost("/api/raycast", {
+        start: { x: 0, y: 0, z: 1000 },
+        end: { x: 0, y: 0, z: -1000 },
+        multi: true,
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.hitCount).toBeDefined();
+      expect(typeof data.hitCount).toBe("number");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a raycast (line trace) tool for spatial queries in the editor world.

| Tool | Description |
|------|-------------|
| `raycast` | Perform a line trace from point A to B, returning hit actor, component, impact point, normal, and distance |

## New files

| File | Purpose |
|------|--------|
| `Source/BlueprintMCP/Private/BlueprintMCPHandlers_Spatial.cpp` | C++ line trace handler |
| `Tools/src/tools/spatial.ts` | TypeScript MCP tool definition |
| `Tools/test/tools/spatial.test.ts` | Integration tests |

## Features

- **Single & multi-hit modes**: Single returns first hit, multi returns all hits along the ray
- **Collision channels**: Visibility (default), Camera, WorldStatic, WorldDynamic, Pawn, PhysicsBody
- **Complex geometry tracing**: Optional flag to trace against complex collision meshes
- **Rich hit data**: Actor label/class, component name, impact point, impact normal, distance, physical material

## Integration changes needed

### `BlueprintMCPServer.h` — add handler declaration:
```cpp
// ----- Spatial tools -----
FString HandleRaycast(const FString& Body);
```

### `BlueprintMCPServer.cpp` — add route binding and handler:

Route binding (before `RegisterHandlers()`):
```cpp
// Spatial tools
Router->BindRoute(FHttpPath(TEXT("/api/raycast")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("raycast")));
```

Handler map entry:
```cpp
HandlerMap.Add(TEXT("raycast"), [this](const TMap<FString, FString>&, const FString& B) { return HandleRaycast(B); });
```

Note: raycast is read-only so it does NOT need to be added to `MutationEndpoints`.

### `Tools/src/index.ts` — register the new tools:
```typescript
import { registerSpatialTools } from "./tools/spatial.js";
// ... then in the registration block:
registerSpatialTools(server);
```

## Test plan

- [ ] `raycast` — trace against a StaticMesh floor, verify hit result includes actor/component info
- [ ] `raycast` — trace into empty space, verify `hit: false`
- [ ] `raycast` — multi-hit mode returns array of hits
- [ ] `raycast` — different collision channels produce different results
- [ ] Error handling for missing start/end fields
- [ ] `npm run build` succeeds
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)