### PR TITLE
Add view mode tools: viewport rendering and display control

### DIFF
--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_ViewMode.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_ViewMode.cpp
@@ -1,0 +1,289 @@
+#include "BlueprintMCPServer.h"
+#include "Editor.h"
+#include "LevelEditorViewport.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+
+// ============================================================
+// Helper — get the first active viewport client
+// ============================================================
+
+static FLevelEditorViewportClient* GetFirstViewportClient(FString& OutError)
+{
+	if (!GEditor)
+	{
+		OutError = TEXT("Editor not available.");
+		return nullptr;
+	}
+
+	if (GEditor->GetLevelViewportClients().Num() > 0)
+	{
+		return GEditor->GetLevelViewportClients()[0];
+	}
+
+	OutError = TEXT("No active viewport found.");
+	return nullptr;
+}
+
+// ============================================================
+// HandleSetViewMode — change the viewport rendering mode
+// ============================================================
+
+FString FBlueprintMCPServer::HandleSetViewMode(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	FString ModeName;
+	if (!Json->TryGetStringField(TEXT("mode"), ModeName) || ModeName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'mode'. Options: Lit, Unlit, Wireframe, DetailLighting, LightingOnly, LightComplexity, ShaderComplexity, PathTracing."));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: set_view_mode('%s')"), *ModeName);
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("set_view_mode requires editor mode."));
+	}
+
+	FString Error;
+	FLevelEditorViewportClient* VC = GetFirstViewportClient(Error);
+	if (!VC) return MakeErrorJson(Error);
+
+	EViewModeIndex NewMode;
+	if (ModeName.Equals(TEXT("Lit"), ESearchCase::IgnoreCase))
+		NewMode = VMI_Lit;
+	else if (ModeName.Equals(TEXT("Unlit"), ESearchCase::IgnoreCase))
+		NewMode = VMI_Unlit;
+	else if (ModeName.Equals(TEXT("Wireframe"), ESearchCase::IgnoreCase))
+		NewMode = VMI_BrushWireframe;
+	else if (ModeName.Equals(TEXT("DetailLighting"), ESearchCase::IgnoreCase))
+		NewMode = VMI_Lit_DetailLighting;
+	else if (ModeName.Equals(TEXT("LightingOnly"), ESearchCase::IgnoreCase))
+		NewMode = VMI_LightingOnly;
+	else if (ModeName.Equals(TEXT("LightComplexity"), ESearchCase::IgnoreCase))
+		NewMode = VMI_LightComplexity;
+	else if (ModeName.Equals(TEXT("ShaderComplexity"), ESearchCase::IgnoreCase))
+		NewMode = VMI_ShaderComplexity;
+	else if (ModeName.Equals(TEXT("PathTracing"), ESearchCase::IgnoreCase))
+		NewMode = VMI_PathTracing;
+	else
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Unknown view mode: '%s'. Options: Lit, Unlit, Wireframe, DetailLighting, LightingOnly, LightComplexity, ShaderComplexity, PathTracing."), *ModeName));
+	}
+
+	VC->SetViewMode(NewMode);
+	VC->Invalidate();
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("mode"), ModeName);
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleSetShowFlags — toggle viewport show flags
+// ============================================================
+
+FString FBlueprintMCPServer::HandleSetShowFlags(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	FString FlagName;
+	if (!Json->TryGetStringField(TEXT("flag"), FlagName) || FlagName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'flag'. Examples: Grid, Fog, Volumes, BSP, Collision, Navigation, Bounds."));
+	}
+
+	bool bEnabled = true;
+	Json->TryGetBoolField(TEXT("enabled"), bEnabled);
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: set_show_flags('%s', %s)"), *FlagName, bEnabled ? TEXT("true") : TEXT("false"));
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("set_show_flags requires editor mode."));
+	}
+
+	FString Error;
+	FLevelEditorViewportClient* VC = GetFirstViewportClient(Error);
+	if (!VC) return MakeErrorJson(Error);
+
+	// Use the engine show flag index lookup
+	int32 FlagIndex = FEngineShowFlags::FindIndexByName(*FlagName);
+	if (FlagIndex == INDEX_NONE)
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Unknown show flag: '%s'. Common flags: Grid, Fog, Volumes, BSP, Collision, Navigation, Bounds, StaticMeshes, SkeletalMeshes, Lighting, PostProcessing."), *FlagName));
+	}
+
+	FEngineShowFlags& ShowFlags = VC->EngineShowFlags;
+	ShowFlags.SetSingleFlag(FlagIndex, bEnabled);
+	VC->Invalidate();
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("flag"), FlagName);
+	Result->SetBoolField(TEXT("enabled"), bEnabled);
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleSetViewportType — switch between perspective/orthographic
+// ============================================================
+
+FString FBlueprintMCPServer::HandleSetViewportType(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	FString TypeName;
+	if (!Json->TryGetStringField(TEXT("type"), TypeName) || TypeName.IsEmpty())
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'type'. Options: Perspective, Top, Bottom, Left, Right, Front, Back."));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: set_viewport_type('%s')"), *TypeName);
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("set_viewport_type requires editor mode."));
+	}
+
+	FString Error;
+	FLevelEditorViewportClient* VC = GetFirstViewportClient(Error);
+	if (!VC) return MakeErrorJson(Error);
+
+	if (TypeName.Equals(TEXT("Perspective"), ESearchCase::IgnoreCase))
+	{
+		VC->SetViewportType(LVT_Perspective);
+	}
+	else if (TypeName.Equals(TEXT("Top"), ESearchCase::IgnoreCase))
+	{
+		VC->SetViewportType(LVT_OrthoXY);
+	}
+	else if (TypeName.Equals(TEXT("Bottom"), ESearchCase::IgnoreCase))
+	{
+		VC->SetViewportType(LVT_OrthoNegativeXY);
+	}
+	else if (TypeName.Equals(TEXT("Left"), ESearchCase::IgnoreCase))
+	{
+		VC->SetViewportType(LVT_OrthoYZ);
+	}
+	else if (TypeName.Equals(TEXT("Right"), ESearchCase::IgnoreCase))
+	{
+		VC->SetViewportType(LVT_OrthoNegativeYZ);
+	}
+	else if (TypeName.Equals(TEXT("Front"), ESearchCase::IgnoreCase))
+	{
+		VC->SetViewportType(LVT_OrthoXZ);
+	}
+	else if (TypeName.Equals(TEXT("Back"), ESearchCase::IgnoreCase))
+	{
+		VC->SetViewportType(LVT_OrthoNegativeXZ);
+	}
+	else
+	{
+		return MakeErrorJson(FString::Printf(TEXT("Unknown viewport type: '%s'. Options: Perspective, Top, Bottom, Left, Right, Front, Back."), *TypeName));
+	}
+
+	VC->Invalidate();
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetStringField(TEXT("type"), TypeName);
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleSetRealtimeRendering — toggle realtime rendering
+// ============================================================
+
+FString FBlueprintMCPServer::HandleSetRealtimeRendering(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	bool bEnabled = true;
+	if (!Json->TryGetBoolField(TEXT("enabled"), bEnabled))
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'enabled' (boolean)."));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: set_realtime_rendering(%s)"), bEnabled ? TEXT("true") : TEXT("false"));
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("set_realtime_rendering requires editor mode."));
+	}
+
+	FString Error;
+	FLevelEditorViewportClient* VC = GetFirstViewportClient(Error);
+	if (!VC) return MakeErrorJson(Error);
+
+	VC->SetRealtime(bEnabled);
+	VC->Invalidate();
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetBoolField(TEXT("realtime"), VC->IsRealtime());
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandleSetGameView — toggle game view mode (hides editor UI)
+// ============================================================
+
+FString FBlueprintMCPServer::HandleSetGameView(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	bool bEnabled = true;
+	if (!Json->TryGetBoolField(TEXT("enabled"), bEnabled))
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'enabled' (boolean)."));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: set_game_view(%s)"), bEnabled ? TEXT("true") : TEXT("false"));
+
+	if (!bIsEditor)
+	{
+		return MakeErrorJson(TEXT("set_game_view requires editor mode."));
+	}
+
+	FString Error;
+	FLevelEditorViewportClient* VC = GetFirstViewportClient(Error);
+	if (!VC) return MakeErrorJson(Error);
+
+	VC->SetGameView(bEnabled);
+	VC->Invalidate();
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), true);
+	Result->SetBoolField(TEXT("gameView"), VC->IsInGameView());
+
+	return JsonToString(Result);
+}

