### PR TITLE
Add camera tools: get/set viewport camera

### DIFF
--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_Camera.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_Camera.cpp
@@ -1,0 +1,149 @@
+#include "BlueprintMCPServer.h"
+#include "Editor.h"
+#include "LevelEditorViewport.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+
+// ============================================================
+// HandleGetViewportCamera — get the viewport camera transform
+// ============================================================
+
+FString FBlueprintMCPServer::HandleGetViewportCamera(const FString& Body)
+{
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: get_viewport_camera()"));
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("get_viewport_camera requires editor mode."));
+	}
+
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("Editor not available."));
+	}
+
+	FLevelEditorViewportClient* ViewportClient = nullptr;
+	if (GEditor->GetLevelViewportClients().Num() > 0)
+	{
+		ViewportClient = GEditor->GetLevelViewportClients()[0];
+	}
+
+	if (!ViewportClient)
+	{
+		return MakeErrorJson(TEXT("No active viewport found."));
+	}
+
+	FVector Location = ViewportClient->GetViewLocation();
+	FRotator Rotation = ViewportClient->GetViewRotation();
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+
+	TSharedRef<FJsonObject> LocObj = MakeShared<FJsonObject>();
+	LocObj->SetNumberField(TEXT("x"), Location.X);
+	LocObj->SetNumberField(TEXT("y"), Location.Y);
+	LocObj->SetNumberField(TEXT("z"), Location.Z);
+	Result->SetObjectField(TEXT("location"), LocObj);
+
+	TSharedRef<FJsonObject> RotObj = MakeShared<FJsonObject>();
+	RotObj->SetNumberField(TEXT("pitch"), Rotation.Pitch);
+	RotObj->SetNumberField(TEXT("yaw"), Rotation.Yaw);
+	RotObj->SetNumberField(TEXT("roll"), Rotation.Roll);
+	Result->SetObjectField(TEXT("rotation"), RotObj);
+
+	Result->SetNumberField(TEXT("fov"), ViewportClient->ViewFOV);
+	Result->SetNumberField(TEXT("cameraSpeed"), ViewportClient->GetCameraSpeedSetting());
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleSetViewportCamera — set the viewport camera transform
+// ============================================================
+
+FString FBlueprintMCPServer::HandleSetViewportCamera(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: set_viewport_camera()"));
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("set_viewport_camera requires editor mode."));
+	}
+
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("Editor not available."));
+	}
+
+	FLevelEditorViewportClient* ViewportClient = nullptr;
+	if (GEditor->GetLevelViewportClients().Num() > 0)
+	{
+		ViewportClient = GEditor->GetLevelViewportClients()[0];
+	}
+
+	if (!ViewportClient)
+	{
+		return MakeErrorJson(TEXT("No active viewport found."));
+	}
+
+	// Parse optional location
+	const TSharedPtr<FJsonObject>* LocObj = nullptr;
+	if (Json->TryGetObjectField(TEXT("location"), LocObj))
+	{
+		double X = 0, Y = 0, Z = 0;
+		(*LocObj)->TryGetNumberField(TEXT("x"), X);
+		(*LocObj)->TryGetNumberField(TEXT("y"), Y);
+		(*LocObj)->TryGetNumberField(TEXT("z"), Z);
+		ViewportClient->SetViewLocation(FVector(X, Y, Z));
+	}
+
+	// Parse optional rotation
+	const TSharedPtr<FJsonObject>* RotObj = nullptr;
+	if (Json->TryGetObjectField(TEXT("rotation"), RotObj))
+	{
+		double Pitch = 0, Yaw = 0, Roll = 0;
+		(*RotObj)->TryGetNumberField(TEXT("pitch"), Pitch);
+		(*RotObj)->TryGetNumberField(TEXT("yaw"), Yaw);
+		(*RotObj)->TryGetNumberField(TEXT("roll"), Roll);
+		ViewportClient->SetViewRotation(FRotator(Pitch, Yaw, Roll));
+	}
+
+	// Parse optional FOV
+	double FOV = 0;
+	if (Json->TryGetNumberField(TEXT("fov"), FOV) && FOV > 0)
+	{
+		ViewportClient->ViewFOV = FOV;
+	}
+
+	ViewportClient->Invalidate();
+
+	// Return current state
+	FVector FinalLoc = ViewportClient->GetViewLocation();
+	FRotator FinalRot = ViewportClient->GetViewRotation();
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+
+	TSharedRef<FJsonObject> FinalLocObj = MakeShared<FJsonObject>();
+	FinalLocObj->SetNumberField(TEXT("x"), FinalLoc.X);
+	FinalLocObj->SetNumberField(TEXT("y"), FinalLoc.Y);
+	FinalLocObj->SetNumberField(TEXT("z"), FinalLoc.Z);
+	Result->SetObjectField(TEXT("location"), FinalLocObj);
+
+	TSharedRef<FJsonObject> FinalRotObj = MakeShared<FJsonObject>();
+	FinalRotObj->SetNumberField(TEXT("pitch"), FinalRot.Pitch);
+	FinalRotObj->SetNumberField(TEXT("yaw"), FinalRot.Yaw);
+	FinalRotObj->SetNumberField(TEXT("roll"), FinalRot.Roll);
+	Result->SetObjectField(TEXT("rotation"), FinalRotObj);
+
+	Result->SetNumberField(TEXT("fov"), ViewportClient->ViewFOV);
+
+	return JsonToString(Result);
+}

