### PR TITLE
Add selection tools: get/set/clear editor selection

### DIFF
--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_Selection.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_Selection.cpp
@@ -1,0 +1,191 @@
+#include "BlueprintMCPServer.h"
+#include "Editor.h"
+#include "Engine/World.h"
+#include "Engine/Selection.h"
+#include "EngineUtils.h"
+#include "GameFramework/Actor.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+
+// ============================================================
+// HandleGetEditorSelection — get currently selected actors
+// ============================================================
+
+FString FBlueprintMCPServer::HandleGetEditorSelection(const FString& Body)
+{
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: get_editor_selection()"));
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("get_editor_selection requires editor mode."));
+	}
+
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("Editor not available."));
+	}
+
+	USelection* Selection = GEditor->GetSelectedActors();
+	if (!Selection)
+	{
+		return MakeErrorJson(TEXT("Selection object not available."));
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetNumberField(TEXT("count"), Selection->Num());
+
+	TArray<TSharedPtr<FJsonValue>> ActorArray;
+	for (int32 i = 0; i < Selection->Num(); ++i)
+	{
+		AActor* Actor = Cast<AActor>(Selection->GetSelectedObject(i));
+		if (!Actor) continue;
+
+		TSharedRef<FJsonObject> ActorObj = MakeShared<FJsonObject>();
+		ActorObj->SetStringField(TEXT("label"), Actor->GetActorLabel());
+		ActorObj->SetStringField(TEXT("class"), Actor->GetClass()->GetName());
+
+		FVector Loc = Actor->GetActorLocation();
+		TSharedRef<FJsonObject> LocObj = MakeShared<FJsonObject>();
+		LocObj->SetNumberField(TEXT("x"), Loc.X);
+		LocObj->SetNumberField(TEXT("y"), Loc.Y);
+		LocObj->SetNumberField(TEXT("z"), Loc.Z);
+		ActorObj->SetObjectField(TEXT("location"), LocObj);
+
+		ActorArray.Add(MakeShared<FJsonValueObject>(ActorObj));
+	}
+	Result->SetArrayField(TEXT("selectedActors"), ActorArray);
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleSetEditorSelection — select actors by label
+// ============================================================
+
+FString FBlueprintMCPServer::HandleSetEditorSelection(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	const TArray<TSharedPtr<FJsonValue>>* ActorLabelsArray = nullptr;
+	if (!Json->TryGetArrayField(TEXT("actorLabels"), ActorLabelsArray) || !ActorLabelsArray)
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'actorLabels' (array of actor label strings)."));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: set_editor_selection(%d actors)"), ActorLabelsArray->Num());
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("set_editor_selection requires editor mode."));
+	}
+
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("Editor not available."));
+	}
+
+	UWorld* World = GEditor->GetEditorWorldContext().World();
+	if (!World)
+	{
+		return MakeErrorJson(TEXT("No editor world available."));
+	}
+
+	// Clear current selection
+	GEditor->SelectNone(false, true, false);
+
+	TArray<FString> Selected;
+	TArray<FString> NotFound;
+
+	for (const TSharedPtr<FJsonValue>& Value : *ActorLabelsArray)
+	{
+		FString Label = Value->AsString();
+		if (Label.IsEmpty()) continue;
+
+		bool bFound = false;
+		for (TActorIterator<AActor> It(World); It; ++It)
+		{
+			AActor* Actor = *It;
+			if (Actor && (Actor->GetActorLabel() == Label ||
+				Actor->GetActorLabel().Equals(Label, ESearchCase::IgnoreCase)))
+			{
+				GEditor->SelectActor(Actor, true, true);
+				Selected.Add(Actor->GetActorLabel());
+				bFound = true;
+				break;
+			}
+		}
+
+		if (!bFound)
+		{
+			NotFound.Add(Label);
+		}
+	}
+
+	if (GEditor)
+	{
+		GEditor->RedrawAllViewports(true);
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetNumberField(TEXT("selectedCount"), Selected.Num());
+	Result->SetNumberField(TEXT("notFoundCount"), NotFound.Num());
+
+	TArray<TSharedPtr<FJsonValue>> SelectedArray;
+	for (const FString& Label : Selected)
+	{
+		SelectedArray.Add(MakeShared<FJsonValueString>(Label));
+	}
+	Result->SetArrayField(TEXT("selected"), SelectedArray);
+
+	if (NotFound.Num() > 0)
+	{
+		TArray<TSharedPtr<FJsonValue>> NotFoundArray;
+		for (const FString& Label : NotFound)
+		{
+			NotFoundArray.Add(MakeShared<FJsonValueString>(Label));
+		}
+		Result->SetArrayField(TEXT("notFound"), NotFoundArray);
+	}
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleClearSelection — deselect all actors
+// ============================================================
+
+FString FBlueprintMCPServer::HandleClearSelection(const FString& Body)
+{
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: clear_selection()"));
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("clear_selection requires editor mode."));
+	}
+
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("Editor not available."));
+	}
+
+	int32 PreviousCount = GEditor->GetSelectedActors()->Num();
+	GEditor->SelectNone(false, true, false);
+
+	if (GEditor)
+	{
+		GEditor->RedrawAllViewports(true);
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetNumberField(TEXT("previousSelectionCount"), PreviousCount);
+
+	return JsonToString(Result);
+}

