### PR TITLE
Add CVar tools: get_cvar, set_cvar, list_cvars

### DIFF
--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_CVars.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_CVars.cpp
@@ -1,0 +1,201 @@
+#include "BlueprintMCPServer.h"
+#include "HAL/IConsoleManager.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+
+// ============================================================
+// HandleGetCVar — get a console variable value
+// ============================================================
+
+FString FBlueprintMCPServer::HandleGetCVar(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	FString Name;
+	if (!Json->TryGetStringField(TEXT("name"), Name) || Name.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'name' (console variable name)."));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: get_cvar('%s')"), *Name);
+
+	IConsoleVariable* CVar = IConsoleManager::Get().FindConsoleVariable(*Name);
+	if (!CVar)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Console variable '%s' not found. Use list_cvars to search."), *Name));
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetStringField(TEXT("name"), Name);
+	Result->SetStringField(TEXT("value"), CVar->GetString());
+
+	// Try to determine the type
+	if (CVar->IsVariableInt())
+	{
+		Result->SetStringField(TEXT("type"), TEXT("int"));
+		Result->SetNumberField(TEXT("intValue"), CVar->GetInt());
+	}
+	else if (CVar->IsVariableFloat())
+	{
+		Result->SetStringField(TEXT("type"), TEXT("float"));
+		Result->SetNumberField(TEXT("floatValue"), CVar->GetFloat());
+	}
+	else
+	{
+		Result->SetStringField(TEXT("type"), TEXT("string"));
+	}
+
+	// Get help text
+	FString Help = CVar->GetHelp();
+	if (!Help.IsEmpty())
+	{
+		Result->SetStringField(TEXT("help"), Help);
+	}
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleSetCVar — set a console variable value
+// ============================================================
+
+FString FBlueprintMCPServer::HandleSetCVar(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	FString Name;
+	if (!Json->TryGetStringField(TEXT("name"), Name) || Name.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'name' (console variable name)."));
+	}
+
+	FString Value;
+	if (!Json->TryGetStringField(TEXT("value"), Value))
+	{
+		// Try numeric value
+		double NumValue = 0;
+		if (Json->TryGetNumberField(TEXT("value"), NumValue))
+		{
+			Value = FString::SanitizeFloat(NumValue);
+		}
+		else
+		{
+			// Try bool value
+			bool BoolValue = false;
+			if (Json->TryGetBoolField(TEXT("value"), BoolValue))
+			{
+				Value = BoolValue ? TEXT("1") : TEXT("0");
+			}
+			else
+			{
+				return MakeErrorJson(TEXT("Missing required field: 'value'."));
+			}
+		}
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: set_cvar('%s', '%s')"), *Name, *Value);
+
+	IConsoleVariable* CVar = IConsoleManager::Get().FindConsoleVariable(*Name);
+	if (!CVar)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Console variable '%s' not found. Use list_cvars to search."), *Name));
+	}
+
+	FString PreviousValue = CVar->GetString();
+	CVar->Set(*Value, ECVF_SetByConsole);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("name"), Name);
+	Result->SetStringField(TEXT("previousValue"), PreviousValue);
+	Result->SetStringField(TEXT("newValue"), CVar->GetString());
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleListCVars — search/list console variables
+// ============================================================
+
+FString FBlueprintMCPServer::HandleListCVars(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	FString Filter;
+	Json->TryGetStringField(TEXT("filter"), Filter);
+
+	int32 MaxResults = 50;
+	double MaxResultsDouble = 50;
+	if (Json->TryGetNumberField(TEXT("maxResults"), MaxResultsDouble))
+	{
+		MaxResults = FMath::Clamp((int32)MaxResultsDouble, 1, 500);
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: list_cvars(filter='%s', max=%d)"), *Filter, MaxResults);
+
+	TArray<TSharedPtr<FJsonValue>> CVarArray;
+	int32 TotalMatches = 0;
+
+	IConsoleManager::Get().ForEachConsoleObjectThatStartsWith(
+		FConsoleObjectVisitor::CreateLambda(
+			[&](const TCHAR* Name, IConsoleObject* Object)
+			{
+				IConsoleVariable* CVar = Object->AsVariable();
+				if (!CVar) return;
+
+				FString NameStr(Name);
+
+				// Apply filter if specified
+				if (!Filter.IsEmpty() && !NameStr.Contains(Filter, ESearchCase::IgnoreCase))
+				{
+					return;
+				}
+
+				TotalMatches++;
+
+				if (CVarArray.Num() >= MaxResults) return;
+
+				TSharedRef<FJsonObject> CVarObj = MakeShared<FJsonObject>();
+				CVarObj->SetStringField(TEXT("name"), NameStr);
+				CVarObj->SetStringField(TEXT("value"), CVar->GetString());
+
+				FString Help = CVar->GetHelp();
+				if (!Help.IsEmpty())
+				{
+					// Truncate long help text
+					if (Help.Len() > 200)
+					{
+						Help = Help.Left(200) + TEXT("...");
+					}
+					CVarObj->SetStringField(TEXT("help"), Help);
+				}
+
+				CVarArray.Add(MakeShared<FJsonValueObject>(CVarObj));
+			}),
+		TEXT(""));
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetNumberField(TEXT("count"), CVarArray.Num());
+	Result->SetNumberField(TEXT("totalMatches"), TotalMatches);
+	Result->SetArrayField(TEXT("cvars"), CVarArray);
+	if (!Filter.IsEmpty())
+	{
+		Result->SetStringField(TEXT("filter"), Filter);
+	}
+
+	return JsonToString(Result);
+}

--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -793,6 +793,14 @@ bool FBlueprintMCPServer::Start(int32 InPort, bool bEditorMode)
 	Router->BindRoute(FHttpPath(TEXT("/api/exec")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("exec")));
 
+	// CVar tools
+	Router->BindRoute(FHttpPath(TEXT("/api/get-cvar")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("getCVar")));
+	Router->BindRoute(FHttpPath(TEXT("/api/set-cvar")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("setCVar")));
+	Router->BindRoute(FHttpPath(TEXT("/api/list-cvars")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("listCVars")));
+
 	// Register TMap dispatch handlers
 	RegisterHandlers();
 
@@ -944,6 +952,7 @@ void FBlueprintMCPServer::RegisterHandlers()
 		TEXT("addAnimNode"),
 		TEXT("addStateMachine"),
 		TEXT("setStateAnimation"),
+		TEXT("setCVar"),
 	};
 
 	// GET handlers (use QueryParams, ignore Body)
