### PR TITLE
Add screenshot tools: viewport capture and high-res output

### DIFF
--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_Screenshot.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_Screenshot.cpp
@@ -1,0 +1,191 @@
+#include "BlueprintMCPServer.h"
+#include "Editor.h"
+#include "LevelEditorViewport.h"
+#include "UnrealClient.h"
+#include "HighResScreenshot.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "ImageUtils.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+
+// ============================================================
+// HandleTakeScreenshot — capture a viewport screenshot
+// ============================================================
+
+FString FBlueprintMCPServer::HandleTakeScreenshot(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: take_screenshot()"));
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("take_screenshot requires editor mode."));
+	}
+
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("Editor not available."));
+	}
+
+	FString Filename;
+	if (!Json->TryGetStringField(TEXT("filename"), Filename) || Filename.IsEmpty())
+	{
+		Filename = FString::Printf(TEXT("Screenshot_%s"), *FDateTime::Now().ToString(TEXT("%Y%m%d_%H%M%S")));
+	}
+
+	// Ensure .png extension
+	if (!Filename.EndsWith(TEXT(".png")))
+	{
+		Filename += TEXT(".png");
+	}
+
+	// Output directory
+	FString OutputDir = FPaths::ProjectSavedDir() / TEXT("Screenshots");
+	FString FullPath = OutputDir / Filename;
+
+	// Get the active viewport
+	FLevelEditorViewportClient* ViewportClient = nullptr;
+	if (GEditor->GetLevelViewportClients().Num() > 0)
+	{
+		ViewportClient = GEditor->GetLevelViewportClients()[0];
+	}
+
+	if (!ViewportClient || !ViewportClient->Viewport)
+	{
+		return MakeErrorJson(TEXT("No active viewport found."));
+	}
+
+	FViewport* Viewport = ViewportClient->Viewport;
+
+	// Read pixels from viewport
+	TArray<FColor> Bitmap;
+	int32 Width = Viewport->GetSizeXY().X;
+	int32 Height = Viewport->GetSizeXY().Y;
+
+	if (Width <= 0 || Height <= 0)
+	{
+		return MakeErrorJson(TEXT("Viewport has invalid dimensions."));
+	}
+
+	bool bReadSuccess = Viewport->ReadPixels(Bitmap);
+	if (!bReadSuccess || Bitmap.Num() == 0)
+	{
+		return MakeErrorJson(TEXT("Failed to read pixels from viewport."));
+	}
+
+	// Save as PNG
+	TArray<uint8> PngData;
+	FImageUtils::PNGCompressImageArray(Width, Height, Bitmap, PngData);
+
+	IPlatformFile& PlatformFile = FPlatformFileManager::Get().GetPlatformFile();
+	PlatformFile.CreateDirectoryTree(*OutputDir);
+
+	bool bSaved = FFileHelper::SaveArrayToFile(PngData, *FullPath);
+	if (!bSaved)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Failed to save screenshot to '%s'."), *FullPath));
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("filename"), Filename);
+	Result->SetStringField(TEXT("fullPath"), FullPath);
+	Result->SetNumberField(TEXT("width"), Width);
+	Result->SetNumberField(TEXT("height"), Height);
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: Screenshot saved to '%s' (%dx%d)"), *FullPath, Width, Height);
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleTakeHighResScreenshot — capture a high-resolution screenshot
+// ============================================================
+
+FString FBlueprintMCPServer::HandleTakeHighResScreenshot(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: take_high_res_screenshot()"));
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("take_high_res_screenshot requires editor mode."));
+	}
+
+	if (!GEditor)
+	{
+		return MakeErrorJson(TEXT("Editor not available."));
+	}
+
+	double ResMultiplier = 2.0;
+	Json->TryGetNumberField(TEXT("resolutionMultiplier"), ResMultiplier);
+	if (ResMultiplier < 1.0) ResMultiplier = 1.0;
+	if (ResMultiplier > 8.0) ResMultiplier = 8.0;
+
+	FString Filename;
+	if (!Json->TryGetStringField(TEXT("filename"), Filename) || Filename.IsEmpty())
+	{
+		Filename = FString::Printf(TEXT("HighRes_%s"), *FDateTime::Now().ToString(TEXT("%Y%m%d_%H%M%S")));
+	}
+
+	if (!Filename.EndsWith(TEXT(".png")))
+	{
+		Filename += TEXT(".png");
+	}
+
+	FString OutputDir = FPaths::ProjectSavedDir() / TEXT("Screenshots");
+	FString FullPath = OutputDir / Filename;
+
+	FLevelEditorViewportClient* ViewportClient = nullptr;
+	if (GEditor->GetLevelViewportClients().Num() > 0)
+	{
+		ViewportClient = GEditor->GetLevelViewportClients()[0];
+	}
+
+	if (!ViewportClient || !ViewportClient->Viewport)
+	{
+		return MakeErrorJson(TEXT("No active viewport found."));
+	}
+
+	// Configure high-res screenshot settings
+	FHighResScreenshotConfig& Config = GetHighResScreenshotConfig();
+	Config.SetResolution(
+		ViewportClient->Viewport->GetSizeXY().X,
+		ViewportClient->Viewport->GetSizeXY().Y,
+		ResMultiplier
+	);
+	Config.SetFilename(FullPath);
+	Config.bMaskEnabled = false;
+
+	// Request the screenshot
+	ViewportClient->Viewport->TakeHighResScreenShot();
+
+	int32 FinalWidth = FMath::CeilToInt(ViewportClient->Viewport->GetSizeXY().X * ResMultiplier);
+	int32 FinalHeight = FMath::CeilToInt(ViewportClient->Viewport->GetSizeXY().Y * ResMultiplier);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("filename"), Filename);
+	Result->SetStringField(TEXT("fullPath"), FullPath);
+	Result->SetNumberField(TEXT("resolutionMultiplier"), ResMultiplier);
+	Result->SetNumberField(TEXT("estimatedWidth"), FinalWidth);
+	Result->SetNumberField(TEXT("estimatedHeight"), FinalHeight);
+	Result->SetStringField(TEXT("note"), TEXT("High-res screenshot is captured asynchronously. The file may take a moment to appear on disk."));
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: High-res screenshot requested at %dx multiplier -> '%s'"), (int32)ResMultiplier, *FullPath);
+
+	return JsonToString(Result);
+}