--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -793,6 +793,18 @@ bool FBlueprintMCPServer::Start(int32 InPort, bool bEditorMode)
 	Router->BindRoute(FHttpPath(TEXT("/api/exec")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("exec")));
 
+	// View mode tools
+	Router->BindRoute(FHttpPath(TEXT("/api/set-view-mode")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("setViewMode")));
+	Router->BindRoute(FHttpPath(TEXT("/api/set-show-flags")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("setShowFlags")));
+	Router->BindRoute(FHttpPath(TEXT("/api/set-viewport-type")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("setViewportType")));
+	Router->BindRoute(FHttpPath(TEXT("/api/set-realtime-rendering")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("setRealtimeRendering")));
+	Router->BindRoute(FHttpPath(TEXT("/api/set-game-view")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("setGameView")));
+
 	// Register TMap dispatch handlers
 	RegisterHandlers();
 
@@ -944,6 +956,7 @@ void FBlueprintMCPServer::RegisterHandlers()
 		TEXT("addAnimNode"),
 		TEXT("addStateMachine"),
 		TEXT("setStateAnimation"),
+		TEXT("setViewMode"),
 	};
 
 	// GET handlers (use QueryParams, ignore Body)
@@ -1055,6 +1068,13 @@ void FBlueprintMCPServer::RegisterHandlers()
 
 	// Console command execution
 	HandlerMap.Add(TEXT("exec"),                    [this](const TMap<FString, FString>&, const FString& B) { return HandleExecCommand(B); });
