### PR TITLE
Add sublevel tools: level info, list/load/unload sublevels

### DIFF
--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_Sublevels.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_Sublevels.cpp
@@ -1,0 +1,311 @@
+#include "BlueprintMCPServer.h"
+#include "Editor.h"
+#include "Engine/World.h"
+#include "Engine/Level.h"
+#include "Engine/LevelStreaming.h"
+#include "EditorLevelUtils.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+
+// ============================================================
+// HandleGetLevelInfo — get information about the current level
+// ============================================================
+
+FString FBlueprintMCPServer::HandleGetLevelInfo(const FString& Body)
+{
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: get_level_info()"));
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("get_level_info requires editor mode."));
+	}
+
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("Editor not available."));
+	}
+
+	UWorld* World = GEditor->GetEditorWorldContext().World();
+	if (!World)
+	{
+		return MakeErrorJson(TEXT("No editor world available."));
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("worldName"), World->GetName());
+	Result->SetStringField(TEXT("mapName"), World->GetMapName());
+
+	// Persistent level info
+	ULevel* PersistentLevel = World->PersistentLevel;
+	if (PersistentLevel)
+	{
+		Result->SetNumberField(TEXT("persistentLevelActorCount"), PersistentLevel->Actors.Num());
+	}
+
+	// Streaming levels
+	const TArray<ULevelStreaming*>& StreamingLevels = World->GetStreamingLevels();
+	Result->SetNumberField(TEXT("streamingLevelCount"), StreamingLevels.Num());
+
+	TArray<TSharedPtr<FJsonValue>> LevelArray;
+	for (ULevelStreaming* StreamingLevel : StreamingLevels)
+	{
+		if (!StreamingLevel) continue;
+
+		TSharedRef<FJsonObject> LevelObj = MakeShared<FJsonObject>();
+		LevelObj->SetStringField(TEXT("packageName"), StreamingLevel->GetWorldAssetPackageName());
+		LevelObj->SetStringField(TEXT("shortName"), FPackageName::GetShortName(StreamingLevel->GetWorldAssetPackageName()));
+
+		bool bIsLoaded = StreamingLevel->GetLoadedLevel() != nullptr;
+		bool bIsVisible = StreamingLevel->GetShouldBeVisibleFlag();
+
+		LevelObj->SetBoolField(TEXT("isLoaded"), bIsLoaded);
+		LevelObj->SetBoolField(TEXT("isVisible"), bIsVisible);
+
+		if (bIsLoaded && StreamingLevel->GetLoadedLevel())
+		{
+			LevelObj->SetNumberField(TEXT("actorCount"), StreamingLevel->GetLoadedLevel()->Actors.Num());
+		}
+
+		LevelArray.Add(MakeShared<FJsonValueObject>(LevelObj));
+	}
+	Result->SetArrayField(TEXT("streamingLevels"), LevelArray);
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleListSublevels — list all streaming sublevels
+// ============================================================
+
+FString FBlueprintMCPServer::HandleListSublevels(const FString& Body)
+{
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: list_sublevels()"));
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("list_sublevels requires editor mode."));
+	}
+
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("Editor not available."));
+	}
+
+	UWorld* World = GEditor->GetEditorWorldContext().World();
+	if (!World)
+	{
+		return MakeErrorJson(TEXT("No editor world available."));
+	}
+
+	const TArray<ULevelStreaming*>& StreamingLevels = World->GetStreamingLevels();
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetNumberField(TEXT("count"), StreamingLevels.Num());
+
+	TArray<TSharedPtr<FJsonValue>> LevelArray;
+	for (ULevelStreaming* StreamingLevel : StreamingLevels)
+	{
+		if (!StreamingLevel) continue;
+
+		TSharedRef<FJsonObject> LevelObj = MakeShared<FJsonObject>();
+		LevelObj->SetStringField(TEXT("packageName"), StreamingLevel->GetWorldAssetPackageName());
+		LevelObj->SetStringField(TEXT("shortName"), FPackageName::GetShortName(StreamingLevel->GetWorldAssetPackageName()));
+
+		bool bIsLoaded = StreamingLevel->GetLoadedLevel() != nullptr;
+		bool bIsVisible = StreamingLevel->GetShouldBeVisibleFlag();
+
+		LevelObj->SetBoolField(TEXT("isLoaded"), bIsLoaded);
+		LevelObj->SetBoolField(TEXT("isVisible"), bIsVisible);
+
+		// Get the streaming class name (e.g., LevelStreamingDynamic, LevelStreamingAlwaysLoaded)
+		LevelObj->SetStringField(TEXT("streamingClass"), StreamingLevel->GetClass()->GetName());
+
+		if (bIsLoaded && StreamingLevel->GetLoadedLevel())
+		{
+			LevelObj->SetNumberField(TEXT("actorCount"), StreamingLevel->GetLoadedLevel()->Actors.Num());
+		}
+
+		LevelArray.Add(MakeShared<FJsonValueObject>(LevelObj));
+	}
+	Result->SetArrayField(TEXT("sublevels"), LevelArray);
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleLoadSublevel — load a streaming sublevel
+// ============================================================
+
+FString FBlueprintMCPServer::HandleLoadSublevel(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	FString LevelName;
+	if (!Json->TryGetStringField(TEXT("levelName"), LevelName) || LevelName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'levelName' (package name or short name of the sublevel)."));
+	}
+
+	bool bMakeVisible = true;
+	Json->TryGetBoolField(TEXT("makeVisible"), bMakeVisible);
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: load_sublevel('%s', visible=%s)"),
+		*LevelName, bMakeVisible ? TEXT("true") : TEXT("false"));
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("load_sublevel requires editor mode."));
+	}
+
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("Editor not available."));
+	}
+
+	UWorld* World = GEditor->GetEditorWorldContext().World();
+	if (!World)
+	{
+		return MakeErrorJson(TEXT("No editor world available."));
+	}
+
+	// Find the streaming level by name
+	ULevelStreaming* FoundLevel = nullptr;
+	const TArray<ULevelStreaming*>& StreamingLevels = World->GetStreamingLevels();
+	for (ULevelStreaming* StreamingLevel : StreamingLevels)
+	{
+		if (!StreamingLevel) continue;
+
+		FString PackageName = StreamingLevel->GetWorldAssetPackageName();
+		FString ShortName = FPackageName::GetShortName(PackageName);
+
+		if (PackageName.Equals(LevelName, ESearchCase::IgnoreCase) ||
+			ShortName.Equals(LevelName, ESearchCase::IgnoreCase))
+		{
+			FoundLevel = StreamingLevel;
+			break;
+		}
+	}
+
+	if (!FoundLevel)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Sublevel '%s' not found. Use list_sublevels to see available sublevels."), *LevelName));
+	}
+
+	bool bWasLoaded = FoundLevel->GetLoadedLevel() != nullptr;
+
+	// Set streaming flags to load the level
+	FoundLevel->SetShouldBeLoaded(true);
+	if (bMakeVisible)
+	{
+		FoundLevel->SetShouldBeVisible(true);
+	}
+
+	// Force an update
+	World->FlushLevelStreaming(EFlushLevelStreamingType::Full);
+
+	bool bIsNowLoaded = FoundLevel->GetLoadedLevel() != nullptr;
+
+	if (GEditor)
+	{
+		GEditor->RedrawAllViewports(true);
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("levelName"), FoundLevel->GetWorldAssetPackageName());
+	Result->SetBoolField(TEXT("wasLoaded"), bWasLoaded);
+	Result->SetBoolField(TEXT("isLoaded"), bIsNowLoaded);
+	Result->SetBoolField(TEXT("isVisible"), FoundLevel->GetShouldBeVisibleFlag());
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleUnloadSublevel — unload a streaming sublevel
+// ============================================================
+
+FString FBlueprintMCPServer::HandleUnloadSublevel(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	FString LevelName;
+	if (!Json->TryGetStringField(TEXT("levelName"), LevelName) || LevelName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'levelName' (package name or short name of the sublevel)."));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: unload_sublevel('%s')"), *LevelName);
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("unload_sublevel requires editor mode."));
+	}
+
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("Editor not available."));
+	}
+
+	UWorld* World = GEditor->GetEditorWorldContext().World();
+	if (!World)
+	{
+		return MakeErrorJson(TEXT("No editor world available."));
+	}
+
+	// Find the streaming level by name
+	ULevelStreaming* FoundLevel = nullptr;
+	const TArray<ULevelStreaming*>& StreamingLevels = World->GetStreamingLevels();
+	for (ULevelStreaming* StreamingLevel : StreamingLevels)
+	{
+		if (!StreamingLevel) continue;
+
+		FString PackageName = StreamingLevel->GetWorldAssetPackageName();
+		FString ShortName = FPackageName::GetShortName(PackageName);
+
+		if (PackageName.Equals(LevelName, ESearchCase::IgnoreCase) ||
+			ShortName.Equals(LevelName, ESearchCase::IgnoreCase))
+		{
+			FoundLevel = StreamingLevel;
+			break;
+		}
+	}
+
+	if (!FoundLevel)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Sublevel '%s' not found. Use list_sublevels to see available sublevels."), *LevelName));
+	}
+
+	bool bWasLoaded = FoundLevel->GetLoadedLevel() != nullptr;
+
+	// Set streaming flags to unload the level
+	FoundLevel->SetShouldBeVisible(false);
+	FoundLevel->SetShouldBeLoaded(false);
+
+	// Force an update
+	World->FlushLevelStreaming(EFlushLevelStreamingType::Full);
+
+	bool bIsNowLoaded = FoundLevel->GetLoadedLevel() != nullptr;
+
+	if (GEditor)
+	{
+		GEditor->RedrawAllViewports(true);
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("levelName"), FoundLevel->GetWorldAssetPackageName());
+	Result->SetBoolField(TEXT("wasLoaded"), bWasLoaded);
+	Result->SetBoolField(TEXT("isLoaded"), bIsNowLoaded);
+
+	return JsonToString(Result);
+}

