### PR TITLE
Add undo/redo tools: undo, redo, begin/end transaction

### DIFF
--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_UndoRedo.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_UndoRedo.cpp
@@ -1,0 +1,178 @@
+#include "BlueprintMCPServer.h"
+#include "Editor.h"
+#include "Editor/TransBuffer.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+
+// ============================================================
+// HandleUndo — undo the last editor action
+// ============================================================
+
+FString FBlueprintMCPServer::HandleUndo(const FString& Body)
+{
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: undo()"));
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("undo requires editor mode."));
+	}
+
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("Editor not available."));
+	}
+
+	UTransBuffer* TransBuffer = CastChecked<UTransBuffer>(GEditor->Trans);
+	if (!TransBuffer)
+	{
+		return MakeErrorJson(TEXT("Transaction buffer not available."));
+	}
+
+	if (TransBuffer->GetUndoCount() == 0)
+	{
+		return MakeErrorJson(TEXT("Nothing to undo."));
+	}
+
+	// Get the description of what we're about to undo
+	FString UndoDescription;
+	if (TransBuffer->GetUndoCount() > 0)
+	{
+		UndoDescription = TransBuffer->GetUndoContext(false).Title.ToString();
+	}
+
+	bool bSuccess = GEditor->UndoTransaction();
+
+	if (GEditor)
+	{
+		GEditor->RedrawAllViewports(true);
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), bSuccess);
+	Result->SetStringField(TEXT("undoneAction"), UndoDescription);
+	Result->SetNumberField(TEXT("remainingUndoCount"), TransBuffer->GetUndoCount());
+	Result->SetNumberField(TEXT("redoCount"), TransBuffer->GetRedoCount());
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleRedo — redo the last undone action
+// ============================================================
+
+FString FBlueprintMCPServer::HandleRedo(const FString& Body)
+{
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: redo()"));
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("redo requires editor mode."));
+	}
+
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("Editor not available."));
+	}
+
+	UTransBuffer* TransBuffer = CastChecked<UTransBuffer>(GEditor->Trans);
+	if (!TransBuffer)
+	{
+		return MakeErrorJson(TEXT("Transaction buffer not available."));
+	}
+
+	if (TransBuffer->GetRedoCount() == 0)
+	{
+		return MakeErrorJson(TEXT("Nothing to redo."));
+	}
+
+	// Get the description of what we're about to redo
+	FString RedoDescription;
+	if (TransBuffer->GetRedoCount() > 0)
+	{
+		RedoDescription = TransBuffer->GetUndoContext(true).Title.ToString();
+	}
+
+	bool bSuccess = GEditor->RedoTransaction();
+
+	if (GEditor)
+	{
+		GEditor->RedrawAllViewports(true);
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), bSuccess);
+	Result->SetStringField(TEXT("redoneAction"), RedoDescription);
+	Result->SetNumberField(TEXT("undoCount"), TransBuffer->GetUndoCount());
+	Result->SetNumberField(TEXT("remainingRedoCount"), TransBuffer->GetRedoCount());
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleBeginTransaction — begin a named undo transaction
+// ============================================================
+
+FString FBlueprintMCPServer::HandleBeginTransaction(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	FString Description;
+	if (!Json->TryGetStringField(TEXT("description"), Description) || Description.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'description' (human-readable description of the transaction)."));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: begin_transaction('%s')"), *Description);
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("begin_transaction requires editor mode."));
+	}
+
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("Editor not available."));
+	}
+
+	int32 TransactionIndex = GEditor->BeginTransaction(FText::FromString(Description));
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("description"), Description);
+	Result->SetNumberField(TEXT("transactionIndex"), TransactionIndex);
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleEndTransaction — end the current undo transaction
+// ============================================================
+
+FString FBlueprintMCPServer::HandleEndTransaction(const FString& Body)
+{
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: end_transaction()"));
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("end_transaction requires editor mode."));
+	}
+
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("Editor not available."));
+	}
+
+	int32 TransactionIndex = GEditor->EndTransaction();
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetNumberField(TEXT("transactionIndex"), TransactionIndex);
+
+	return JsonToString(Result);
+}

--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -793,6 +793,16 @@ bool FBlueprintMCPServer::Start(int32 InPort, bool bEditorMode)
 	Router->BindRoute(FHttpPath(TEXT("/api/exec")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("exec")));
 
+	// Undo/Redo tools
+	Router->BindRoute(FHttpPath(TEXT("/api/undo")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("undo")));
+	Router->BindRoute(FHttpPath(TEXT("/api/redo")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("redo")));
+	Router->BindRoute(FHttpPath(TEXT("/api/begin-transaction")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("beginTransaction")));
+	Router->BindRoute(FHttpPath(TEXT("/api/end-transaction")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("endTransaction")));
+
 	// Register TMap dispatch handlers
 	RegisterHandlers();
 
@@ -944,6 +954,8 @@ void FBlueprintMCPServer::RegisterHandlers()
 		TEXT("addAnimNode"),
 		TEXT("addStateMachine"),
 		TEXT("setStateAnimation"),
