### PR TITLE
Add content browser tools: navigate and open asset editor

### DIFF
--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_ContentBrowser.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_ContentBrowser.cpp
@@ -1,0 +1,123 @@
+#include "BlueprintMCPServer.h"
+#include "Editor.h"
+#include "ContentBrowserModule.h"
+#include "IContentBrowserSingleton.h"
+#include "AssetRegistry/AssetRegistryModule.h"
+#include "Subsystems/AssetEditorSubsystem.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+
+// ============================================================
+// HandleNavigateContentBrowser — navigate to a path in the Content Browser
+// ============================================================
+
+FString FBlueprintMCPServer::HandleNavigateContentBrowser(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	FString Path;
+	if (!Json->TryGetStringField(TEXT("path"), Path) || Path.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'path'. Provide a content path like '/Game/Blueprints'."));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: navigate_content_browser('%s')"), *Path);
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("navigate_content_browser requires editor mode."));
+	}
+
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("Editor not available."));
+	}
+
+	FContentBrowserModule& ContentBrowserModule = FModuleManager::LoadModuleChecked<FContentBrowserModule>(TEXT("ContentBrowser"));
+	IContentBrowserSingleton& ContentBrowser = ContentBrowserModule.Get();
+
+	// Navigate to the specified path
+	ContentBrowser.FocusPrimaryContentBrowser(false);
+
+	TArray<FString> PathArray;
+	PathArray.Add(Path);
+	ContentBrowser.SetSelectedPaths(PathArray, false);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("navigatedTo"), Path);
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleOpenAssetEditor — open an asset in its appropriate editor
+// ============================================================
+
+FString FBlueprintMCPServer::HandleOpenAssetEditor(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	FString AssetPath;
+	if (!Json->TryGetStringField(TEXT("assetPath"), AssetPath) || AssetPath.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'assetPath'. Provide the full asset path or name."));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: open_asset_editor('%s')"), *AssetPath);
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("open_asset_editor requires editor mode."));
+	}
+
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("Editor not available."));
+	}
+
+	// Try to find the asset
+	FAssetData* AssetData = FindAnyAsset(AssetPath);
+	if (!AssetData)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Asset '%s' not found. Use list_blueprints or search to find available assets."), *AssetPath));
+	}
+
+	UObject* Asset = AssetData->GetAsset();
+	if (!Asset)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Failed to load asset '%s'."), *AssetPath));
+	}
+
+	// Open the asset editor
+	UAssetEditorSubsystem* AssetEditorSubsystem = GEditor->GetEditorSubsystem<UAssetEditorSubsystem>();
+	if (!AssetEditorSubsystem)
+	{
+		return MakeErrorJson(TEXT("AssetEditorSubsystem not available."));
+	}
+
+	bool bOpened = AssetEditorSubsystem->OpenEditorForAsset(Asset);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), bOpened);
+	Result->SetStringField(TEXT("assetName"), AssetData->AssetName.ToString());
+	Result->SetStringField(TEXT("assetPath"), AssetData->PackageName.ToString());
+	Result->SetStringField(TEXT("assetClass"), AssetData->AssetClassPath.GetAssetName().ToString());
+
+	if (!bOpened)
+	{
+		Result->SetStringField(TEXT("warning"), TEXT("Asset editor could not be opened. The asset type may not have a dedicated editor."));
+	}
+
+	return JsonToString(Result);
+}

--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -793,6 +793,12 @@ bool FBlueprintMCPServer::Start(int32 InPort, bool bEditorMode)
 	Router->BindRoute(FHttpPath(TEXT("/api/exec")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("exec")));
 
+	// Content browser tools
+	Router->BindRoute(FHttpPath(TEXT("/api/navigate-content-browser")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("navigateContentBrowser")));
+	Router->BindRoute(FHttpPath(TEXT("/api/open-asset-editor")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("openAssetEditor")));
+
 	// Register TMap dispatch handlers
 	RegisterHandlers();
 
@@ -1055,6 +1061,10 @@ void FBlueprintMCPServer::RegisterHandlers()
 
 	// Console command execution
 	HandlerMap.Add(TEXT("exec"),                    [this](const TMap<FString, FString>&, const FString& B) { return HandleExecCommand(B); });
+
+	// Content browser handlers
+	HandlerMap.Add(TEXT("navigateContentBrowser"), [this](const TMap<FString, FString>&, const FString& B) { return HandleNavigateContentBrowser(B); });
+	HandlerMap.Add(TEXT("openAssetEditor"), [this](const TMap<FString, FString>&, const FString& B) { return HandleOpenAssetEditor(B); });
 }
 
 // ============================================================

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -260,6 +260,10 @@ private:
 	// ----- Console command execution -----
 	FString HandleExecCommand(const FString& Body);
 
+	// ----- Content browser tools -----
+	FString HandleNavigateContentBrowser(const FString& Body);
+	FString HandleOpenAssetEditor(const FString& Body);
+
 	// ----- Animation Blueprint handlers -----
 	FString HandleCreateAnimBlueprint(const FString& Body);
 	FString HandleAddAnimState(const FString& Body);

