### PR TITLE
Add editor utility tools: focus, notify, save, dirty packages

### DIFF
--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_EditorUtils.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_EditorUtils.cpp
@@ -1,0 +1,227 @@
+#include "BlueprintMCPServer.h"
+#include "Editor.h"
+#include "Engine/World.h"
+#include "EngineUtils.h"
+#include "GameFramework/Actor.h"
+#include "LevelEditorViewport.h"
+#include "FileHelpers.h"
+#include "UObject/Package.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+#include "Framework/Notifications/NotificationManager.h"
+#include "Widgets/Notifications/SNotificationList.h"
+
+// ============================================================
+// Helper — find an actor by label
+// ============================================================
+
+static AActor* FindActorByLabelEditorUtils(const FString& Label, FString& OutError)
+{
+	if (!GEditor)
+	{
+		OutError = TEXT("Editor not available.");
+		return nullptr;
+	}
+
+	UWorld* World = GEditor->GetEditorWorldContext().World();
+	if (!World)
+	{
+		OutError = TEXT("No editor world available.");
+		return nullptr;
+	}
+
+	for (TActorIterator<AActor> It(World); It; ++It)
+	{
+		AActor* Actor = *It;
+		if (Actor && Actor->GetActorLabel() == Label)
+		{
+			return Actor;
+		}
+	}
+
+	for (TActorIterator<AActor> It(World); It; ++It)
+	{
+		AActor* Actor = *It;
+		if (Actor && Actor->GetActorLabel().Equals(Label, ESearchCase::IgnoreCase))
+		{
+			return Actor;
+		}
+	}
+
+	OutError = FString::Printf(TEXT("Actor with label '%s' not found."), *Label);
+	return nullptr;
+}
+
+// ============================================================
+// HandleFocusActor — focus the viewport on an actor
+// ============================================================
+
+FString FBlueprintMCPServer::HandleFocusActor(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	FString ActorLabel;
+	if (!Json->TryGetStringField(TEXT("actorLabel"), ActorLabel) || ActorLabel.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'actorLabel'."));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: focus_actor('%s')"), *ActorLabel);
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("focus_actor requires editor mode."));
+	}
+
+	FString Error;
+	AActor* Actor = FindActorByLabelEditorUtils(ActorLabel, Error);
+	if (!Actor) return MakeErrorJson(Error);
+
+	// Select the actor and focus
+	GEditor->SelectNone(false, true, false);
+	GEditor->SelectActor(Actor, true, true);
+	GEditor->MoveViewportCamerasToActor(*Actor, false);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("actorLabel"), ActorLabel);
+
+	FVector Loc = Actor->GetActorLocation();
+	TSharedRef<FJsonObject> LocObj = MakeShared<FJsonObject>();
+	LocObj->SetNumberField(TEXT("x"), Loc.X);
+	LocObj->SetNumberField(TEXT("y"), Loc.Y);
+	LocObj->SetNumberField(TEXT("z"), Loc.Z);
+	Result->SetObjectField(TEXT("location"), LocObj);
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleEditorNotification — show a toast notification
+// ============================================================
+
+FString FBlueprintMCPServer::HandleEditorNotification(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	FString Message;
+	if (!Json->TryGetStringField(TEXT("message"), Message) || Message.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'message'."));
+	}
+
+	FString SeverityStr;
+	Json->TryGetStringField(TEXT("severity"), SeverityStr);
+
+	double Duration = 5.0;
+	Json->TryGetNumberField(TEXT("duration"), Duration);
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: editor_notification('%s')"), *Message);
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("editor_notification requires editor mode."));
+	}
+
+	SNotificationItem::ECompletionState CompletionState = SNotificationItem::CS_None;
+	if (SeverityStr.Equals(TEXT("success"), ESearchCase::IgnoreCase))
+	{
+		CompletionState = SNotificationItem::CS_Success;
+	}
+	else if (SeverityStr.Equals(TEXT("fail"), ESearchCase::IgnoreCase) || SeverityStr.Equals(TEXT("error"), ESearchCase::IgnoreCase))
+	{
+		CompletionState = SNotificationItem::CS_Fail;
+	}
+	else if (SeverityStr.Equals(TEXT("pending"), ESearchCase::IgnoreCase))
+	{
+		CompletionState = SNotificationItem::CS_Pending;
+	}
+
+	FNotificationInfo Info(FText::FromString(Message));
+	Info.bFireAndForget = true;
+	Info.ExpireDuration = Duration;
+	Info.bUseLargeFont = false;
+
+	TSharedPtr<SNotificationItem> Notification = FSlateNotificationManager::Get().AddNotification(Info);
+	if (Notification.IsValid() && CompletionState != SNotificationItem::CS_None)
+	{
+		Notification->SetCompletionState(CompletionState);
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("message"), Message);
+	Result->SetNumberField(TEXT("duration"), Duration);
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleSaveAll — save all dirty packages
+// ============================================================
+
+FString FBlueprintMCPServer::HandleSaveAll(const FString& Body)
+{
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: save_all()"));
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("save_all requires editor mode."));
+	}
+
+	bool bPromptUserToSave = false;
+	bool bSaveMapPackages = true;
+	bool bSaveContentPackages = true;
+
+	bool bSuccess = FEditorFileUtils::SaveDirtyPackages(bPromptUserToSave, bSaveMapPackages, bSaveContentPackages);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), bSuccess);
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleGetDirtyPackages — list unsaved packages
+// ============================================================
+
+FString FBlueprintMCPServer::HandleGetDirtyPackages(const FString& Body)
+{
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: get_dirty_packages()"));
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("get_dirty_packages requires editor mode."));
+	}
+
+	TArray<UPackage*> DirtyPackages;
+	FEditorFileUtils::GetDirtyPackages(DirtyPackages);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetNumberField(TEXT("count"), DirtyPackages.Num());
+
+	TArray<TSharedPtr<FJsonValue>> PackageArray;
+	for (UPackage* Package : DirtyPackages)
+	{
+		if (!Package) continue;
+
+		TSharedRef<FJsonObject> PkgObj = MakeShared<FJsonObject>();
+		PkgObj->SetStringField(TEXT("name"), Package->GetName());
+		PkgObj->SetStringField(TEXT("fileName"), Package->FileName.ToString());
+
+		PackageArray.Add(MakeShared<FJsonValueObject>(PkgObj));
+	}
+	Result->SetArrayField(TEXT("packages"), PackageArray);
+
+	return JsonToString(Result);
+}