--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -793,6 +793,12 @@ bool FBlueprintMCPServer::Start(int32 InPort, bool bEditorMode)
 	Router->BindRoute(FHttpPath(TEXT("/api/exec")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("exec")));
 
+	// Screenshot tools
+	Router->BindRoute(FHttpPath(TEXT("/api/take-screenshot")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("takeScreenshot")));
+	Router->BindRoute(FHttpPath(TEXT("/api/take-high-res-screenshot")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("takeHighResScreenshot")));
+
 	// Register TMap dispatch handlers
 	RegisterHandlers();
 
@@ -1055,6 +1061,10 @@ void FBlueprintMCPServer::RegisterHandlers()
 
 	// Console command execution
 	HandlerMap.Add(TEXT("exec"),                    [this](const TMap<FString, FString>&, const FString& B) { return HandleExecCommand(B); });
+
+	// Screenshot handlers
+	HandlerMap.Add(TEXT("takeScreenshot"), [this](const TMap<FString, FString>&, const FString& B) { return HandleTakeScreenshot(B); });
+	HandlerMap.Add(TEXT("takeHighResScreenshot"), [this](const TMap<FString, FString>&, const FString& B) { return HandleTakeHighResScreenshot(B); });
 }
 
 // ============================================================

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -260,6 +260,10 @@ private:
 	// ----- Console command execution -----
 	FString HandleExecCommand(const FString& Body);
 
+	// ----- Screenshot tools -----
+	FString HandleTakeScreenshot(const FString& Body);
+	FString HandleTakeHighResScreenshot(const FString& Body);
+
 	// ----- Animation Blueprint handlers -----
 	FString HandleCreateAnimBlueprint(const FString& Body);
 	FString HandleAddAnimState(const FString& Body);

--- a/Tools/src/index.ts
+++ b/Tools/src/index.ts
@@ -20,6 +20,7 @@ import { registerUserTypeTools } from "./tools/user-types.js";
 import { registerMaterialReadTools } from "./tools/material-read.js";
 import { registerMaterialMutationTools } from "./tools/material-mutation.js";
 import { registerAnimationTools } from "./tools/animation-mutation.js";
+import { registerScreenshotTools } from "./tools/screenshot.js";
 
 // Resource registrations
 import { registerBlueprintListResource } from "./resources/blueprint-list.js";
@@ -48,6 +49,7 @@ registerUserTypeTools(server);
 registerMaterialReadTools(server);
 registerMaterialMutationTools(server);
 registerAnimationTools(server);
+registerScreenshotTools(server);
 
 // Register resources
 registerBlueprintListResource(server);