--- a/Tools/src/index.ts
+++ b/Tools/src/index.ts
@@ -20,6 +20,7 @@ import { registerUserTypeTools } from "./tools/user-types.js";
 import { registerMaterialReadTools } from "./tools/material-read.js";
 import { registerMaterialMutationTools } from "./tools/material-mutation.js";
 import { registerAnimationTools } from "./tools/animation-mutation.js";
+import { registerContentBrowserTools } from "./tools/content-browser.js";
 
 // Resource registrations
 import { registerBlueprintListResource } from "./resources/blueprint-list.js";
@@ -48,6 +49,7 @@ registerUserTypeTools(server);
 registerMaterialReadTools(server);
 registerMaterialMutationTools(server);
 registerAnimationTools(server);
+registerContentBrowserTools(server);
 
 // Register resources
 registerBlueprintListResource(server);

--- a/Tools/src/tools/content-browser.ts
+++ b/Tools/src/tools/content-browser.ts
@@ -1,0 +1,62 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ensureUE, uePost } from "../ue-bridge.js";
+
+export function registerContentBrowserTools(server: McpServer): void {
+  server.tool(
+    "navigate_content_browser",
+    "Navigate the Content Browser to a specific folder path. Useful for browsing assets in a particular directory. Requires editor mode.",
+    {
+      path: z.string().describe("Content path to navigate to, e.g. '/Game/Blueprints' or '/Game/Materials'"),
+    },
+    async ({ path }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/navigate-content-browser", { path });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        `Content Browser navigated to: ${data.navigatedTo}`,
+        `\nNext steps:`,
+        `  1. Use list_blueprints to see assets in this folder`,
+        `  2. Use open_asset_editor to open a specific asset`,
+      ];
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "open_asset_editor",
+    "Open an asset in its dedicated editor (Blueprint editor, Material editor, etc.). Requires editor mode.",
+    {
+      assetPath: z.string().describe("Asset name or full package path (e.g. 'BP_MyActor' or '/Game/Blueprints/BP_MyActor')"),
+    },
+    async ({ assetPath }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/open-asset-editor", { assetPath });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        `${data.success ? "Opened" : "Failed to open"} editor for '${data.assetName}'`,
+        `  Path: ${data.assetPath}`,
+        `  Class: ${data.assetClass}`,
+      ];
+
+      if (data.warning) {
+        lines.push(`  Warning: ${data.warning}`);
+      }
+
+      lines.push(
+        `\nNext steps:`,
+        `  1. Use get_blueprint to inspect the asset's contents`,
+        `  2. Use navigate_content_browser to browse related assets`,
+      );
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+}

--- a/Tools/test/tools/content-browser.test.ts
+++ b/Tools/test/tools/content-browser.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { uePost } from "../helpers.js";
+
+describe("content browser tools", () => {
+  describe("navigate_content_browser", () => {
+    it("navigates to a valid path", async () => {
+      const data = await uePost("/api/navigate-content-browser", {
+        path: "/Game",
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+      expect(data.navigatedTo).toBe("/Game");
+    });
+
+    it("rejects missing path", async () => {
+      const data = await uePost("/api/navigate-content-browser", {});
+      expect(data.error).toBeDefined();
+    });
+  });
+
+  describe("open_asset_editor", () => {
+    it("returns error for non-existent asset", async () => {
+      const data = await uePost("/api/open-asset-editor", {
+        assetPath: "BP_Nonexistent_XYZ_999",
+      });
+      expect(data.error).toBeDefined();
+    });
+
+    it("rejects missing assetPath", async () => {
+      const data = await uePost("/api/open-asset-editor", {});
+      expect(data.error).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds 2 new MCP tools for interacting with the UE5 Content Browser.

| Tool | Description |
|------|-------------|
| `navigate_content_browser` | Navigate the Content Browser to a specific folder path |
| `open_asset_editor` | Open an asset in its dedicated editor (Blueprint, Material, etc.) |

## Key implementation details

- **C++ handler**: `BlueprintMCPHandlers_ContentBrowser.cpp` uses `FContentBrowserModule` and `UAssetEditorSubsystem`
- **Editor-only**: Both tools require editor mode (not available in commandlet)
- **Asset resolution**: `open_asset_editor` uses the existing `FindAnyAsset()` helper to resolve names or paths
- Routes registered in `BlueprintMCPServer.cpp`, declarations in header, TypeScript tools in `content-browser.ts`

## Test plan

- [ ] `navigate_content_browser` navigates to `/Game` successfully
- [ ] `navigate_content_browser` rejects missing path parameter
- [ ] `open_asset_editor` returns error for non-existent asset
- [ ] `open_asset_editor` rejects missing assetPath parameter
- [ ] Manual: verify Content Browser focus changes in editor
- [ ] Manual: verify asset editor window opens for a Blueprint

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)