### PR TITLE
Add PIE runtime tools: player transform, teleport, actor query

### DIFF
--- a/Source/BlueprintMCP/Private/BlueprintMCPHandlers_PIERuntime.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPHandlers_PIERuntime.cpp
@@ -1,0 +1,269 @@
+#include "BlueprintMCPServer.h"
+#include "Editor.h"
+#include "Engine/World.h"
+#include "EngineUtils.h"
+#include "GameFramework/Actor.h"
+#include "GameFramework/PlayerController.h"
+#include "GameFramework/Pawn.h"
+#include "GameFramework/Character.h"
+#include "Dom/JsonObject.h"
+#include "Dom/JsonValue.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+
+// ============================================================
+// Helper — get the PIE world or return error
+// ============================================================
+
+static UWorld* GetPIEWorld(bool bIsEditor, FString& OutError)
+{
+	if (!bIsEditor)
+	{
+		OutError = TEXT("This tool requires editor mode.");
+		return nullptr;
+	}
+
+	if (!GEditor || !GEditor->PlayWorld)
+	{
+		OutError = TEXT("PIE is not running. Use start_pie first.");
+		return nullptr;
+	}
+
+	return GEditor->PlayWorld;
+}
+
+// ============================================================
+// HandlePIEGetPlayerTransform — get player pawn location/rotation
+// ============================================================
+
+FString FBlueprintMCPServer::HandlePIEGetPlayerTransform(const FString& Body)
+{
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: pie_get_player_transform()"));
+
+	FString Error;
+	UWorld* PIEWorld = GetPIEWorld(bIsEditor, Error);
+	if (!PIEWorld) return MakeErrorJson(Error);
+
+	APlayerController* PC = PIEWorld->GetFirstPlayerController();
+	if (!PC)
+	{
+		return MakeErrorJson(TEXT("No player controller found in PIE world."));
+	}
+
+	APawn* PlayerPawn = PC->GetPawn();
+	if (!PlayerPawn)
+	{
+		return MakeErrorJson(TEXT("No player pawn found. The player may not have possessed a pawn yet."));
+	}
+
+	FVector Location = PlayerPawn->GetActorLocation();
+	FRotator Rotation = PlayerPawn->GetActorRotation();
+	FVector Velocity = PlayerPawn->GetVelocity();
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+
+	TSharedRef<FJsonObject> LocObj = MakeShared<FJsonObject>();
+	LocObj->SetNumberField(TEXT("x"), Location.X);
+	LocObj->SetNumberField(TEXT("y"), Location.Y);
+	LocObj->SetNumberField(TEXT("z"), Location.Z);
+	Result->SetObjectField(TEXT("location"), LocObj);
+
+	TSharedRef<FJsonObject> RotObj = MakeShared<FJsonObject>();
+	RotObj->SetNumberField(TEXT("pitch"), Rotation.Pitch);
+	RotObj->SetNumberField(TEXT("yaw"), Rotation.Yaw);
+	RotObj->SetNumberField(TEXT("roll"), Rotation.Roll);
+	Result->SetObjectField(TEXT("rotation"), RotObj);
+
+	TSharedRef<FJsonObject> VelObj = MakeShared<FJsonObject>();
+	VelObj->SetNumberField(TEXT("x"), Velocity.X);
+	VelObj->SetNumberField(TEXT("y"), Velocity.Y);
+	VelObj->SetNumberField(TEXT("z"), Velocity.Z);
+	Result->SetObjectField(TEXT("velocity"), VelObj);
+
+	Result->SetStringField(TEXT("pawnClass"), PlayerPawn->GetClass()->GetName());
+	Result->SetNumberField(TEXT("speed"), Velocity.Size());
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandlePIETeleportPlayer — teleport the player pawn
+// ============================================================
+
+FString FBlueprintMCPServer::HandlePIETeleportPlayer(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: pie_teleport_player()"));
+
+	FString Error;
+	UWorld* PIEWorld = GetPIEWorld(bIsEditor, Error);
+	if (!PIEWorld) return MakeErrorJson(Error);
+
+	APlayerController* PC = PIEWorld->GetFirstPlayerController();
+	if (!PC)
+	{
+		return MakeErrorJson(TEXT("No player controller found in PIE world."));
+	}
+
+	APawn* PlayerPawn = PC->GetPawn();
+	if (!PlayerPawn)
+	{
+		return MakeErrorJson(TEXT("No player pawn found."));
+	}
+
+	// Parse location
+	const TSharedPtr<FJsonObject>* LocObj = nullptr;
+	if (!Json->TryGetObjectField(TEXT("location"), LocObj))
+	{
+		return MakeErrorJson(TEXT("Missing required field: 'location' with x, y, z coordinates."));
+	}
+
+	double X = 0, Y = 0, Z = 0;
+	(*LocObj)->TryGetNumberField(TEXT("x"), X);
+	(*LocObj)->TryGetNumberField(TEXT("y"), Y);
+	(*LocObj)->TryGetNumberField(TEXT("z"), Z);
+
+	FVector NewLocation(X, Y, Z);
+
+	// Parse optional rotation
+	FRotator NewRotation = PlayerPawn->GetActorRotation();
+	const TSharedPtr<FJsonObject>* RotObj = nullptr;
+	if (Json->TryGetObjectField(TEXT("rotation"), RotObj))
+	{
+		double Pitch = 0, Yaw = 0, Roll = 0;
+		(*RotObj)->TryGetNumberField(TEXT("pitch"), Pitch);
+		(*RotObj)->TryGetNumberField(TEXT("yaw"), Yaw);
+		(*RotObj)->TryGetNumberField(TEXT("roll"), Roll);
+		NewRotation = FRotator(Pitch, Yaw, Roll);
+	}
+
+	bool bTeleported = PlayerPawn->TeleportTo(NewLocation, NewRotation);
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetBoolField(TEXT("success"), bTeleported);
+
+	FVector FinalLoc = PlayerPawn->GetActorLocation();
+	TSharedRef<FJsonObject> FinalLocObj = MakeShared<FJsonObject>();
+	FinalLocObj->SetNumberField(TEXT("x"), FinalLoc.X);
+	FinalLocObj->SetNumberField(TEXT("y"), FinalLoc.Y);
+	FinalLocObj->SetNumberField(TEXT("z"), FinalLoc.Z);
+	Result->SetObjectField(TEXT("location"), FinalLocObj);
+
+	FRotator FinalRot = PlayerPawn->GetActorRotation();
+	TSharedRef<FJsonObject> FinalRotObj = MakeShared<FJsonObject>();
+	FinalRotObj->SetNumberField(TEXT("pitch"), FinalRot.Pitch);
+	FinalRotObj->SetNumberField(TEXT("yaw"), FinalRot.Yaw);
+	FinalRotObj->SetNumberField(TEXT("roll"), FinalRot.Roll);
+	Result->SetObjectField(TEXT("rotation"), FinalRotObj);
+
+	if (!bTeleported)
+	{
+		Result->SetStringField(TEXT("warning"), TEXT("Teleport failed. The destination may be blocked by collision."));
+	}
+
+	return JsonToString(Result);
+}
+
+// ============================================================
+// HandlePIEQueryActors — query actors in the PIE world
+// ============================================================
+
+FString FBlueprintMCPServer::HandlePIEQueryActors(const FString& Body)
+{
+	TSharedPtr<FJsonObject> Json = ParseBodyJson(Body);
+	if (!Json.IsValid())
+	{
+		return MakeErrorJson(TEXT("Invalid JSON body."));
+	}
+
+	UE_LOG(LogTemp, Display, TEXT("BlueprintMCP: pie_query_actors()"));
+
+	FString Error;
+	UWorld* PIEWorld = GetPIEWorld(bIsEditor, Error);
+	if (!PIEWorld) return MakeErrorJson(Error);
+
+	FString ClassFilter;
+	Json->TryGetStringField(TEXT("classFilter"), ClassFilter);
+
+	FString TagFilter;
+	Json->TryGetStringField(TEXT("tagFilter"), TagFilter);
+
+	int32 MaxResults = 100;
+	Json->TryGetNumberField(TEXT("maxResults"), MaxResults);
+	if (MaxResults <= 0) MaxResults = 100;
+	if (MaxResults > 1000) MaxResults = 1000;
+
+	TArray<TSharedPtr<FJsonValue>> ActorArray;
+	int32 Count = 0;
+
+	for (TActorIterator<AActor> It(PIEWorld); It && Count < MaxResults; ++It)
+	{
+		AActor* Actor = *It;
+		if (!Actor) continue;
+
+		// Apply class filter
+		if (!ClassFilter.IsEmpty())
+		{
+			FString ClassName = Actor->GetClass()->GetName();
+			if (!ClassName.Contains(ClassFilter, ESearchCase::IgnoreCase))
+			{
+				continue;
+			}
+		}
+
+		// Apply tag filter
+		if (!TagFilter.IsEmpty())
+		{
+			bool bHasTag = false;
+			for (const FName& Tag : Actor->Tags)
+			{
+				if (Tag.ToString().Contains(TagFilter, ESearchCase::IgnoreCase))
+				{
+					bHasTag = true;
+					break;
+				}
+			}
+			if (!bHasTag) continue;
+		}
+
+		TSharedRef<FJsonObject> ActorObj = MakeShared<FJsonObject>();
+		ActorObj->SetStringField(TEXT("name"), Actor->GetName());
+		ActorObj->SetStringField(TEXT("label"), Actor->GetActorLabel());
+		ActorObj->SetStringField(TEXT("class"), Actor->GetClass()->GetName());
+
+		FVector Loc = Actor->GetActorLocation();
+		TSharedRef<FJsonObject> LocObj = MakeShared<FJsonObject>();
+		LocObj->SetNumberField(TEXT("x"), Loc.X);
+		LocObj->SetNumberField(TEXT("y"), Loc.Y);
+		LocObj->SetNumberField(TEXT("z"), Loc.Z);
+		ActorObj->SetObjectField(TEXT("location"), LocObj);
+
+		// Tags
+		TArray<TSharedPtr<FJsonValue>> TagArray;
+		for (const FName& Tag : Actor->Tags)
+		{
+			TagArray.Add(MakeShared<FJsonValueString>(Tag.ToString()));
+		}
+		ActorObj->SetArrayField(TEXT("tags"), TagArray);
+
+		ActorObj->SetBoolField(TEXT("hidden"), Actor->IsHidden());
+
+		ActorArray.Add(MakeShared<FJsonValueObject>(ActorObj));
+		Count++;
+	}
+
+	TSharedRef<FJsonObject> Result = MakeShared<FJsonObject>();
+	Result->SetArrayField(TEXT("actors"), ActorArray);
+	Result->SetNumberField(TEXT("count"), ActorArray.Num());
+	if (!ClassFilter.IsEmpty())
+		Result->SetStringField(TEXT("classFilter"), ClassFilter);
+	if (!TagFilter.IsEmpty())
+		Result->SetStringField(TEXT("tagFilter"), TagFilter);
+
+	return JsonToString(Result);
+}

--- a/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
+++ b/Source/BlueprintMCP/Private/BlueprintMCPServer.cpp
@@ -793,6 +793,14 @@ bool FBlueprintMCPServer::Start(int32 InPort, bool bEditorMode)
 	Router->BindRoute(FHttpPath(TEXT("/api/exec")), EHttpServerRequestVerbs::VERB_POST,
 		QueuedHandler(TEXT("exec")));
 
+	// PIE runtime tools
+	Router->BindRoute(FHttpPath(TEXT("/api/pie-get-player-transform")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("pieGetPlayerTransform")));
+	Router->BindRoute(FHttpPath(TEXT("/api/pie-teleport-player")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("pieTeleportPlayer")));
+	Router->BindRoute(FHttpPath(TEXT("/api/pie-query-actors")), EHttpServerRequestVerbs::VERB_POST,
+		QueuedHandler(TEXT("pieQueryActors")));
+
 	// Register TMap dispatch handlers
 	RegisterHandlers();
 
@@ -944,6 +952,7 @@ void FBlueprintMCPServer::RegisterHandlers()
 		TEXT("addAnimNode"),
 		TEXT("addStateMachine"),
 		TEXT("setStateAnimation"),
+		TEXT("pieTeleportPlayer"),
 	};
 
 	// GET handlers (use QueryParams, ignore Body)