--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -793,6 +793,14 @@ bool FBlueprintMCPServer::Start(int32 InPort, bool bEditorMode)
 	Router->BindRoute(FHttpPath(TEXT("/api/exec")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("exec")));
 
+	// Selection tools
+	Router->BindRoute(FHttpPath(TEXT("/api/get-editor-selection")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("getEditorSelection")));
+	Router->BindRoute(FHttpPath(TEXT("/api/set-editor-selection")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("setEditorSelection")));
+	Router->BindRoute(FHttpPath(TEXT("/api/clear-selection")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("clearSelection")));
+
 	// Register TMap dispatch handlers
 	RegisterHandlers();
 
@@ -944,6 +952,8 @@ void FBlueprintMCPServer::RegisterHandlers()
 		TEXT("addAnimNode"),
 		TEXT("addStateMachine"),
 		TEXT("setStateAnimation"),
+		TEXT("setEditorSelection"),
+		TEXT("clearSelection"),
 	};
 
 	// GET handlers (use QueryParams, ignore Body)
@@ -1055,6 +1065,11 @@ void FBlueprintMCPServer::RegisterHandlers()
 
 	// Console command execution
 	HandlerMap.Add(TEXT("exec"),                    [this](const TMap<FString, FString>&, const FString& B) { return HandleExecCommand(B); });
+
+	// Selection handlers
+	HandlerMap.Add(TEXT("getEditorSelection"), [this](const TMap<FString, FString>&, const FString& B) { return HandleGetEditorSelection(B); });
+	HandlerMap.Add(TEXT("setEditorSelection"), [this](const TMap<FString, FString>&, const FString& B) { return HandleSetEditorSelection(B); });
+	HandlerMap.Add(TEXT("clearSelection"), [this](const TMap<FString, FString>&, const FString& B) { return HandleClearSelection(B); });
 }
 
 // ============================================================

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -260,6 +260,12 @@ private:
 	// ----- Console command execution -----
 	FString HandleExecCommand(const FString& Body);
 
+
+	// ----- Selection tools -----
+	FString HandleGetEditorSelection(const FString& Body);
+	FString HandleSetEditorSelection(const FString& Body);
+	FString HandleClearSelection(const FString& Body);
+
 	// ----- Animation Blueprint handlers -----
 	FString HandleCreateAnimBlueprint(const FString& Body);
 	FString HandleAddAnimState(const FString& Body);

--- a/Tools/src/index.ts
+++ b/Tools/src/index.ts
@@ -20,6 +20,7 @@ import { registerUserTypeTools } from "./tools/user-types.js";
 import { registerMaterialReadTools } from "./tools/material-read.js";
 import { registerMaterialMutationTools } from "./tools/material-mutation.js";
 import { registerAnimationTools } from "./tools/animation-mutation.js";
+import { registerSelectionTools } from "./tools/selection.js";
 
 // Resource registrations
 import { registerBlueprintListResource } from "./resources/blueprint-list.js";
@@ -48,6 +49,7 @@ registerUserTypeTools(server);
 registerMaterialReadTools(server);
 registerMaterialMutationTools(server);
 registerAnimationTools(server);
+registerSelectionTools(server);
 
 // Register resources
 registerBlueprintListResource(server);