+		TEXT("undo"),
+		TEXT("redo"),
 	};
 
 	// GET handlers (use QueryParams, ignore Body)
@@ -1055,6 +1067,12 @@ void FBlueprintMCPServer::RegisterHandlers()
 
 	// Console command execution
 	HandlerMap.Add(TEXT("exec"),                    [this](const TMap<FString, FString>&, const FString& B) { return HandleExecCommand(B); });
+
+	// Undo/Redo handlers
+	HandlerMap.Add(TEXT("undo"), [this](const TMap<FString, FString>&, const FString& B) { return HandleUndo(B); });
+	HandlerMap.Add(TEXT("redo"), [this](const TMap<FString, FString>&, const FString& B) { return HandleRedo(B); });
+	HandlerMap.Add(TEXT("beginTransaction"), [this](const TMap<FString, FString>&, const FString& B) { return HandleBeginTransaction(B); });
+	HandlerMap.Add(TEXT("endTransaction"), [this](const TMap<FString, FString>&, const FString& B) { return HandleEndTransaction(B); });
 }
 
 // ============================================================

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -260,6 +260,13 @@ private:
 	// ----- Console command execution -----
 	FString HandleExecCommand(const FString& Body);
 
+
+	// ----- Undo/Redo tools -----
+	FString HandleUndo(const FString& Body);
+	FString HandleRedo(const FString& Body);
+	FString HandleBeginTransaction(const FString& Body);
+	FString HandleEndTransaction(const FString& Body);
+
 	// ----- Animation Blueprint handlers -----
 	FString HandleCreateAnimBlueprint(const FString& Body);
 	FString HandleAddAnimState(const FString& Body);

--- a/Tools/src/index.ts
+++ b/Tools/src/index.ts
@@ -20,6 +20,7 @@ import { registerUserTypeTools } from "./tools/user-types.js";
 import { registerMaterialReadTools } from "./tools/material-read.js";
 import { registerMaterialMutationTools } from "./tools/material-mutation.js";
 import { registerAnimationTools } from "./tools/animation-mutation.js";
+import { registerUndoRedoTools } from "./tools/undo-redo.js";
 
 // Resource registrations
 import { registerBlueprintListResource } from "./resources/blueprint-list.js";
@@ -48,6 +49,7 @@ registerUserTypeTools(server);
 registerMaterialReadTools(server);
 registerMaterialMutationTools(server);
 registerAnimationTools(server);
+registerUndoRedoTools(server);
 
 // Register resources
 registerBlueprintListResource(server);

--- a/Tools/src/tools/undo-redo.ts
+++ b/Tools/src/tools/undo-redo.ts
@@ -1,0 +1,101 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ensureUE, uePost } from "../ue-bridge.js";
+
+export function registerUndoRedoTools(server: McpServer): void {
+  server.tool(
+    "undo",
+    "Undo the last editor action. Returns the description of the undone action and remaining undo/redo counts. Requires editor mode.",
+    {},
+    async () => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/undo", {});
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        `Undone: ${data.undoneAction || "(unnamed action)"}`,
+        `Remaining undo actions: ${data.remainingUndoCount}`,
+        `Available redo actions: ${data.redoCount}`,
+        `\nNext steps:`,
+        `  1. Use redo to re-apply the undone action`,
+        `  2. Use undo again to undo further`,
+      ];
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "redo",
+    "Redo the last undone editor action. Returns the description of the redone action and remaining undo/redo counts. Requires editor mode.",
+    {},
+    async () => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/redo", {});
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        `Redone: ${data.redoneAction || "(unnamed action)"}`,
+        `Available undo actions: ${data.undoCount}`,
+        `Remaining redo actions: ${data.remainingRedoCount}`,
+        `\nNext steps:`,
+        `  1. Use undo to undo the redone action`,
+        `  2. Use redo again to redo further`,
+      ];
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "begin_transaction",
+    "Begin a named undo transaction. All modifications between begin_transaction and end_transaction will be grouped as a single undoable action. Requires editor mode.",
+    {
+      description: z.string().describe("Human-readable description of the transaction (shown in Edit > Undo)"),
+    },
+    async ({ description }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/begin-transaction", { description });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        `Transaction started: '${data.description}'`,
+        `Transaction index: ${data.transactionIndex}`,
+        `\nNext steps:`,
+        `  1. Make your modifications (set_actor_transform, set_actor_property, etc.)`,
+        `  2. Call end_transaction to close the transaction`,
+        `  3. The entire group can then be undone with a single undo call`,
+      ];
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "end_transaction",
+    "End the current undo transaction. All modifications since the matching begin_transaction will be grouped as a single undoable action. Requires editor mode.",
+    {},
+    async () => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/end-transaction", {});
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        `Transaction ended`,
+        `Transaction index: ${data.transactionIndex}`,
+        `\nNext steps:`,
+        `  1. Use undo to undo the entire transaction as one action`,
+      ];
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+}