@@ -1055,6 +1064,11 @@ void FBlueprintMCPServer::RegisterHandlers()
 
 	// Console command execution
 	HandlerMap.Add(TEXT("exec"),                    [this](const TMap<FString, FString>&, const FString& B) { return HandleExecCommand(B); });
+
+	// PIE runtime handlers
+	HandlerMap.Add(TEXT("pieGetPlayerTransform"), [this](const TMap<FString, FString>&, const FString& B) { return HandlePIEGetPlayerTransform(B); });
+	HandlerMap.Add(TEXT("pieTeleportPlayer"), [this](const TMap<FString, FString>&, const FString& B) { return HandlePIETeleportPlayer(B); });
+	HandlerMap.Add(TEXT("pieQueryActors"), [this](const TMap<FString, FString>&, const FString& B) { return HandlePIEQueryActors(B); });
 }
 
 // ============================================================

--- a/Source/BlueprintMCP/Public/BlueprintMCPServer.h
+++ b/Source/BlueprintMCP/Public/BlueprintMCPServer.h
@@ -260,6 +260,11 @@ private:
 	// ----- Console command execution -----
 	FString HandleExecCommand(const FString& Body);
 
+	// ----- PIE runtime tools -----
+	FString HandlePIEGetPlayerTransform(const FString& Body);
+	FString HandlePIETeleportPlayer(const FString& Body);
+	FString HandlePIEQueryActors(const FString& Body);
+
 	// ----- Animation Blueprint handlers -----
 	FString HandleCreateAnimBlueprint(const FString& Body);
 	FString HandleAddAnimState(const FString& Body);