--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -793,6 +793,16 @@ bool FBlueprintMCPServer::Start(int32 InPort, bool bEditorMode)
 	Router->BindRoute(FHttpPath(TEXT("/api/exec")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("exec")));
 
+	// Editor utility tools
+	Router->BindRoute(FHttpPath(TEXT("/api/focus-actor")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("focusActor")));
+	Router->BindRoute(FHttpPath(TEXT("/api/editor-notification")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("editorNotification")));
+	Router->BindRoute(FHttpPath(TEXT("/api/save-all")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("saveAll")));
+	Router->BindRoute(FHttpPath(TEXT("/api/get-dirty-packages")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("getDirtyPackages")));
+
 	// Register TMap dispatch handlers
 	RegisterHandlers();
 
@@ -944,6 +954,7 @@ void FBlueprintMCPServer::RegisterHandlers()
 		TEXT("addAnimNode"),
 		TEXT("addStateMachine"),
 		TEXT("setStateAnimation"),
+		TEXT("saveAll"),
 	};
 
 	// GET handlers (use QueryParams, ignore Body)
@@ -1055,6 +1066,12 @@ void FBlueprintMCPServer::RegisterHandlers()
 
 	// Console command execution
 	HandlerMap.Add(TEXT("exec"),                    [this](const TMap<FString, FString>&, const FString& B) { return HandleExecCommand(B); });
+
+	// Editor utility handlers
+	HandlerMap.Add(TEXT("focusActor"), [this](const TMap<FString, FString>&, const FString& B) { return HandleFocusActor(B); });
+	HandlerMap.Add(TEXT("editorNotification"), [this](const TMap<FString, FString>&, const FString& B) { return HandleEditorNotification(B); });
+	HandlerMap.Add(TEXT("saveAll"), [this](const TMap<FString, FString>&, const FString& B) { return HandleSaveAll(B); });
+	HandlerMap.Add(TEXT("getDirtyPackages"), [this](const TMap<FString, FString>&, const FString& B) { return HandleGetDirtyPackages(B); });
 }
 
 // ============================================================

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -260,6 +260,13 @@ private:
 	// ----- Console command execution -----
 	FString HandleExecCommand(const FString& Body);
 