--- a/Tools/test/tools/undo-redo.test.ts
+++ b/Tools/test/tools/undo-redo.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { uePost } from "../helpers.js";
+
+describe("undo/redo tools", () => {
+  describe("undo", () => {
+    it("returns appropriate response when nothing to undo", async () => {
+      // In a fresh commandlet there may be nothing to undo
+      const data = await uePost("/api/undo", {});
+      // Either succeeds or returns an error about nothing to undo
+      if (data.error) {
+        expect(data.error).toContain("undo");
+      } else {
+        expect(data.success).toBe(true);
+      }
+    });
+  });
+
+  describe("redo", () => {
+    it("returns appropriate response when nothing to redo", async () => {
+      const data = await uePost("/api/redo", {});
+      if (data.error) {
+        expect(data.error).toContain("redo");
+      } else {
+        expect(data.success).toBe(true);
+      }
+    });
+  });
+
+  describe("begin_transaction", () => {
+    it("returns error for missing description field", async () => {
+      const data = await uePost("/api/begin-transaction", {});
+      expect(data.error).toBeDefined();
+      expect(data.error).toContain("description");
+    });
+
+    it("succeeds with valid description", async () => {
+      const data = await uePost("/api/begin-transaction", {
+        description: "Test transaction",
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+      expect(data.transactionIndex).toBeDefined();
+
+      // End the transaction to clean up
+      const endData = await uePost("/api/end-transaction", {});
+      expect(endData.error).toBeUndefined();
+    });
+  });
+
+  describe("end_transaction", () => {
+    it("can end a transaction", async () => {
+      // Start a transaction first
+      await uePost("/api/begin-transaction", { description: "Test end" });
+      const data = await uePost("/api/end-transaction", {});
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds four MCP tools for undo/redo and grouped transaction management.

| Tool | Description |
|------|-------------|
| `undo` | Undo the last editor action, returns description and remaining counts |
| `redo` | Redo the last undone action, returns description and remaining counts |
| `begin_transaction` | Begin a named undo transaction for grouping multiple operations |
| `end_transaction` | End the current transaction, grouping all changes as one undoable action |

## New files

| File | Purpose |
|------|--------|
| `Source/BlueprintMCP/Private/BlueprintMCPHandlers_UndoRedo.cpp` | C++ handler implementations |
| `Tools/src/tools/undo-redo.ts` | TypeScript MCP tool definitions |
| `Tools/test/tools/undo-redo.test.ts` | Integration tests |

## Integration changes needed

### `BlueprintMCPServer.h` — add handler declarations:
```cpp
// ----- Undo/redo tools -----
FString HandleUndo(const FString& Body);
FString HandleRedo(const FString& Body);
FString HandleBeginTransaction(const FString& Body);
FString HandleEndTransaction(const FString& Body);
```

### `BlueprintMCPServer.cpp` — add route bindings and handlers:

Add to `MutationEndpoints`:
```cpp
TEXT("undo"),
TEXT("redo"),
TEXT("beginTransaction"),
TEXT("endTransaction"),
```

Route bindings:
```cpp
// Undo/redo tools
Router->BindRoute(FHttpPath(TEXT("/api/undo")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("undo")));
Router->BindRoute(FHttpPath(TEXT("/api/redo")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("redo")));
Router->BindRoute(FHttpPath(TEXT("/api/begin-transaction")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("beginTransaction")));
Router->BindRoute(FHttpPath(TEXT("/api/end-transaction")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("endTransaction")));
```

Handler map:
```cpp
HandlerMap.Add(TEXT("undo"),             [this](const TMap<FString, FString>&, const FString& B) { return HandleUndo(B); });
HandlerMap.Add(TEXT("redo"),             [this](const TMap<FString, FString>&, const FString& B) { return HandleRedo(B); });
HandlerMap.Add(TEXT("beginTransaction"), [this](const TMap<FString, FString>&, const FString& B) { return HandleBeginTransaction(B); });
HandlerMap.Add(TEXT("endTransaction"),   [this](const TMap<FString, FString>&, const FString& B) { return HandleEndTransaction(B); });
```

### `Tools/src/index.ts`:
```typescript
import { registerUndoRedoTools } from "./tools/undo-redo.js";
registerUndoRedoTools(server);
```

## Key implementation details

- Uses UE5's `UTransBuffer` for undo count/redo count queries
- `undo`/`redo` check available actions before attempting, returning clear errors
- `begin_transaction`/`end_transaction` use `GEditor->BeginTransaction`/`EndTransaction` for proper integration with UE5's undo system
- Transaction descriptions appear in Edit > Undo menu
- Note: `undo`/`redo` should NOT be in MutationEndpoints' auto-transaction wrapping since they manage their own transactions

## Test plan

- [ ] `undo` after a mutation undoes the action
- [ ] `redo` after an undo restores the action
- [ ] `begin_transaction` + multiple mutations + `end_transaction` groups as one undo
- [ ] `undo` with nothing to undo returns clear error
- [ ] `redo` with nothing to redo returns clear error
- [ ] `begin_transaction` rejects missing description
- [ ] `npm run build` succeeds
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)