--- a/Tools/src/tools/selection.ts
+++ b/Tools/src/tools/selection.ts
@@ -1,0 +1,90 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ensureUE, uePost } from "../ue-bridge.js";
+
+export function registerSelectionTools(server: McpServer): void {
+  server.tool(
+    "get_editor_selection",
+    "Get the currently selected actors in the editor. Returns labels, classes, and locations. Requires editor mode.",
+    {},
+    async () => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/get-editor-selection", {});
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Selected actors: ${data.count}`);
+
+      if (data.selectedActors && data.selectedActors.length > 0) {
+        for (const actor of data.selectedActors) {
+          lines.push(`  - ${actor.label} (${actor.class}) at (${actor.location.x}, ${actor.location.y}, ${actor.location.z})`);
+        }
+      } else {
+        lines.push("No actors selected.");
+      }
+
+      lines.push(`\nNext steps:`);
+      lines.push(`  1. Use set_editor_selection to change the selection`);
+      lines.push(`  2. Use clear_selection to deselect all`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "set_editor_selection",
+    "Select specific actors by label. Clears the current selection first. Requires editor mode.",
+    {
+      actorLabels: z.array(z.string()).describe("Array of actor labels to select"),
+    },
+    async ({ actorLabels }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/set-editor-selection", { actorLabels });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        `Selected ${data.selectedCount} actor(s)`,
+      ];
+
+      if (data.selected && data.selected.length > 0) {
+        lines.push(`Selected: ${data.selected.join(", ")}`);
+      }
+
+      if (data.notFoundCount > 0) {
+        lines.push(`Not found (${data.notFoundCount}): ${data.notFound.join(", ")}`);
+      }
+
+      lines.push(`\nNext steps:`);
+      lines.push(`  1. Use get_editor_selection to verify the selection`);
+      lines.push(`  2. Use focus_actor to focus on a selected actor`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "clear_selection",
+    "Deselect all currently selected actors in the editor. Requires editor mode.",
+    {},
+    async () => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/clear-selection", {});
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        `Selection cleared`,
+        `Previously selected: ${data.previousSelectionCount} actor(s)`,
+        `\nNext steps:`,
+        `  1. Use set_editor_selection to select new actors`,
+      ];
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+}

--- a/Tools/test/tools/selection.test.ts
+++ b/Tools/test/tools/selection.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { uePost } from "../helpers.js";
+
+describe("selection tools", () => {
+  describe("get_editor_selection", () => {
+    it("returns selection without errors", async () => {
+      const data = await uePost("/api/get-editor-selection", {});
+      expect(data.error).toBeUndefined();
+      expect(typeof data.count).toBe("number");
+      expect(Array.isArray(data.selectedActors)).toBe(true);
+    });
+  });
+
+  describe("set_editor_selection", () => {
+    it("returns error for missing actorLabels field", async () => {
+      const data = await uePost("/api/set-editor-selection", {});
+      expect(data.error).toBeDefined();
+      expect(data.error).toContain("actorLabels");
+    });
+
+    it("handles non-existent actors gracefully", async () => {
+      const data = await uePost("/api/set-editor-selection", {
+        actorLabels: ["NonExistent_Actor_XYZ_999"],
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.selectedCount).toBe(0);
+      expect(data.notFoundCount).toBe(1);
+    });
+
+    it("accepts empty array", async () => {
+      const data = await uePost("/api/set-editor-selection", {
+        actorLabels: [],
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.selectedCount).toBe(0);
+    });
+  });
+
+  describe("clear_selection", () => {
+    it("clears selection without errors", async () => {
+      const data = await uePost("/api/clear-selection", {});
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+      expect(typeof data.previousSelectionCount).toBe("number");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds three MCP tools for managing the editor's actor selection.

| Tool | Description |
|------|-------------|
| `get_editor_selection` | Get currently selected actors with labels, classes, and locations |
| `set_editor_selection` | Select actors by label array, reports found/not-found counts |
| `clear_selection` | Deselect all actors |

## New files

| File | Purpose |
|------|--------|
| `Source/BlueprintMCP/Private/BlueprintMCPHandlers_Selection.cpp` | C++ handler implementations |
| `Tools/src/tools/selection.ts` | TypeScript MCP tool definitions |
| `Tools/test/tools/selection.test.ts` | Integration tests |

## Integration changes needed

### `BlueprintMCPServer.h`:
```cpp
// ----- Selection tools -----
FString HandleGetEditorSelection(const FString& Body);
FString HandleSetEditorSelection(const FString& Body);
FString HandleClearSelection(const FString& Body);
```

### `BlueprintMCPServer.cpp`:

Mutation endpoints:
```cpp
TEXT("setEditorSelection"),
TEXT("clearSelection"),
```

Route bindings:
```cpp
Router->BindRoute(FHttpPath(TEXT("/api/get-editor-selection")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("getEditorSelection")));
Router->BindRoute(FHttpPath(TEXT("/api/set-editor-selection")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("setEditorSelection")));
Router->BindRoute(FHttpPath(TEXT("/api/clear-selection")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("clearSelection")));
```

Handler map:
```cpp
HandlerMap.Add(TEXT("getEditorSelection"), [this](const TMap<FString, FString>&, const FString& B) { return HandleGetEditorSelection(B); });
HandlerMap.Add(TEXT("setEditorSelection"), [this](const TMap<FString, FString>&, const FString& B) { return HandleSetEditorSelection(B); });
HandlerMap.Add(TEXT("clearSelection"),     [this](const TMap<FString, FString>&, const FString& B) { return HandleClearSelection(B); });
```

### `Tools/src/index.ts`:
```typescript
import { registerSelectionTools } from "./tools/selection.js";
registerSelectionTools(server);
```

## Key implementation details

- **get_editor_selection**: Returns label, class, and world location for each selected actor
- **set_editor_selection**: Clears existing selection first, then selects by label with case-insensitive fallback; reports both selected and not-found actors
- **clear_selection**: Reports previous selection count before clearing

## Test plan

- [ ] `get_editor_selection` returns empty array with no selection
- [ ] `set_editor_selection` selects known actors
- [ ] `set_editor_selection` handles mix of valid/invalid labels
- [ ] `clear_selection` clears and reports previous count
- [ ] `npm run build` succeeds
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)