+
+	// View mode handlers
+	HandlerMap.Add(TEXT("setViewMode"), [this](const TMap<FString, FString>&, const FString& B) { return HandleSetViewMode(B); });
+	HandlerMap.Add(TEXT("setShowFlags"), [this](const TMap<FString, FString>&, const FString& B) { return HandleSetShowFlags(B); });
+	HandlerMap.Add(TEXT("setViewportType"), [this](const TMap<FString, FString>&, const FString& B) { return HandleSetViewportType(B); });
+	HandlerMap.Add(TEXT("setRealtimeRendering"), [this](const TMap<FString, FString>&, const FString& B) { return HandleSetRealtimeRendering(B); });
+	HandlerMap.Add(TEXT("setGameView"), [this](const TMap<FString, FString>&, const FString& B) { return HandleSetGameView(B); });
 }
 
 // ============================================================

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -260,6 +260,13 @@ private:
 	// ----- Console command execution -----
 	FString HandleExecCommand(const FString& Body);
 
+	// ----- View mode tools -----
+	FString HandleSetViewMode(const FString& Body);
+	FString HandleSetShowFlags(const FString& Body);
+	FString HandleSetViewportType(const FString& Body);
+	FString HandleSetRealtimeRendering(const FString& Body);
+	FString HandleSetGameView(const FString& Body);
+
 	// ----- Animation Blueprint handlers -----
 	FString HandleCreateAnimBlueprint(const FString& Body);
 	FString HandleAddAnimState(const FString& Body);

--- a/Tools/src/index.ts
+++ b/Tools/src/index.ts
@@ -20,6 +20,7 @@ import { registerUserTypeTools } from "./tools/user-types.js";
 import { registerMaterialReadTools } from "./tools/material-read.js";
 import { registerMaterialMutationTools } from "./tools/material-mutation.js";
 import { registerAnimationTools } from "./tools/animation-mutation.js";
+import { registerViewModeTools } from "./tools/view-mode.js";
 
 // Resource registrations
 import { registerBlueprintListResource } from "./resources/blueprint-list.js";