--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -793,6 +793,16 @@ bool FBlueprintMCPServer::Start(int32 InPort, bool bEditorMode)
 	Router->BindRoute(FHttpPath(TEXT("/api/exec")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("exec")));
 
+	// Sublevel tools
+	Router->BindRoute(FHttpPath(TEXT("/api/get-level-info")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("getLevelInfo")));
+	Router->BindRoute(FHttpPath(TEXT("/api/list-sublevels")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("listSublevels")));
+	Router->BindRoute(FHttpPath(TEXT("/api/load-sublevel")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("loadSublevel")));
+	Router->BindRoute(FHttpPath(TEXT("/api/unload-sublevel")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("unloadSublevel")));
+
 	// Register TMap dispatch handlers
 	RegisterHandlers();
 
@@ -944,6 +954,8 @@ void FBlueprintMCPServer::RegisterHandlers()
 		TEXT("addAnimNode"),
 		TEXT("addStateMachine"),
 		TEXT("setStateAnimation"),
+		TEXT("loadSublevel"),
+		TEXT("unloadSublevel"),
 	};
 
 	// GET handlers (use QueryParams, ignore Body)
@@ -1055,6 +1067,12 @@ void FBlueprintMCPServer::RegisterHandlers()
 
 	// Console command execution
 	HandlerMap.Add(TEXT("exec"),                    [this](const TMap<FString, FString>&, const FString& B) { return HandleExecCommand(B); });