--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -793,6 +793,12 @@ bool FBlueprintMCPServer::Start(int32 InPort, bool bEditorMode)
 	Router->BindRoute(FHttpPath(TEXT("/api/exec")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("exec")));
 
+	// Camera tools
+	Router->BindRoute(FHttpPath(TEXT("/api/get-viewport-camera")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("getViewportCamera")));
+	Router->BindRoute(FHttpPath(TEXT("/api/set-viewport-camera")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("setViewportCamera")));
+
 	// Register TMap dispatch handlers
 	RegisterHandlers();
 
@@ -944,6 +950,7 @@ void FBlueprintMCPServer::RegisterHandlers()
 		TEXT("addAnimNode"),
 		TEXT("addStateMachine"),
 		TEXT("setStateAnimation"),
+		TEXT("setViewportCamera"),
 	};
 
 	// GET handlers (use QueryParams, ignore Body)
@@ -1055,6 +1062,10 @@ void FBlueprintMCPServer::RegisterHandlers()
 
 	// Console command execution
 	HandlerMap.Add(TEXT("exec"),                    [this](const TMap<FString, FString>&, const FString& B) { return HandleExecCommand(B); });
+
+	// Camera handlers
+	HandlerMap.Add(TEXT("getViewportCamera"), [this](const TMap<FString, FString>&, const FString& B) { return HandleGetViewportCamera(B); });
+	HandlerMap.Add(TEXT("setViewportCamera"), [this](const TMap<FString, FString>&, const FString& B) { return HandleSetViewportCamera(B); });
 }
 
 // ============================================================

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -260,6 +260,11 @@ private:
 	// ----- Console command execution -----
 	FString HandleExecCommand(const FString& Body);
 
+
+	// ----- Camera tools -----
+	FString HandleGetViewportCamera(const FString& Body);
+	FString HandleSetViewportCamera(const FString& Body);
+
 	// ----- Animation Blueprint handlers -----
 	FString HandleCreateAnimBlueprint(const FString& Body);
 	FString HandleAddAnimState(const FString& Body);

--- a/Tools/src/index.ts
+++ b/Tools/src/index.ts
@@ -20,6 +20,7 @@ import { registerUserTypeTools } from "./tools/user-types.js";
 import { registerMaterialReadTools } from "./tools/material-read.js";
 import { registerMaterialMutationTools } from "./tools/material-mutation.js";
 import { registerAnimationTools } from "./tools/animation-mutation.js";
+import { registerCameraTools } from "./tools/camera.js";
 
 // Resource registrations
 import { registerBlueprintListResource } from "./resources/blueprint-list.js";
@@ -48,6 +49,7 @@ registerUserTypeTools(server);
 registerMaterialReadTools(server);
 registerMaterialMutationTools(server);
 registerAnimationTools(server);
+registerCameraTools(server);
 
 // Register resources
 registerBlueprintListResource(server);