@@ -48,6 +49,7 @@ registerUserTypeTools(server);
 registerMaterialReadTools(server);
 registerMaterialMutationTools(server);
 registerAnimationTools(server);
+registerViewModeTools(server);
 
 // Register resources
 registerBlueprintListResource(server);

--- a/Tools/src/tools/view-mode.ts
+++ b/Tools/src/tools/view-mode.ts
@@ -1,0 +1,96 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ensureUE, uePost } from "../ue-bridge.js";
+
+export function registerViewModeTools(server: McpServer): void {
+  server.tool(
+    "set_view_mode",
+    "Change the viewport rendering mode (Lit, Unlit, Wireframe, etc.). Requires editor mode.",
+    {
+      mode: z.enum(["Lit", "Unlit", "Wireframe", "DetailLighting", "LightingOnly", "LightComplexity", "ShaderComplexity", "PathTracing"])
+        .describe("Viewport rendering mode"),
+    },
+    async ({ mode }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/set-view-mode", { mode });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      return { content: [{ type: "text" as const, text: `View mode set to: ${data.mode}` }] };
+    }
+  );
+
+  server.tool(
+    "set_show_flags",
+    "Toggle viewport show flags (Grid, Fog, Collision, etc.). Requires editor mode.",
+    {
+      flag: z.string().describe("Show flag name (e.g. Grid, Fog, Volumes, BSP, Collision, Navigation, Bounds, StaticMeshes, Lighting, PostProcessing)"),
+      enabled: z.boolean().optional().describe("true to enable, false to disable (default: true)"),
+    },
+    async ({ flag, enabled }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { flag };
+      if (enabled !== undefined) body.enabled = enabled;
+
+      const data = await uePost("/api/set-show-flags", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      return { content: [{ type: "text" as const, text: `Show flag '${data.flag}' ${data.enabled ? "enabled" : "disabled"}` }] };
+    }
+  );
+
+  server.tool(
+    "set_viewport_type",
+    "Switch the viewport between Perspective and orthographic views (Top, Front, Left, etc.). Requires editor mode.",
+    {
+      type: z.enum(["Perspective", "Top", "Bottom", "Left", "Right", "Front", "Back"])
+        .describe("Viewport projection type"),
+    },
+    async ({ type }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/set-viewport-type", { type });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      return { content: [{ type: "text" as const, text: `Viewport type set to: ${data.type}` }] };
+    }
+  );
+
+  server.tool(
+    "set_realtime_rendering",
+    "Enable or disable realtime rendering in the viewport. When disabled, the viewport only updates on interaction. Requires editor mode.",
+    {
+      enabled: z.boolean().describe("true to enable realtime, false to disable"),
+    },
+    async ({ enabled }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/set-realtime-rendering", { enabled });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      return { content: [{ type: "text" as const, text: `Realtime rendering: ${data.realtime ? "enabled" : "disabled"}` }] };
+    }
+  );
+
+  server.tool(
+    "set_game_view",
+    "Toggle game view mode, which hides editor-only visuals (icons, wireframes, selection outlines) to preview the scene as it appears in-game. Requires editor mode.",
+    {
+      enabled: z.boolean().describe("true to enable game view, false to show editor visuals"),
+    },
+    async ({ enabled }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/set-game-view", { enabled });
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      return { content: [{ type: "text" as const, text: `Game view: ${data.gameView ? "enabled" : "disabled"}` }] };
+    }
+  );
+}

--- a/Tools/test/tools/view-mode.test.ts
+++ b/Tools/test/tools/view-mode.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { uePost } from "../helpers.js";
+
+describe("view mode tools", () => {
+  describe("set_view_mode", () => {
+    it("sets view mode to Lit", async () => {
+      const data = await uePost("/api/set-view-mode", { mode: "Lit" });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+      expect(data.mode).toBe("Lit");
+    });
+
+    it("sets view mode to Wireframe", async () => {
+      const data = await uePost("/api/set-view-mode", { mode: "Wireframe" });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+    });
+
+    it("rejects unknown view mode", async () => {
+      const data = await uePost("/api/set-view-mode", { mode: "InvalidMode" });
+      expect(data.error).toBeDefined();
+    });
+
+    it("rejects missing mode", async () => {
+      const data = await uePost("/api/set-view-mode", {});
+      expect(data.error).toBeDefined();
+    });
+
+    // Reset to Lit after tests
+    it("resets to Lit", async () => {
+      await uePost("/api/set-view-mode", { mode: "Lit" });
+    });
+  });
+
+  describe("set_show_flags", () => {
+    it("disables Grid flag", async () => {
+      const data = await uePost("/api/set-show-flags", { flag: "Grid", enabled: false });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+      expect(data.enabled).toBe(false);
+    });
+
+    it("enables Grid flag", async () => {
+      const data = await uePost("/api/set-show-flags", { flag: "Grid", enabled: true });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+      expect(data.enabled).toBe(true);
+    });
+
+    it("rejects unknown flag", async () => {
+      const data = await uePost("/api/set-show-flags", { flag: "NonExistentFlag_XYZ" });
+      expect(data.error).toBeDefined();
+    });
+  });
+
+  describe("set_viewport_type", () => {
+    it("switches to Top view", async () => {
+      const data = await uePost("/api/set-viewport-type", { type: "Top" });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+    });
+
+    it("switches back to Perspective", async () => {
+      const data = await uePost("/api/set-viewport-type", { type: "Perspective" });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+    });
+
+    it("rejects unknown type", async () => {
+      const data = await uePost("/api/set-viewport-type", { type: "Isometric" });
+      expect(data.error).toBeDefined();
+    });
+  });
+
+  describe("set_realtime_rendering", () => {
+    it("disables realtime rendering", async () => {
+      const data = await uePost("/api/set-realtime-rendering", { enabled: false });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+    });
+
+    it("enables realtime rendering", async () => {
+      const data = await uePost("/api/set-realtime-rendering", { enabled: true });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+      expect(data.realtime).toBe(true);
+    });
+  });
+
+  describe("set_game_view", () => {
+    it("enables game view", async () => {
+      const data = await uePost("/api/set-game-view", { enabled: true });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+    });
+
+    it("disables game view", async () => {
+      const data = await uePost("/api/set-game-view", { enabled: false });
+      expect(data.error).toBeUndefined();
+      expect(data.success).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds 5 new MCP tools for controlling viewport rendering and display settings.

| Tool | Description |
|------|-------------|
| `set_view_mode` | Change rendering mode (Lit, Unlit, Wireframe, PathTracing, etc.) |
| `set_show_flags` | Toggle show flags (Grid, Fog, Collision, Navigation, etc.) |
| `set_viewport_type` | Switch between Perspective and orthographic views (Top, Front, Left, etc.) |
| `set_realtime_rendering` | Enable/disable realtime viewport rendering |
| `set_game_view` | Toggle game view mode (hides editor-only visuals) |

## Key implementation details

- **C++ handler**: `BlueprintMCPHandlers_ViewMode.cpp` uses `FLevelEditorViewportClient` APIs
- **View modes**: Maps string names to `EViewModeIndex` enum values
- **Show flags**: Uses `FEngineShowFlags::FindIndexByName()` for dynamic flag lookup
- **Viewport types**: Supports all orthographic projections via `ELevelViewportType`
- **Editor-only**: All tools require editor mode with an active viewport
- Routes registered in `BlueprintMCPServer.cpp`, declarations in header, TypeScript tools in `view-mode.ts`

## Test plan

- [ ] `set_view_mode` switches to Lit, Wireframe modes
- [ ] `set_view_mode` rejects unknown mode names
- [ ] `set_show_flags` toggles Grid flag on/off
- [ ] `set_show_flags` rejects unknown flag names
- [ ] `set_viewport_type` switches to Top and back to Perspective
- [ ] `set_realtime_rendering` enables and disables
- [ ] `set_game_view` enables and disables
- [ ] Manual: verify visual changes in viewport for each tool

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)