@@ -1055,6 +1064,11 @@ void FBlueprintMCPServer::RegisterHandlers()
 
 	// Console command execution
 	HandlerMap.Add(TEXT("exec"),                    [this](const TMap<FString, FString>&, const FString& B) { return HandleExecCommand(B); });
+
+	// CVar handlers
+	HandlerMap.Add(TEXT("getCVar"), [this](const TMap<FString, FString>&, const FString& B) { return HandleGetCVar(B); });
+	HandlerMap.Add(TEXT("setCVar"), [this](const TMap<FString, FString>&, const FString& B) { return HandleSetCVar(B); });
+	HandlerMap.Add(TEXT("listCVars"), [this](const TMap<FString, FString>&, const FString& B) { return HandleListCVars(B); });
 }
 
 // ============================================================

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -260,6 +260,12 @@ private:
 	// ----- Console command execution -----
 	FString HandleExecCommand(const FString& Body);
 
+
+	// ----- CVar tools -----
+	FString HandleGetCVar(const FString& Body);
+	FString HandleSetCVar(const FString& Body);
+	FString HandleListCVars(const FString& Body);
+
 	// ----- Animation Blueprint handlers -----
 	FString HandleCreateAnimBlueprint(const FString& Body);
 	FString HandleAddAnimState(const FString& Body);

--- a/Tools/src/index.ts
+++ b/Tools/src/index.ts
@@ -20,6 +20,7 @@ import { registerUserTypeTools } from "./tools/user-types.js";
 import { registerMaterialReadTools } from "./tools/material-read.js";
 import { registerMaterialMutationTools } from "./tools/material-mutation.js";
 import { registerAnimationTools } from "./tools/animation-mutation.js";
+import { registerCVarTools } from "./tools/cvars.js";
 
 // Resource registrations
 import { registerBlueprintListResource } from "./resources/blueprint-list.js";
@@ -48,6 +49,7 @@ registerUserTypeTools(server);
 registerMaterialReadTools(server);
 registerMaterialMutationTools(server);
 registerAnimationTools(server);