+
+	// Sublevel handlers
+	HandlerMap.Add(TEXT("getLevelInfo"), [this](const TMap<FString, FString>&, const FString& B) { return HandleGetLevelInfo(B); });
+	HandlerMap.Add(TEXT("listSublevels"), [this](const TMap<FString, FString>&, const FString& B) { return HandleListSublevels(B); });
+	HandlerMap.Add(TEXT("loadSublevel"), [this](const TMap<FString, FString>&, const FString& B) { return HandleLoadSublevel(B); });
+	HandlerMap.Add(TEXT("unloadSublevel"), [this](const TMap<FString, FString>&, const FString& B) { return HandleUnloadSublevel(B); });
 }
 
 // ============================================================

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -260,6 +260,13 @@ private:
 	// ----- Console command execution -----
 	FString HandleExecCommand(const FString& Body);
 
+
+	// ----- Sublevel tools -----
+	FString HandleGetLevelInfo(const FString& Body);
+	FString HandleListSublevels(const FString& Body);
+	FString HandleLoadSublevel(const FString& Body);
+	FString HandleUnloadSublevel(const FString& Body);
+
 	// ----- Animation Blueprint handlers -----
 	FString HandleCreateAnimBlueprint(const FString& Body);
 	FString HandleAddAnimState(const FString& Body);