--- a/Tools/src/tools/camera.ts
+++ b/Tools/src/tools/camera.ts
@@ -1,0 +1,73 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ensureUE, uePost } from "../ue-bridge.js";
+
+export function registerCameraTools(server: McpServer): void {
+  server.tool(
+    "get_viewport_camera",
+    "Get the current viewport camera position, rotation, FOV, and speed. Requires editor mode.",
+    {},
+    async () => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/get-viewport-camera", {});
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        `Viewport Camera:`,
+        `  Location: (${data.location.x.toFixed(1)}, ${data.location.y.toFixed(1)}, ${data.location.z.toFixed(1)})`,
+        `  Rotation: pitch=${data.rotation.pitch.toFixed(1)}, yaw=${data.rotation.yaw.toFixed(1)}, roll=${data.rotation.roll.toFixed(1)}`,
+        `  FOV: ${data.fov.toFixed(1)}`,
+        `  Camera speed: ${data.cameraSpeed}`,
+        `\nNext steps:`,
+        `  1. Use set_viewport_camera to reposition the camera`,
+        `  2. Use take_screenshot to capture this view`,
+      ];
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "set_viewport_camera",
+    "Set the viewport camera position, rotation, and/or FOV. All parameters are optional \u2014 only provided values are changed. Requires editor mode.",
+    {
+      location: z.object({
+        x: z.number().describe("X coordinate"),
+        y: z.number().describe("Y coordinate"),
+        z: z.number().describe("Z coordinate"),
+      }).optional().describe("Camera world position"),
+      rotation: z.object({
+        pitch: z.number().describe("Pitch in degrees (up/down)"),
+        yaw: z.number().describe("Yaw in degrees (left/right)"),
+        roll: z.number().optional().describe("Roll in degrees (default: 0)"),
+      }).optional().describe("Camera rotation in degrees"),
+      fov: z.number().optional().describe("Field of view in degrees (typical: 60-120)"),
+    },
+    async ({ location, rotation, fov }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = {};
+      if (location) body.location = location;
+      if (rotation) body.rotation = { pitch: rotation.pitch, yaw: rotation.yaw, roll: rotation.roll ?? 0 };
+      if (fov !== undefined) body.fov = fov;
+
+      const data = await uePost("/api/set-viewport-camera", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        `Camera updated:`,
+        `  Location: (${data.location.x.toFixed(1)}, ${data.location.y.toFixed(1)}, ${data.location.z.toFixed(1)})`,
+        `  Rotation: pitch=${data.rotation.pitch.toFixed(1)}, yaw=${data.rotation.yaw.toFixed(1)}, roll=${data.rotation.roll.toFixed(1)}`,
+        `  FOV: ${data.fov.toFixed(1)}`,
+        `\nNext steps:`,
+        `  1. Use get_viewport_camera to verify the position`,
+        `  2. Use take_screenshot to capture this view`,
+      ];
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+}

--- a/Tools/test/tools/camera.test.ts
+++ b/Tools/test/tools/camera.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { uePost } from "../helpers.js";
+
+describe("camera tools", () => {
+  describe("get_viewport_camera", () => {
+    it("returns camera info without errors", async () => {
+      const data = await uePost("/api/get-viewport-camera", {});
+      expect(data.error).toBeUndefined();
+      expect(data.location).toBeDefined();
+      expect(typeof data.location.x).toBe("number");
+      expect(typeof data.location.y).toBe("number");
+      expect(typeof data.location.z).toBe("number");
+      expect(data.rotation).toBeDefined();
+      expect(typeof data.rotation.pitch).toBe("number");
+      expect(typeof data.rotation.yaw).toBe("number");
+      expect(typeof data.fov).toBe("number");
+    });
+  });
+
+  describe("set_viewport_camera", () => {
+    it("sets camera location", async () => {
+      const data = await uePost("/api/set-viewport-camera", {
+        location: { x: 100, y: 200, z: 300 },
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+      expect(data.location).toBeDefined();
+    });
+
+    it("sets camera rotation", async () => {
+      const data = await uePost("/api/set-viewport-camera", {
+        rotation: { pitch: -30, yaw: 45, roll: 0 },
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+      expect(data.rotation).toBeDefined();
+    });
+
+    it("accepts empty body (no changes)", async () => {
+      const data = await uePost("/api/set-viewport-camera", {});
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds two MCP tools for controlling the editor viewport camera.

| Tool | Description |
|------|-------------|
| `get_viewport_camera` | Get camera location, rotation, FOV, and speed |
| `set_viewport_camera` | Set camera location, rotation, and/or FOV (all optional) |

## New files

| File | Purpose |
|------|--------|
| `Source/BlueprintMCP/Private/BlueprintMCPHandlers_Camera.cpp` | C++ handler implementations |
| `Tools/src/tools/camera.ts` | TypeScript MCP tool definitions |
| `Tools/test/tools/camera.test.ts` | Integration tests |

## Integration changes needed

### `BlueprintMCPServer.h`:
```cpp
// ----- Camera tools -----
FString HandleGetViewportCamera(const FString& Body);
FString HandleSetViewportCamera(const FString& Body);
```

### `BlueprintMCPServer.cpp`:

Mutation endpoints:
```cpp
TEXT("setViewportCamera"),
```

Route bindings:
```cpp
Router->BindRoute(FHttpPath(TEXT("/api/get-viewport-camera")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("getViewportCamera")));
Router->BindRoute(FHttpPath(TEXT("/api/set-viewport-camera")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("setViewportCamera")));
```

Handler map:
```cpp
HandlerMap.Add(TEXT("getViewportCamera"), [this](const TMap<FString, FString>&, const FString& B) { return HandleGetViewportCamera(B); });
HandlerMap.Add(TEXT("setViewportCamera"), [this](const TMap<FString, FString>&, const FString& B) { return HandleSetViewportCamera(B); });
```

### `Tools/src/index.ts`:
```typescript
import { registerCameraTools } from "./tools/camera.js";
registerCameraTools(server);
```

## Key implementation details

- Uses `FLevelEditorViewportClient` (first active viewport)
- `set_viewport_camera` is incremental: only provided fields are updated
- Returns final camera state after setting, so caller can verify
- Supports location (XYZ), rotation (pitch/yaw/roll), and FOV

## Test plan

- [ ] `get_viewport_camera` returns valid transform data
- [ ] `set_viewport_camera` with location moves the camera
- [ ] `set_viewport_camera` with rotation rotates the camera
- [ ] `set_viewport_camera` with FOV changes field of view
- [ ] Empty body accepted (no-op)
- [ ] `npm run build` succeeds
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)