+registerCVarTools(server);
 
 // Register resources
 registerBlueprintListResource(server);

--- a/Tools/src/tools/cvars.ts
+++ b/Tools/src/tools/cvars.ts
@@ -1,0 +1,99 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ensureUE, uePost } from "../ue-bridge.js";
+
+export function registerCVarTools(server: McpServer): void {
+  server.tool(
+    "get_cvar",
+    "Get the current value of a console variable (CVar). Returns the value, type, and help text. Works in both editor and commandlet mode.",
+    {
+      name: z.string().describe("Console variable name (e.g., 'r.ScreenPercentage', 'r.VSync')"),
+    },
+    async ({ name }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/get-cvar", { name });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        `${data.name} = ${data.value}`,
+        `Type: ${data.type}`,
+      ];
+      if (data.help) lines.push(`Help: ${data.help}`);
+      lines.push(`\nNext steps:`);
+      lines.push(`  1. Use set_cvar to change the value`);
+      lines.push(`  2. Use list_cvars to find related variables`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "set_cvar",
+    "Set a console variable (CVar) to a new value. Returns the previous and new values. Works in both editor and commandlet mode.",
+    {
+      name: z.string().describe("Console variable name"),
+      value: z.union([z.string(), z.number(), z.boolean()])
+        .describe("New value for the CVar (string, number, or boolean)"),
+    },
+    async ({ name, value }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/set-cvar", { name, value: String(value) });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        `${data.name}: ${data.previousValue} -> ${data.newValue}`,
+        `\nNext steps:`,
+        `  1. Use get_cvar to verify the change`,
+        `  2. Note: some CVars require editor restart to take effect`,
+      ];
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "list_cvars",
+    "Search and list console variables (CVars). Filter by name substring. Returns name, value, and help text. Works in both editor and commandlet mode.",
+    {
+      filter: z.string().optional()
+        .describe("Substring filter for CVar names (e.g., 'r.Shadow' to find shadow-related CVars)"),
+      maxResults: z.number().optional()
+        .describe("Maximum number of results to return (default: 50, max: 500)"),
+    },
+    async ({ filter, maxResults }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = {};
+      if (filter) body.filter = filter;
+      if (maxResults !== undefined) body.maxResults = maxResults;
+
+      const data = await uePost("/api/list-cvars", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      if (data.filter) {
+        lines.push(`CVars matching '${data.filter}': ${data.totalMatches} total, showing ${data.count}`);
+      } else {
+        lines.push(`CVars: ${data.totalMatches} total, showing ${data.count}`);
+      }
+
+      if (data.cvars && data.cvars.length > 0) {
+        for (const cvar of data.cvars) {
+          lines.push(`  ${cvar.name} = ${cvar.value}`);
+          if (cvar.help) lines.push(`    ${cvar.help}`);
+        }
+      }
+
+      if (data.totalMatches > data.count) {
+        lines.push(`\n  ... and ${data.totalMatches - data.count} more. Use a more specific filter or increase maxResults.`);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+}

--- a/Tools/test/tools/cvars.test.ts
+++ b/Tools/test/tools/cvars.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { uePost } from "../helpers.js";
+
+describe("cvar tools", () => {
+  describe("get_cvar", () => {
+    it("returns error for missing name field", async () => {
+      const data = await uePost("/api/get-cvar", {});
+      expect(data.error).toBeDefined();
+      expect(data.error).toContain("name");
+    });
+
+    it("returns error for non-existent cvar", async () => {
+      const data = await uePost("/api/get-cvar", {
+        name: "nonexistent.cvar.xyz.999",
+      });
+      expect(data.error).toBeDefined();
+    });
+
+    it("gets a known cvar", async () => {
+      const data = await uePost("/api/get-cvar", { name: "r.VSync" });
+      // r.VSync may or may not exist depending on build, so just check structure
+      if (!data.error) {
+        expect(data.name).toBe("r.VSync");
+        expect(data.value).toBeDefined();
+        expect(data.type).toBeDefined();
+      }
+    });
+  });
+
+  describe("set_cvar", () => {
+    it("returns error for missing name field", async () => {
+      const data = await uePost("/api/set-cvar", { value: "1" });
+      expect(data.error).toBeDefined();
+      expect(data.error).toContain("name");
+    });
+
+    it("returns error for missing value field", async () => {
+      const data = await uePost("/api/set-cvar", { name: "r.VSync" });
+      expect(data.error).toBeDefined();
+      expect(data.error).toContain("value");
+    });
+
+    it("returns error for non-existent cvar", async () => {
+      const data = await uePost("/api/set-cvar", {
+        name: "nonexistent.cvar.xyz.999",
+        value: "1",
+      });
+      expect(data.error).toBeDefined();
+    });
+  });
+
+  describe("list_cvars", () => {
+    it("returns cvar list without filter", async () => {
+      const data = await uePost("/api/list-cvars", {});
+      expect(data.error).toBeUndefined();
+      expect(typeof data.count).toBe("number");
+      expect(typeof data.totalMatches).toBe("number");
+      expect(Array.isArray(data.cvars)).toBe(true);
+    });
+
+    it("filters by name substring", async () => {
+      const data = await uePost("/api/list-cvars", { filter: "r.Shadow" });
+      expect(data.error).toBeUndefined();
+      expect(data.filter).toBe("r.Shadow");
+      // All returned CVars should contain the filter string
+      if (data.cvars && data.cvars.length > 0) {
+        for (const cvar of data.cvars) {
+          expect(cvar.name.toLowerCase()).toContain("r.shadow");
+        }
+      }
+    });
+
+    it("respects maxResults", async () => {
+      const data = await uePost("/api/list-cvars", { maxResults: 5 });
+      expect(data.error).toBeUndefined();
+      expect(data.cvars.length).toBeLessThanOrEqual(5);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds three MCP tools for reading, writing, and searching UE5 console variables (CVars).

| Tool | Description |
|------|-------------|
| `get_cvar` | Get a CVar's value, type (int/float/string), and help text |
| `set_cvar` | Set a CVar to a new value; supports string, number, and boolean inputs |
| `list_cvars` | Search CVars by name substring with pagination |

## New files

| File | Purpose |
|------|--------|
| `Source/BlueprintMCP/Private/BlueprintMCPHandlers_CVars.cpp` | C++ handler implementations |
| `Tools/src/tools/cvars.ts` | TypeScript MCP tool definitions |
| `Tools/test/tools/cvars.test.ts` | Integration tests |

## Integration changes needed

### `BlueprintMCPServer.h`:
```cpp
// ----- CVar tools -----
FString HandleGetCVar(const FString& Body);
FString HandleSetCVar(const FString& Body);
FString HandleListCVars(const FString& Body);
```

### `BlueprintMCPServer.cpp`:

Mutation endpoints:
```cpp
TEXT("setCVar"),
```

Route bindings:
```cpp
Router->BindRoute(FHttpPath(TEXT("/api/get-cvar")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("getCVar")));
Router->BindRoute(FHttpPath(TEXT("/api/set-cvar")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("setCVar")));
Router->BindRoute(FHttpPath(TEXT("/api/list-cvars")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("listCVars")));
```

Handler map:
```cpp
HandlerMap.Add(TEXT("getCVar"),   [this](const TMap<FString, FString>&, const FString& B) { return HandleGetCVar(B); });
HandlerMap.Add(TEXT("setCVar"),   [this](const TMap<FString, FString>&, const FString& B) { return HandleSetCVar(B); });
HandlerMap.Add(TEXT("listCVars"), [this](const TMap<FString, FString>&, const FString& B) { return HandleListCVars(B); });
```

### `Tools/src/index.ts`:
```typescript
import { registerCVarTools } from "./tools/cvars.js";
registerCVarTools(server);
```

## Key implementation details

- **Type detection**: `get_cvar` reports int/float/string type and provides typed values
- **Flexible value input**: `set_cvar` accepts string, number, or boolean values in JSON
- **Efficient search**: `list_cvars` uses `ForEachConsoleObjectThatStartsWith` with substring filtering and pagination (default 50, max 500)
- **Help text**: Included where available, truncated to 200 chars in list results
- These tools work in both editor and commandlet mode (CVars don't require editor)

## Test plan

- [ ] `get_cvar` returns value and type for a known CVar (e.g., `r.VSync`)
- [ ] `get_cvar` errors for non-existent CVars
- [ ] `set_cvar` changes a CVar value and reports previous/new
- [ ] `list_cvars` returns paginated results
- [ ] `list_cvars` with filter narrows results correctly
- [ ] `npm run build` succeeds
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)