+
+	// ----- Editor utility tools -----
+	FString HandleFocusActor(const FString& Body);
+	FString HandleEditorNotification(const FString& Body);
+	FString HandleSaveAll(const FString& Body);
+	FString HandleGetDirtyPackages(const FString& Body);
+
 	// ----- Animation Blueprint handlers -----
 	FString HandleCreateAnimBlueprint(const FString& Body);
 	FString HandleAddAnimState(const FString& Body);

--- a/Tools/src/index.ts
+++ b/Tools/src/index.ts
@@ -20,6 +20,7 @@ import { registerUserTypeTools } from "./tools/user-types.js";
 import { registerMaterialReadTools } from "./tools/material-read.js";
 import { registerMaterialMutationTools } from "./tools/material-mutation.js";
 import { registerAnimationTools } from "./tools/animation-mutation.js";
+import { registerEditorUtilityTools } from "./tools/editor-utils.js";
 
 // Resource registrations
 import { registerBlueprintListResource } from "./resources/blueprint-list.js";
@@ -48,6 +49,7 @@ registerUserTypeTools(server);
 registerMaterialReadTools(server);
 registerMaterialMutationTools(server);
 registerAnimationTools(server);
+registerEditorUtilityTools(server);
 
 // Register resources
 registerBlueprintListResource(server);