--- a/Tools/src/index.ts
+++ b/Tools/src/index.ts
@@ -20,6 +20,7 @@ import { registerUserTypeTools } from "./tools/user-types.js";
 import { registerMaterialReadTools } from "./tools/material-read.js";
 import { registerMaterialMutationTools } from "./tools/material-mutation.js";
 import { registerAnimationTools } from "./tools/animation-mutation.js";
+import { registerSublevelTools } from "./tools/sublevels.js";
 
 // Resource registrations
 import { registerBlueprintListResource } from "./resources/blueprint-list.js";
@@ -48,6 +49,7 @@ registerUserTypeTools(server);
 registerMaterialReadTools(server);
 registerMaterialMutationTools(server);
 registerAnimationTools(server);
+registerSublevelTools(server);
 
 // Register resources
 registerBlueprintListResource(server);

--- a/Tools/src/tools/sublevels.ts
+++ b/Tools/src/tools/sublevels.ts
@@ -1,0 +1,138 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ensureUE, uePost } from "../ue-bridge.js";
+
+export function registerSublevelTools(server: McpServer): void {
+  server.tool(
+    "get_level_info",
+    "Get information about the current editor world including persistent level details and all streaming sublevels. Requires editor mode.",
+    {},
+    async () => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/get-level-info", {});
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`World: ${data.worldName}`);
+      lines.push(`Map: ${data.mapName}`);
+      if (data.persistentLevelActorCount !== undefined) {
+        lines.push(`Persistent level actors: ${data.persistentLevelActorCount}`);
+      }
+      lines.push(`Streaming sublevels: ${data.streamingLevelCount}`);
+
+      if (data.streamingLevels && data.streamingLevels.length > 0) {
+        lines.push(`\nSublevels:`);
+        for (const level of data.streamingLevels) {
+          const status = level.isLoaded
+            ? (level.isVisible ? "loaded, visible" : "loaded, hidden")
+            : "unloaded";
+          const actors = level.actorCount !== undefined ? `, ${level.actorCount} actors` : "";
+          lines.push(`  - ${level.shortName} [${status}${actors}]`);
+        }
+      }
+
+      lines.push(`\nNext steps:`);
+      lines.push(`  1. Use list_sublevels for detailed sublevel information`);
+      lines.push(`  2. Use load_sublevel / unload_sublevel to manage streaming levels`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "list_sublevels",
+    "List all streaming sublevels in the current world with their load/visibility status, streaming class, and actor counts. Requires editor mode.",
+    {},
+    async () => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/list-sublevels", {});
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Found ${data.count} sublevel(s)`);
+
+      if (data.sublevels && data.sublevels.length > 0) {
+        for (const level of data.sublevels) {
+          lines.push(`\n  ${level.shortName}`);
+          lines.push(`    Package: ${level.packageName}`);
+          lines.push(`    Loaded: ${level.isLoaded}`);
+          lines.push(`    Visible: ${level.isVisible}`);
+          lines.push(`    Streaming class: ${level.streamingClass}`);
+          if (level.actorCount !== undefined) {
+            lines.push(`    Actors: ${level.actorCount}`);
+          }
+        }
+      } else {
+        lines.push("No streaming sublevels found in this world.");
+      }
+
+      lines.push(`\nNext steps:`);
+      lines.push(`  1. Use load_sublevel to load an unloaded sublevel`);
+      lines.push(`  2. Use unload_sublevel to unload a loaded sublevel`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "load_sublevel",
+    "Load a streaming sublevel by name. Optionally make it visible immediately. Requires editor mode.",
+    {
+      levelName: z.string().describe("Package name or short name of the sublevel to load"),
+      makeVisible: z.boolean().optional()
+        .describe("Whether to also make the sublevel visible after loading (default: true)"),
+    },
+    async ({ levelName, makeVisible }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { levelName };
+      if (makeVisible !== undefined) body.makeVisible = makeVisible;
+
+      const data = await uePost("/api/load-sublevel", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        `Loaded sublevel '${data.levelName}'`,
+        `Was loaded: ${data.wasLoaded}`,
+        `Is loaded: ${data.isLoaded}`,
+        `Is visible: ${data.isVisible}`,
+        `\nNext steps:`,
+        `  1. Use list_actors to see actors in the loaded sublevel`,
+        `  2. Use unload_sublevel to unload it when no longer needed`,
+      ];
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "unload_sublevel",
+    "Unload a streaming sublevel by name. Hides and unloads the sublevel. Requires editor mode.",
+    {
+      levelName: z.string().describe("Package name or short name of the sublevel to unload"),
+    },
+    async ({ levelName }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/unload-sublevel", { levelName });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        `Unloaded sublevel '${data.levelName}'`,
+        `Was loaded: ${data.wasLoaded}`,
+        `Is loaded: ${data.isLoaded}`,
+        `\nNext steps:`,
+        `  1. Use load_sublevel to reload the sublevel`,
+        `  2. Use list_sublevels to verify the status`,
+      ];
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+}

--- a/Tools/test/tools/sublevels.test.ts
+++ b/Tools/test/tools/sublevels.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { uePost } from "../helpers.js";
+
+describe("sublevel tools", () => {
+  describe("get_level_info", () => {
+    it("returns world information without errors", async () => {
+      const data = await uePost("/api/get-level-info", {});
+      expect(data.error).toBeUndefined();
+      expect(data.worldName).toBeDefined();
+      expect(data.mapName).toBeDefined();
+      expect(typeof data.streamingLevelCount).toBe("number");
+    });
+  });
+
+  describe("list_sublevels", () => {
+    it("returns sublevel list without errors", async () => {
+      const data = await uePost("/api/list-sublevels", {});
+      expect(data.error).toBeUndefined();
+      expect(typeof data.count).toBe("number");
+      expect(Array.isArray(data.sublevels)).toBe(true);
+    });
+  });
+
+  describe("load_sublevel", () => {
+    it("returns error for missing levelName field", async () => {
+      const data = await uePost("/api/load-sublevel", {});
+      expect(data.error).toBeDefined();
+      expect(data.error).toContain("levelName");
+    });
+
+    it("returns error for non-existent sublevel", async () => {
+      const data = await uePost("/api/load-sublevel", {
+        levelName: "NonExistent_Sublevel_XYZ_999",
+      });
+      expect(data.error).toBeDefined();
+    });
+  });
+
+  describe("unload_sublevel", () => {
+    it("returns error for missing levelName field", async () => {
+      const data = await uePost("/api/unload-sublevel", {});
+      expect(data.error).toBeDefined();
+      expect(data.error).toContain("levelName");
+    });
+
+    it("returns error for non-existent sublevel", async () => {
+      const data = await uePost("/api/unload-sublevel", {
+        levelName: "NonExistent_Sublevel_XYZ_999",
+      });
+      expect(data.error).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds four new MCP tools for querying and managing streaming sublevels in the editor.

| Tool | Description |
|------|-------------|
| `get_level_info` | Get world name, map name, persistent level actor count, and streaming sublevel overview |
| `list_sublevels` | List all streaming sublevels with load/visibility status, streaming class, and actor counts |
| `load_sublevel` | Load a streaming sublevel by name, optionally making it visible |
| `unload_sublevel` | Unload a streaming sublevel by name |

## New files

| File | Purpose |
|------|--------|
| `Source/BlueprintMCP/Private/BlueprintMCPHandlers_Sublevels.cpp` | C++ handler implementations |
| `Tools/src/tools/sublevels.ts` | TypeScript MCP tool definitions |
| `Tools/test/tools/sublevels.test.ts` | Integration tests |

## Integration changes needed

### `BlueprintMCPServer.h` — add handler declarations:
```cpp
// ----- Sublevel tools -----
FString HandleGetLevelInfo(const FString& Body);
FString HandleListSublevels(const FString& Body);
FString HandleLoadSublevel(const FString& Body);
FString HandleUnloadSublevel(const FString& Body);
```

### `BlueprintMCPServer.cpp` — add to `RegisterHandlers()`:

Add to `MutationEndpoints`:
```cpp
TEXT("loadSublevel"),
TEXT("unloadSublevel"),
```

Add route bindings (before `RegisterHandlers()`):
```cpp
// Sublevel tools
Router->BindRoute(FHttpPath(TEXT("/api/get-level-info")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("getLevelInfo")));
Router->BindRoute(FHttpPath(TEXT("/api/list-sublevels")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("listSublevels")));
Router->BindRoute(FHttpPath(TEXT("/api/load-sublevel")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("loadSublevel")));
Router->BindRoute(FHttpPath(TEXT("/api/unload-sublevel")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("unloadSublevel")));
```

Add handler map entries:
```cpp
HandlerMap.Add(TEXT("getLevelInfo"),   [this](const TMap<FString, FString>&, const FString& B) { return HandleGetLevelInfo(B); });
HandlerMap.Add(TEXT("listSublevels"), [this](const TMap<FString, FString>&, const FString& B) { return HandleListSublevels(B); });
HandlerMap.Add(TEXT("loadSublevel"),  [this](const TMap<FString, FString>&, const FString& B) { return HandleLoadSublevel(B); });
HandlerMap.Add(TEXT("unloadSublevel"),[this](const TMap<FString, FString>&, const FString& B) { return HandleUnloadSublevel(B); });
```

### `Tools/src/index.ts` — register the new tools:
```typescript
import { registerSublevelTools } from "./tools/sublevels.js";
// ... then in the registration block:
registerSublevelTools(server);
```

## Key implementation details

- **Level lookup**: Matches by both full package name and short name, case-insensitive
- **Load/unload**: Uses `SetShouldBeLoaded`/`SetShouldBeVisible` flags + `FlushLevelStreaming` for immediate effect
- **Read-only tools**: `get_level_info` and `list_sublevels` are read-only (not in MutationEndpoints)
- All handlers validate editor mode and world availability

## Test plan

- [ ] `get_level_info` returns valid world/map name in a project with sublevels
- [ ] `list_sublevels` returns correct count and status for each sublevel
- [ ] `load_sublevel` loads an unloaded sublevel and makes it visible
- [ ] `unload_sublevel` unloads a loaded sublevel
- [ ] Load/unload by short name works
- [ ] Error handling for non-existent sublevel names
- [ ] `npm run build` succeeds
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)