--- a/Tools/src/tools/screenshot.ts
+++ b/Tools/src/tools/screenshot.ts
@@ -1,0 +1,72 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ensureUE, uePost } from "../ue-bridge.js";
+
+export function registerScreenshotTools(server: McpServer): void {
+  server.tool(
+    "take_screenshot",
+    "Capture a screenshot of the active viewport. Saves as PNG to the project's Saved/Screenshots folder. Requires editor mode.",
+    {
+      filename: z.string().optional()
+        .describe("Output filename (without path). Defaults to 'Screenshot_<timestamp>.png'"),
+    },
+    async ({ filename }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = {};
+      if (filename) body.filename = filename;
+
+      const data = await uePost("/api/take-screenshot", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        `Screenshot captured:`,
+        `  File: ${data.filename}`,
+        `  Path: ${data.fullPath}`,
+        `  Size: ${data.width}x${data.height}`,
+        `\nNext steps:`,
+        `  1. Use set_viewport_camera to adjust the view, then take another screenshot`,
+        `  2. Use take_high_res_screenshot for higher resolution output`,
+      ];
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "take_high_res_screenshot",
+    "Capture a high-resolution screenshot of the active viewport with configurable resolution multiplier. Requires editor mode.",
+    {
+      resolutionMultiplier: z.number().min(1).max(8).optional()
+        .describe("Resolution multiplier (1-8, default: 2). A 2x multiplier on a 1920x1080 viewport produces a 3840x2160 image."),
+      filename: z.string().optional()
+        .describe("Output filename (without path). Defaults to 'HighRes_<timestamp>.png'"),
+    },
+    async ({ resolutionMultiplier, filename }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = {};
+      if (resolutionMultiplier !== undefined) body.resolutionMultiplier = resolutionMultiplier;
+      if (filename) body.filename = filename;
+
+      const data = await uePost("/api/take-high-res-screenshot", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        `High-res screenshot requested:`,
+        `  File: ${data.filename}`,
+        `  Path: ${data.fullPath}`,
+        `  Multiplier: ${data.resolutionMultiplier}x`,
+        `  Estimated size: ${data.estimatedWidth}x${data.estimatedHeight}`,
+        `  Note: ${data.note}`,
+        `\nNext steps:`,
+        `  1. The screenshot is captured asynchronously — check the output path after a moment`,
+        `  2. Use set_viewport_camera to adjust the view before capturing`,
+      ];
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+}

--- a/Tools/test/tools/screenshot.test.ts
+++ b/Tools/test/tools/screenshot.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { uePost } from "../helpers.js";
+
+describe("screenshot tools", () => {
+  describe("take_screenshot", () => {
+    it("captures a screenshot with default filename", async () => {
+      const data = await uePost("/api/take-screenshot", {});
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+      expect(data.filename).toBeDefined();
+      expect(data.fullPath).toBeDefined();
+      expect(typeof data.width).toBe("number");
+      expect(typeof data.height).toBe("number");
+    });
+
+    it("captures a screenshot with custom filename", async () => {
+      const data = await uePost("/api/take-screenshot", {
+        filename: "test_screenshot.png",
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+      expect(data.filename).toBe("test_screenshot.png");
+    });
+  });
+
+  describe("take_high_res_screenshot", () => {
+    it("requests a high-res screenshot with default multiplier", async () => {
+      const data = await uePost("/api/take-high-res-screenshot", {});
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+      expect(data.resolutionMultiplier).toBe(2);
+      expect(typeof data.estimatedWidth).toBe("number");
+      expect(typeof data.estimatedHeight).toBe("number");
+    });
+
+    it("accepts custom resolution multiplier", async () => {
+      const data = await uePost("/api/take-high-res-screenshot", {
+        resolutionMultiplier: 4,
+      });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+      expect(data.resolutionMultiplier).toBe(4);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds 2 new MCP tools for capturing viewport screenshots.

| Tool | Description |
|------|-------------|
| `take_screenshot` | Capture a PNG screenshot of the active viewport |
| `take_high_res_screenshot` | Capture a high-resolution screenshot with configurable multiplier (1-8x) |

## Key implementation details

- **C++ handler**: `BlueprintMCPHandlers_Screenshot.cpp` reads viewport pixels via `FViewport::ReadPixels()` and saves PNG
- **High-res**: Uses `FHighResScreenshotConfig` for async high-res capture with resolution multiplier
- **Output**: Screenshots saved to `<Project>/Saved/Screenshots/` with auto-generated or custom filenames
- **Editor-only**: Both tools require editor mode with an active viewport
- Routes registered in `BlueprintMCPServer.cpp`, declarations in header, TypeScript tools in `screenshot.ts`

## Test plan

- [ ] `take_screenshot` captures with default filename
- [ ] `take_screenshot` captures with custom filename
- [ ] `take_high_res_screenshot` works with default 2x multiplier
- [ ] `take_high_res_screenshot` accepts custom multiplier (e.g. 4x)
- [ ] Manual: verify PNG files appear in Saved/Screenshots
- [ ] Manual: verify high-res output has expected dimensions

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)