--- a/Tools/src/tools/editor-utils.ts
+++ b/Tools/src/tools/editor-utils.ts
@@ -1,0 +1,105 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ensureUE, uePost } from "../ue-bridge.js";
+
+export function registerEditorUtilityTools(server: McpServer): void {
+  server.tool(
+    "focus_actor",
+    "Focus the viewport camera on a specific actor, centering it in view and selecting it. Requires editor mode.",
+    {
+      actorLabel: z.string().describe("Label of the actor to focus on in the World Outliner"),
+    },
+    async ({ actorLabel }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/focus-actor", { actorLabel });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        `Focused on '${data.actorLabel}'`,
+        `Location: (${data.location.x}, ${data.location.y}, ${data.location.z})`,
+        `\nNext steps:`,
+        `  1. The actor is now selected and centered in the viewport`,
+        `  2. Use take_screenshot to capture the current view`,
+      ];
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "editor_notification",
+    "Show a toast notification in the UE5 editor. Useful for providing feedback to the user during long operations. Requires editor mode.",
+    {
+      message: z.string().describe("Notification message text"),
+      severity: z.enum(["none", "success", "fail", "pending"]).optional()
+        .describe("Visual style: none (default), success (green check), fail (red X), pending (spinner)"),
+      duration: z.number().optional()
+        .describe("How long to show the notification in seconds (default: 5)"),
+    },
+    async ({ message, severity, duration }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { message };
+      if (severity) body.severity = severity;
+      if (duration !== undefined) body.duration = duration;
+
+      const data = await uePost("/api/editor-notification", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      return { content: [{ type: "text" as const, text: `Notification shown: "${data.message}" (${data.duration}s)` }] };
+    }
+  );
+
+  server.tool(
+    "save_all",
+    "Save all dirty (unsaved) packages in the editor, including maps and content. Requires editor mode.",
+    {},
+    async () => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/save-all", {});
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        data.success ? "All dirty packages saved successfully." : "Save completed with some failures.",
+        `\nNext steps:`,
+        `  1. Use get_dirty_packages to verify no unsaved changes remain`,
+      ];
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "get_dirty_packages",
+    "List all packages with unsaved changes. Useful for checking what needs saving before closing. Requires editor mode.",
+    {},
+    async () => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/get-dirty-packages", {});
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Unsaved packages: ${data.count}`);
+
+      if (data.packages && data.packages.length > 0) {
+        for (const pkg of data.packages) {
+          lines.push(`  - ${pkg.name}`);
+        }
+      } else {
+        lines.push("No unsaved changes.");
+      }
+
+      lines.push(`\nNext steps:`);
+      lines.push(`  1. Use save_all to save all dirty packages`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+}

--- a/Tools/test/tools/editor-utils.test.ts
+++ b/Tools/test/tools/editor-utils.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { uePost } from "../helpers.js";
+
+describe("editor utility tools", () => {
+  describe("focus_actor", () => {
+    it("returns error for missing actorLabel field", async () => {
+      const data = await uePost("/api/focus-actor", {});
+      expect(data.error).toBeDefined();
+      expect(data.error).toContain("actorLabel");
+    });
+
+    it("returns error for non-existent actor", async () => {
+      const data = await uePost("/api/focus-actor", {
+        actorLabel: "NonExistent_Actor_XYZ_999",
+      });
+      expect(data.error).toBeDefined();
+    });
+  });
+
+  describe("editor_notification", () => {
+    it("returns error for missing message field", async () => {
+      const data = await uePost("/api/editor-notification", {});
+      expect(data.error).toBeDefined();
+      expect(data.error).toContain("message");
+    });
+
+    it("succeeds with valid message", async () => {
+      const data = await uePost("/api/editor-notification", {
+        message: "Test notification from MCP",
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+      expect(data.message).toBe("Test notification from MCP");
+    });
+  });
+
+  describe("save_all", () => {
+    it("completes without errors", async () => {
+      const data = await uePost("/api/save-all", {});
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBeDefined();
+    });
+  });
+
+  describe("get_dirty_packages", () => {
+    it("returns package list without errors", async () => {
+      const data = await uePost("/api/get-dirty-packages", {});
+      expect(data.error).toBeUndefined();
+      expect(typeof data.count).toBe("number");
+      expect(Array.isArray(data.packages)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds four editor utility MCP tools for viewport control, notifications, and save management.

| Tool | Description |
|------|-------------|
| `focus_actor` | Focus viewport camera on an actor, select it, and center in view |
| `editor_notification` | Show a toast notification with configurable severity and duration |
| `save_all` | Save all dirty packages (maps + content) without prompts |
| `get_dirty_packages` | List all unsaved packages with their names |

## New files

| File | Purpose |
|------|--------|
| `Source/BlueprintMCP/Private/BlueprintMCPHandlers_EditorUtils.cpp` | C++ handler implementations |
| `Tools/src/tools/editor-utils.ts` | TypeScript MCP tool definitions |
| `Tools/test/tools/editor-utils.test.ts` | Integration tests |

## Integration changes needed

### `BlueprintMCPServer.h`:
```cpp
// ----- Editor utility tools -----
FString HandleFocusActor(const FString& Body);
FString HandleEditorNotification(const FString& Body);
FString HandleSaveAll(const FString& Body);
FString HandleGetDirtyPackages(const FString& Body);
```

### `BlueprintMCPServer.cpp`:

Mutation endpoints (only save_all mutates):
```cpp
TEXT("saveAll"),
```

Route bindings:
```cpp
Router->BindRoute(FHttpPath(TEXT("/api/focus-actor")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("focusActor")));
Router->BindRoute(FHttpPath(TEXT("/api/editor-notification")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("editorNotification")));
Router->BindRoute(FHttpPath(TEXT("/api/save-all")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("saveAll")));
Router->BindRoute(FHttpPath(TEXT("/api/get-dirty-packages")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("getDirtyPackages")));
```

Handler map:
```cpp
HandlerMap.Add(TEXT("focusActor"),          [this](const TMap<FString, FString>&, const FString& B) { return HandleFocusActor(B); });
HandlerMap.Add(TEXT("editorNotification"),  [this](const TMap<FString, FString>&, const FString& B) { return HandleEditorNotification(B); });
HandlerMap.Add(TEXT("saveAll"),             [this](const TMap<FString, FString>&, const FString& B) { return HandleSaveAll(B); });
HandlerMap.Add(TEXT("getDirtyPackages"),    [this](const TMap<FString, FString>&, const FString& B) { return HandleGetDirtyPackages(B); });
```

### `Tools/src/index.ts`:
```typescript
import { registerEditorUtilityTools } from "./tools/editor-utils.js";
registerEditorUtilityTools(server);
```

## Key implementation details

- **focus_actor**: Uses `MoveViewportCamerasToActor` for smooth camera focus, also selects the actor
- **editor_notification**: Uses Slate `FSlateNotificationManager` with configurable completion state (none/success/fail/pending)
- **save_all**: Uses `FEditorFileUtils::SaveDirtyPackages` with prompts disabled for silent saves
- **get_dirty_packages**: Uses `FEditorFileUtils::GetDirtyPackages` to enumerate unsaved packages

## Test plan

- [ ] `focus_actor` centers viewport on a known actor
- [ ] `focus_actor` errors for non-existent actor
- [ ] `editor_notification` displays toast in editor with all severity levels
- [ ] `save_all` saves without errors
- [ ] `get_dirty_packages` returns accurate count before/after save_all
- [ ] `npm run build` succeeds
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)