### PR TITLE
Add output log tools: get_output_log, clear_output_log

### DIFF
--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_OutputLog.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_OutputLog.cpp
@@ -1,0 +1,175 @@
+#include "BlueprintMCPServer.h"
+#include "Misc/OutputDeviceRedirector.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+
+// ============================================================
+// Custom output device to capture log messages
+// ============================================================
+
+class FMCPLogCapture : public FOutputDevice
+{
+public:
+	struct FLogEntry
+	{
+		FString Message;
+		FString Category;
+		ELogVerbosity::Type Verbosity;
+		double Timestamp;
+	};
+
+	TArray<FLogEntry> Entries;
+	FCriticalSection EntriesLock;
+	int32 MaxEntries = 1000;
+	bool bCapturing = false;
+
+	void StartCapture()
+	{
+		FScopeLock Lock(&EntriesLock);
+		Entries.Reset();
+		bCapturing = true;
+		GLog->AddOutputDevice(this);
+	}
+
+	void StopCapture()
+	{
+		bCapturing = false;
+		GLog->RemoveOutputDevice(this);
+	}
+
+	virtual void Serialize(const TCHAR* V, ELogVerbosity::Type Verbosity, const FName& Category) override
+	{
+		if (!bCapturing) return;
+
+		FScopeLock Lock(&EntriesLock);
+		if (Entries.Num() >= MaxEntries)
+		{
+			// Remove oldest entries
+			Entries.RemoveAt(0, Entries.Num() / 4);
+		}
+
+		FLogEntry Entry;
+		Entry.Message = FString(V);
+		Entry.Category = Category.ToString();
+		Entry.Verbosity = Verbosity;
+		Entry.Timestamp = FPlatformTime::Seconds();
+		Entries.Add(MoveTemp(Entry));
+	}
+};
+
+static FMCPLogCapture GLogCapture;
+
+// ============================================================
+// HandleGetOutputLog — get recent output log entries
+// ============================================================
+
+FString FBlueprintMCPServer::HandleGetOutputLog(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	int32 MaxLines = 100;
+	double MaxLinesDouble = 100;
+	if (Json->TryGetNumberField(TEXT("maxLines"), MaxLinesDouble))
+	{
+		MaxLines = FMath::Clamp((int32)MaxLinesDouble, 1, 1000);
+	}
+
+	FString Filter;
+	Json->TryGetStringField(TEXT("filter"), Filter);
+
+	FString VerbosityFilter;
+	Json->TryGetStringField(TEXT("verbosity"), VerbosityFilter);
+
+	// Start capturing if not already
+	if (!GLogCapture.bCapturing)
+	{
+		GLogCapture.StartCapture();
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: get_output_log(maxLines=%d)"), MaxLines);
+
+	FScopeLock Lock(&GLogCapture.EntriesLock);
+
+	auto VerbosityToString = [](ELogVerbosity::Type V) -> FString {
+		switch (V)
+		{
+		case ELogVerbosity::Fatal:   return TEXT("Fatal");
+		case ELogVerbosity::Error:   return TEXT("Error");
+		case ELogVerbosity::Warning: return TEXT("Warning");
+		case ELogVerbosity::Display: return TEXT("Display");
+		case ELogVerbosity::Log:     return TEXT("Log");
+		case ELogVerbosity::Verbose: return TEXT("Verbose");
+		default:                     return TEXT("Unknown");
+		}
+	};
+
+	TArray<TSharedPtr<FJsonValue>> LogArray;
+	// Iterate from end to get most recent entries
+	int32 StartIdx = FMath::Max(0, GLogCapture.Entries.Num() - MaxLines * 2); // overscan for filtering
+	for (int32 i = GLogCapture.Entries.Num() - 1; i >= StartIdx && LogArray.Num() < MaxLines; --i)
+	{
+		const FMCPLogCapture::FLogEntry& Entry = GLogCapture.Entries[i];
+
+		// Apply verbosity filter
+		if (!VerbosityFilter.IsEmpty())
+		{
+			if (VerbosityFilter.Equals(TEXT("Error"), ESearchCase::IgnoreCase) &&
+				Entry.Verbosity != ELogVerbosity::Error && Entry.Verbosity != ELogVerbosity::Fatal)
+			{
+				continue;
+			}
+			if (VerbosityFilter.Equals(TEXT("Warning"), ESearchCase::IgnoreCase) &&
+				Entry.Verbosity != ELogVerbosity::Warning)
+			{
+				continue;
+			}
+		}
+
+		// Apply text filter
+		if (!Filter.IsEmpty() && !Entry.Message.Contains(Filter, ESearchCase::IgnoreCase) &&
+			!Entry.Category.Contains(Filter, ESearchCase::IgnoreCase))
+		{
+			continue;
+		}
+
+		TSharedRef<FJsonObject> LogObj = MakeShared<FJsonObject>();
+		LogObj->SetStringField(TEXT("message"), Entry.Message);
+		LogObj->SetStringField(TEXT("category"), Entry.Category);
+		LogObj->SetStringField(TEXT("verbosity"), VerbosityToString(Entry.Verbosity));
+
+		LogArray.Insert(MakeShared<FJsonValueObject>(LogObj), 0); // Insert at front to maintain order
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetNumberField(TEXT("count"), LogArray.Num());
+	Result->SetNumberField(TEXT("totalCaptured"), GLogCapture.Entries.Num());
+	Result->SetArrayField(TEXT("entries"), LogArray);
+	Result->SetBoolField(TEXT("capturing"), GLogCapture.bCapturing);
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleClearOutputLog — clear captured log entries
+// ============================================================
+
+FString FBlueprintMCPServer::HandleClearOutputLog(const FString& Body)
+{
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: clear_output_log()"));
+
+	FScopeLock Lock(&GLogCapture.EntriesLock);
+	int32 PreviousCount = GLogCapture.Entries.Num();
+	GLogCapture.Entries.Reset();
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetNumberField(TEXT("clearedEntries"), PreviousCount);
+
+	return JsonToString(Result);
+}

--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -793,6 +793,12 @@ bool FBlueprintMCPServer::Start(int32 InPort, bool bEditorMode)
 	Router->BindRoute(FHttpPath(TEXT("/api/exec")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("exec")));
 
+	// Output log tools
+	Router->BindRoute(FHttpPath(TEXT("/api/get-output-log")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("getOutputLog")));
+	Router->BindRoute(FHttpPath(TEXT("/api/clear-output-log")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("clearOutputLog")));
+
 	// Register TMap dispatch handlers
 	RegisterHandlers();
 
@@ -944,6 +950,7 @@ void FBlueprintMCPServer::RegisterHandlers()
 		TEXT("addAnimNode"),
 		TEXT("addStateMachine"),
 		TEXT("setStateAnimation"),
+		TEXT("clearOutputLog"),
 	};
 
 	// GET handlers (use QueryParams, ignore Body)
@@ -1055,6 +1062,10 @@ void FBlueprintMCPServer::RegisterHandlers()
 
 	// Console command execution
 	HandlerMap.Add(TEXT("exec"),                    [this](const TMap<FString, FString>&, const FString& B) { return HandleExecCommand(B); });
+
+	// Output log handlers
+	HandlerMap.Add(TEXT("getOutputLog"), [this](const TMap<FString, FString>&, const FString& B) { return HandleGetOutputLog(B); });
+	HandlerMap.Add(TEXT("clearOutputLog"), [this](const TMap<FString, FString>&, const FString& B) { return HandleClearOutputLog(B); });
 }
 
 // ============================================================

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -260,6 +260,11 @@ private:
 	// ----- Console command execution -----
 	FString HandleExecCommand(const FString& Body);
 
+
+	// ----- Output log tools -----
+	FString HandleGetOutputLog(const FString& Body);
+	FString HandleClearOutputLog(const FString& Body);
+
 	// ----- Animation Blueprint handlers -----
 	FString HandleCreateAnimBlueprint(const FString& Body);
 	FString HandleAddAnimState(const FString& Body);

--- a/Tools/src/index.ts
+++ b/Tools/src/index.ts
@@ -20,6 +20,7 @@ import { registerUserTypeTools } from "./tools/user-types.js";
 import { registerMaterialReadTools } from "./tools/material-read.js";
 import { registerMaterialMutationTools } from "./tools/material-mutation.js";
 import { registerAnimationTools } from "./tools/animation-mutation.js";
+import { registerOutputLogTools } from "./tools/output-log.js";
 
 // Resource registrations
 import { registerBlueprintListResource } from "./resources/blueprint-list.js";
@@ -48,6 +49,7 @@ registerUserTypeTools(server);
 registerMaterialReadTools(server);
 registerMaterialMutationTools(server);
 registerAnimationTools(server);
+registerOutputLogTools(server);
 
 // Register resources
 registerBlueprintListResource(server);

--- a/Tools/src/tools/output-log.ts
+++ b/Tools/src/tools/output-log.ts
@@ -1,0 +1,73 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ensureUE, uePost } from "../ue-bridge.js";
+
+export function registerOutputLogTools(server: McpServer): void {
+  server.tool(
+    "get_output_log",
+    "Get recent output log entries from the UE5 editor/commandlet. Captures log messages in a ring buffer. Supports filtering by text and verbosity level. The first call starts log capture automatically.",
+    {
+      maxLines: z.number().optional()
+        .describe("Maximum number of log lines to return (default: 100, max: 1000)"),
+      filter: z.string().optional()
+        .describe("Text filter \u2014 only entries whose message or category contains this string"),
+      verbosity: z.enum(["Error", "Warning"]).optional()
+        .describe("Filter by verbosity level: Error (errors+fatals only), Warning (warnings only)"),
+    },
+    async ({ maxLines, filter, verbosity }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = {};
+      if (maxLines !== undefined) body.maxLines = maxLines;
+      if (filter) body.filter = filter;
+      if (verbosity) body.verbosity = verbosity;
+
+      const data = await uePost("/api/get-output-log", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines: string[] = [];
+      lines.push(`Output log: ${data.count} entries (${data.totalCaptured} total captured)`);
+
+      if (data.entries && data.entries.length > 0) {
+        for (const entry of data.entries) {
+          const prefix = entry.verbosity === "Error" || entry.verbosity === "Fatal"
+            ? "[ERR]"
+            : entry.verbosity === "Warning"
+            ? "[WRN]"
+            : "[LOG]";
+          lines.push(`${prefix} [${entry.category}] ${entry.message}`);
+        }
+      } else {
+        lines.push("No log entries matching the filter.");
+      }
+
+      lines.push(`\nNext steps:`);
+      lines.push(`  1. Use filter parameter to search for specific messages`);
+      lines.push(`  2. Use verbosity='Error' to see only errors`);
+      lines.push(`  3. Use clear_output_log to reset the capture buffer`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "clear_output_log",
+    "Clear the captured output log buffer. Does not affect the actual UE5 Output Log window.",
+    {},
+    async () => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/clear-output-log", {});
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      return {
+        content: [{
+          type: "text" as const,
+          text: `Cleared ${data.clearedEntries} log entries from capture buffer.`,
+        }],
+      };
+    }
+  );
+}

--- a/Tools/test/tools/output-log.test.ts
+++ b/Tools/test/tools/output-log.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { uePost } from "../helpers.js";
+
+describe("output log tools", () => {
+  describe("get_output_log", () => {
+    it("returns log entries without errors", async () => {
+      const data = await uePost("/api/get-output-log", {});
+      expect(data.error).toBeUndefined();
+      expect(typeof data.count).toBe("number");
+      expect(typeof data.totalCaptured).toBe("number");
+      expect(Array.isArray(data.entries)).toBe(true);
+      expect(data.capturing).toBe(true);
+    });
+
+    it("respects maxLines", async () => {
+      const data = await uePost("/api/get-output-log", { maxLines: 5 });
+      expect(data.error).toBeUndefined();
+      expect(data.entries.length).toBeLessThanOrEqual(5);
+    });
+
+    it("filters by text", async () => {
+      const data = await uePost("/api/get-output-log", { filter: "BlueprintMCP" });
+      expect(data.error).toBeUndefined();
+      // All entries should contain the filter text
+      if (data.entries && data.entries.length > 0) {
+        for (const entry of data.entries) {
+          const combined = (entry.message + entry.category).toLowerCase();
+          expect(combined).toContain("blueprintmcp");
+        }
+      }
+    });
+  });
+
+  describe("clear_output_log", () => {
+    it("clears log without errors", async () => {
+      const data = await uePost("/api/clear-output-log", {});
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+      expect(typeof data.clearedEntries).toBe("number");
+    });
+
+    it("results in empty log after clear", async () => {
+      await uePost("/api/clear-output-log", {});
+      const data = await uePost("/api/get-output-log", {});
+      expect(data.error).toBeUndefined();
+      // May have some entries from the get_output_log call itself
+      expect(data.count).toBeLessThanOrEqual(5);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds two MCP tools for capturing and querying UE5 output log messages.

| Tool | Description |
|------|-------------|
| `get_output_log` | Get recent log entries with text and verbosity filtering (auto-starts capture on first call) |
| `clear_output_log` | Clear the captured log buffer |

## New files

| File | Purpose |
|------|--------|
| `Source/BlueprintMCP/Private/BlueprintMCPHandlers_OutputLog.cpp` | C++ handlers + custom FOutputDevice |
| `Tools/src/tools/output-log.ts` | TypeScript MCP tool definitions |
| `Tools/test/tools/output-log.test.ts` | Integration tests |

## Architecture

A custom `FMCPLogCapture` class (derived from `FOutputDevice`) is registered with `GLog` to intercept all log messages. Messages are stored in a thread-safe ring buffer (max 1000 entries, auto-pruning oldest 25% when full). The capture starts automatically on the first `get_output_log` call.

## Integration changes needed

### `BlueprintMCPServer.h`:
```cpp
// ----- Output log tools -----
FString HandleGetOutputLog(const FString& Body);
FString HandleClearOutputLog(const FString& Body);
```

### `BlueprintMCPServer.cpp`:

Route bindings:
```cpp
Router->BindRoute(FHttpPath(TEXT("/api/get-output-log")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("getOutputLog")));
Router->BindRoute(FHttpPath(TEXT("/api/clear-output-log")), EHttpServerRequestVerbs::VERB_POST,
    QueuedHandler(TEXT("clearOutputLog")));
```

Handler map:
```cpp
HandlerMap.Add(TEXT("getOutputLog"),   [this](const TMap<FString, FString>&, const FString& B) { return HandleGetOutputLog(B); });
HandlerMap.Add(TEXT("clearOutputLog"), [this](const TMap<FString, FString>&, const FString& B) { return HandleClearOutputLog(B); });
```

Note: Both are read-only (no MutationEndpoints entry needed).

### `Tools/src/index.ts`:
```typescript
import { registerOutputLogTools } from "./tools/output-log.js";
registerOutputLogTools(server);
```

## Key implementation details

- **Thread-safe**: Uses `FCriticalSection` for concurrent access from log and game threads
- **Ring buffer**: Auto-prunes oldest 25% when hitting 1000 entries
- **Text filtering**: Matches against both message content and log category
- **Verbosity filtering**: Error (includes Fatal), Warning
- **Auto-start**: First call to `get_output_log` starts capture if not already running
- **Formatted output**: TypeScript formats entries with `[ERR]`/`[WRN]`/`[LOG]` prefixes

## Test plan

- [ ] `get_output_log` returns entries after capture starts
- [ ] `get_output_log` with `filter="BlueprintMCP"` returns only matching entries
- [ ] `get_output_log` with `verbosity="Error"` returns only errors
- [ ] `get_output_log` with `maxLines=5` limits results
- [ ] `clear_output_log` resets the buffer
- [ ] `get_output_log` after clear shows minimal entries
- [ ] `npm run build` succeeds
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)