--- a/Tools/src/index.ts
+++ b/Tools/src/index.ts
@@ -20,6 +20,7 @@ import { registerUserTypeTools } from "./tools/user-types.js";
 import { registerMaterialReadTools } from "./tools/material-read.js";
 import { registerMaterialMutationTools } from "./tools/material-mutation.js";
 import { registerAnimationTools } from "./tools/animation-mutation.js";
+import { registerPIERuntimeTools } from "./tools/pie-runtime.js";
 
 // Resource registrations
 import { registerBlueprintListResource } from "./resources/blueprint-list.js";
@@ -48,6 +49,7 @@ registerUserTypeTools(server);
 registerMaterialReadTools(server);
 registerMaterialMutationTools(server);
 registerAnimationTools(server);
+registerPIERuntimeTools(server);
 
 // Register resources
 registerBlueprintListResource(server);

--- a/Tools/src/tools/pie-runtime.ts
+++ b/Tools/src/tools/pie-runtime.ts
@@ -1,0 +1,109 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { ensureUE, uePost } from "../ue-bridge.js";
+
+export function registerPIERuntimeTools(server: McpServer): void {
+  server.tool(
+    "pie_get_player_transform",
+    "Get the player pawn's current location, rotation, velocity, and class during PIE. Requires an active PIE session.",
+    {},
+    async () => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const data = await uePost("/api/pie-get-player-transform", {});
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        `Player Pawn (${data.pawnClass}):`,
+        `  Location: (${data.location.x.toFixed(1)}, ${data.location.y.toFixed(1)}, ${data.location.z.toFixed(1)})`,
+        `  Rotation: pitch=${data.rotation.pitch.toFixed(1)}, yaw=${data.rotation.yaw.toFixed(1)}, roll=${data.rotation.roll.toFixed(1)}`,
+        `  Velocity: (${data.velocity.x.toFixed(1)}, ${data.velocity.y.toFixed(1)}, ${data.velocity.z.toFixed(1)})`,
+        `  Speed: ${data.speed.toFixed(1)}`,
+        `\nNext steps:`,
+        `  1. Use pie_teleport_player to move the player`,
+        `  2. Use pie_query_actors to find nearby actors`,
+      ];
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "pie_teleport_player",
+    "Teleport the player pawn to a new location during PIE. Optionally set rotation. Requires an active PIE session.",
+    {
+      location: z.object({
+        x: z.number().describe("X coordinate"),
+        y: z.number().describe("Y coordinate"),
+        z: z.number().describe("Z coordinate"),
+      }).describe("Target world position"),
+      rotation: z.object({
+        pitch: z.number().describe("Pitch in degrees"),
+        yaw: z.number().describe("Yaw in degrees"),
+        roll: z.number().optional().describe("Roll in degrees (default: 0)"),
+      }).optional().describe("Target rotation (optional, keeps current if omitted)"),
+    },
+    async ({ location, rotation }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = { location };
+      if (rotation) body.rotation = { pitch: rotation.pitch, yaw: rotation.yaw, roll: rotation.roll ?? 0 };
+
+      const data = await uePost("/api/pie-teleport-player", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [
+        `${data.success ? "Teleported" : "Teleport failed"}:`,
+        `  Location: (${data.location.x.toFixed(1)}, ${data.location.y.toFixed(1)}, ${data.location.z.toFixed(1)})`,
+        `  Rotation: pitch=${data.rotation.pitch.toFixed(1)}, yaw=${data.rotation.yaw.toFixed(1)}, roll=${data.rotation.roll.toFixed(1)}`,
+      ];
+
+      if (data.warning) lines.push(`  Warning: ${data.warning}`);
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+
+  server.tool(
+    "pie_query_actors",
+    "Query actors in the PIE game world. Filter by class name and/or tag. Requires an active PIE session.",
+    {
+      classFilter: z.string().optional()
+        .describe("Filter actors whose class name contains this string (case-insensitive)"),
+      tagFilter: z.string().optional()
+        .describe("Filter actors that have a tag containing this string (case-insensitive)"),
+      maxResults: z.number().optional()
+        .describe("Maximum number of results (default: 100, max: 1000)"),
+    },
+    async ({ classFilter, tagFilter, maxResults }) => {
+      const err = await ensureUE();
+      if (err) return { content: [{ type: "text" as const, text: err }] };
+
+      const body: Record<string, any> = {};
+      if (classFilter) body.classFilter = classFilter;
+      if (tagFilter) body.tagFilter = tagFilter;
+      if (maxResults !== undefined) body.maxResults = maxResults;
+
+      const data = await uePost("/api/pie-query-actors", body);
+      if (data.error) return { content: [{ type: "text" as const, text: `Error: ${data.error}` }] };
+
+      const lines = [`Found ${data.count} actors in PIE world:`];
+      if (data.classFilter) lines.push(`  Class filter: ${data.classFilter}`);
+      if (data.tagFilter) lines.push(`  Tag filter: ${data.tagFilter}`);
+      lines.push("");
+
+      for (const actor of data.actors.slice(0, 20)) {
+        const loc = actor.location;
+        lines.push(`  ${actor.label || actor.name} (${actor.class}) at (${loc.x.toFixed(0)}, ${loc.y.toFixed(0)}, ${loc.z.toFixed(0)})`);
+      }
+
+      if (data.count > 20) {
+        lines.push(`  ... and ${data.count - 20} more`);
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    }
+  );
+}

--- a/Tools/test/tools/pie-runtime.test.ts
+++ b/Tools/test/tools/pie-runtime.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { uePost } from "../helpers.js";
+
+describe("PIE runtime tools", () => {
+  // Note: These tests require an active PIE session.
+  // They may fail in commandlet mode where PIE is not available.
+
+  describe("pie_get_player_transform", () => {
+    it("returns error when PIE is not running", async () => {
+      const data = await uePost("/api/pie-get-player-transform", {});
+      // Expect an error since PIE is unlikely to be running in test
+      expect(data.error).toBeDefined();
+      expect(data.error).toContain("PIE");
+    });
+  });
+
+  describe("pie_teleport_player", () => {
+    it("returns error when PIE is not running", async () => {
+      const data = await uePost("/api/pie-teleport-player", {
+        location: { x: 0, y: 0, z: 100 },
+      });
+      expect(data.error).toBeDefined();
+      expect(data.error).toContain("PIE");
+    });
+
+    it("rejects missing location", async () => {
+      const data = await uePost("/api/pie-teleport-player", {});
+      expect(data.error).toBeDefined();
+    });
+  });
+
+  describe("pie_query_actors", () => {
+    it("returns error when PIE is not running", async () => {
+      const data = await uePost("/api/pie-query-actors", {});
+      expect(data.error).toBeDefined();
+      expect(data.error).toContain("PIE");
+    });
+
+    it("accepts filters when PIE is not running (still errors)", async () => {
+      const data = await uePost("/api/pie-query-actors", {
+        classFilter: "Character",
+        maxResults: 10,
+      });
+      expect(data.error).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds 3 new MCP tools for interacting with the game world during PIE sessions.

| Tool | Description |
|------|-------------|
| `pie_get_player_transform` | Get player pawn location, rotation, velocity, and class |
| `pie_teleport_player` | Teleport the player pawn to a new world position |
| `pie_query_actors` | Query actors in the PIE world with class/tag filters |

## Key implementation details

- **C++ handler**: `BlueprintMCPHandlers_PIERuntime.cpp` accesses the PIE world via `GEditor->PlayWorld`
- **Player access**: Uses `UWorld::GetFirstPlayerController()` -> `GetPawn()` for player queries
- **Teleport**: Uses `APawn::TeleportTo()` with collision check feedback
- **Actor query**: Iterates `TActorIterator<AActor>` with optional class name and tag substring filters
- **Safety**: All tools return clear errors when PIE is not running
- **Max results**: `pie_query_actors` caps at 1000 results to prevent huge responses
- Routes registered in `BlueprintMCPServer.cpp`, declarations in header, TypeScript tools in `pie-runtime.ts`

## Test plan

- [ ] `pie_get_player_transform` returns error when PIE not running
- [ ] `pie_teleport_player` returns error when PIE not running
- [ ] `pie_teleport_player` rejects missing location field
- [ ] `pie_query_actors` returns error when PIE not running
- [ ] Manual: start PIE, then verify player transform returns valid data
- [ ] Manual: teleport player and verify new position
- [ ] Manual: query actors with class filter and verify results

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)